### PR TITLE
fix: address Snyk CSRF and type validation findings

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -204,7 +204,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     const signed = `${sessionId}.${signedValue(config.sessionSecret, sessionId)}`;
     res.setHeader(
       "Set-Cookie",
-      `${config.sessionCookieName}=${encodeURIComponent(signed)}; HttpOnly; Path=/; SameSite=Lax; Max-Age=${Math.floor(config.sessionTtlMs / 1000)}`
+      `${config.sessionCookieName}=${encodeURIComponent(signed)}; HttpOnly; Path=/; SameSite=Strict; Max-Age=${Math.floor(config.sessionTtlMs / 1000)}`
     );
   }
 
@@ -482,7 +482,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   // Plex image proxy (keeps token server-side)
   app.get("/api/plex/image", requireAuth, async (req, res) => {
-    const plexPath = req.query["path"] as string | undefined;
+    const plexPath = typeof req.query["path"] === "string" ? req.query["path"] : undefined;
     if (!plexPath) {
       res.status(400).json({ error: "path query param required." });
       return;


### PR DESCRIPTION
## Summary

- Harden session cookie from `SameSite=Lax` to `SameSite=Strict` — eliminates CSRF risk; the app is self-hosted with no cross-origin navigation requirements so there is no usability trade-off
- Replace `as string | undefined` cast on the Plex image proxy `path` query param with a `typeof` guard, consistent with the pattern used for `filter`/`search` params in the previous Snyk fix

## Test plan

- [x] Log in, verify session cookie is set with `SameSite=Strict`
- [x] Verify Plex image proxy still loads images correctly
- [x] Run `snyk code test` and confirm both findings are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)