### PR TITLE
docs: add mandatory branch check step to AGENTS.md workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,21 @@ Do not use `host`, `none`, or custom named networks unless explicitly requested.
 
 ## GitHub Workflow And Release Process
 
+### Before Starting Any Work — Branch Check (Mandatory)
+
+Before writing or editing any code, **always check the current branch** with `git branch --show-current`. Then act on what you find:
+
+| Current branch | Situation | Action |
+|---|---|---|
+| `develop` | On the integration branch | Create a new `type/description` branch from `develop` and switch to it |
+| `main` | On the stable branch | Create a new `type/description` branch from `develop` (not main) and switch to it |
+| `feat/*`, `fix/*`, `chore/*` etc. | Already on a work branch | Continue work here — no new branch needed |
+| Something unexpected | Unfamiliar branch | Ask the user before proceeding |
+
+Do this **before** making any edits, installs, or file changes. Never start work and then create the branch after the fact.
+
+---
+
 ### The Full Development Flow
 
 This is the required workflow for all changes. Follow it every time, in order:


### PR DESCRIPTION
## Summary
- Adds a new **Before Starting Any Work** section to `AGENTS.md` with a decision table
- Makes the branch check an explicit mandatory first step before any code changes
- Covers the four branch states the agent may encounter and what to do in each case

## Why
The existing workflow documented the process but didn't instruct the agent to proactively check the current branch before starting. This caused the agent to begin work (e.g. installs) before switching to the correct branch.