### PR TITLE
fix: address Snyk type validation and DOM XSS findings

### DIFF
--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -851,7 +851,7 @@ function AboutTab() {
                 Close
               </button>
               <a
-                href={changelogRelease.html_url}
+                href={changelogRelease.html_url.startsWith("https://github.com/") ? changelogRelease.html_url : "#"}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="px-4 py-2 text-sm rounded-xl bg-primary hover:bg-primary-dim text-on-primary font-medium transition-colors"

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -229,7 +229,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       };
     }
 
-    const hostname = payload.hostname?.trim();
+    const hostname = typeof payload.hostname === "string" ? payload.hostname.trim() : undefined;
     const port = payload.port;
     const useSsl = Boolean(payload.useSsl);
 
@@ -869,8 +869,8 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   app.get("/api/settings/logs", requireAuth, (req, res) => {
     const page = Math.max(1, Number(req.query["page"] ?? 1));
     const pageSize = Math.min(100, Math.max(1, Number(req.query["pageSize"] ?? 25)));
-    const filterParam = (req.query["filter"] as string) ?? "debug";
-    const search = (req.query["search"] as string) ?? "";
+    const filterParam = typeof req.query["filter"] === "string" ? req.query["filter"] : "debug";
+    const search = typeof req.query["search"] === "string" ? req.query["search"] : "";
 
     // Cascade: debug=all, info=info+warn+error, warn=warn+error, error=error only
     const LEVEL_ORDER = ["debug", "info", "warn", "error"];


### PR DESCRIPTION
## Summary
- Replace `as string` casts on `req.query["filter"]` and `req.query["search"]` with `typeof` guards — prevents silent type confusion if query params are arrays
- Add `typeof` guard on `payload.hostname` before calling `.trim()` — prevents runtime TypeError on malformed request bodies
- Validate `changelogRelease.html_url` starts with `https://github.com/` before using as `href` — eliminates Snyk DOM XSS finding

## Test plan
- [x] Log viewer still filters and searches correctly
- [x] Manual Plex configuration (hostname + port) still saves successfully
- [ ] Changelog modal "View on GitHub" link opens the correct release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)