### PR TITLE
docs: add Snyk scanning guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,24 @@ Do not invent the version — always confirm with the user if ambiguous.
 
 ---
 
+### Agent Behaviour — Snyk
+
+When working through Snyk findings:
+
+1. **Always explain the finding first** — describe what Snyk flagged, why it flagged it, and whether it is a genuine issue or a false positive before suggesting any action.
+
+2. **Recommend Fix or Won't Fix honestly** — if fixing the issue would require writing worse code (less readable, against best practice, or purely to satisfy static analysis), say so clearly and recommend Won't Fix instead.
+
+3. **When recommending Won't Fix**, always provide:
+   - A plain-English comment the user can paste into the Snyk GUI (explaining why the code is safe)
+   - The correct Snyk category to select: **Won't Fix** for false positives or deliberate decisions, **Ignore Temporarily** only if there is a genuine plan to revisit
+
+4. **Never suggest a change purely to appease Snyk** if it doesn't improve actual security or code quality.
+
+See `SECURITY.md` for the full Snyk tooling guide, scan commands, and philosophy.
+
+---
+
 ### Agent Behaviour Expectations
 
 Actively guide the workflow rather than waiting for perfect instructions:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,3 +34,48 @@ Security reports are especially helpful for issues involving:
 ## Supported Versions
 
 Hubarr is still early in development. Until a stable release policy is documented, security fixes are handled on the latest supported code line.
+
+---
+
+## Security Scanning with Snyk
+
+### Installation
+
+```bash
+npm install -g snyk
+snyk auth
+```
+
+`snyk auth` will open a browser to authenticate against your Snyk account.
+
+### Scan Commands
+
+| What you're scanning | Command |
+|---|---|
+| Dependencies (npm packages) | `snyk test` |
+| Source code (static analysis) | `snyk code test` |
+| Docker image | `snyk container test hubarr` |
+
+Run all three from the repo root (`/workspaces/hubarr`) to get full coverage.
+
+### Philosophy — Fix vs Ignore
+
+We take security seriously, but we don't fix things for the sake of fixing them.
+
+**Fix it** if:
+- It's a genuine vulnerability with a realistic attack path
+- The fix improves code quality or correctness
+- It's straightforward to address without compromising readability or best practice
+
+**Mark as Won't Fix** if:
+- Snyk can't trace through your validation logic but the code is demonstrably safe (false positive)
+- The "fix" would require writing worse code purely to satisfy static analysis
+- The issue requires a contorted workaround that obscures intent more than it improves security
+
+When in doubt, ask whether fixing it actually makes the code safer — or just makes Snyk happy. Those aren't the same thing.
+
+### Marking Something as Won't Fix in the Snyk GUI
+
+Use **Won't Fix** (not "Ignore Temporarily") for confirmed false positives or conscious decisions not to fix. "Ignore Temporarily" implies you plan to revisit; Won't Fix signals a deliberate call.
+
+See the [Agent Behaviour — Snyk](#agent-behaviour--snyk) section in `AGENTS.md` for how Claude handles these decisions and what it will provide when recommending Won't Fix.


### PR DESCRIPTION
## Summary

- Added a **Snyk** section to `SECURITY.md` covering install, the three scan commands (deps, code, container), and the philosophy on fix vs Won't Fix
- Added an **Agent Behaviour — Snyk** section to `AGENTS.md` with instructions for how to handle findings, when to recommend Won't Fix, and what to always provide to the user when doing so (comment text + correct Snyk category)

## Test plan

- [ ] Read through both docs and check nothing is unclear or incorrect

🤖 Generated with [Claude Code](https://claude.com/claude-code)