### PR TITLE
fix: upgrade base image to node:22-trixie-slim and fix Express 5 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-﻿FROM node:22-bookworm-slim AS deps
+﻿FROM node:22-trixie-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install
 
-FROM node:22-bookworm-slim AS build
+FROM node:22-trixie-slim AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
-FROM node:22-bookworm-slim AS runtime
+FROM node:22-trixie-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=9301

--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,10 +2637,14 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
     "tsx": "^4.19.4",
     "typescript": "^6.0.2",
     "vite": "^8.0.5"
-  },
-  "overrides": {
-    "path-to-regexp": "0.1.13"
   }
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1141,7 +1141,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   if (fs.existsSync(clientDir)) {
     app.use(express.static(clientDir));
-    app.get("*", staticRateLimiter, (req, res, next) => {
+    app.get("/*path", staticRateLimiter, (req, res, next) => {
       if (req.path.startsWith("/api/")) {
         next();
         return;


### PR DESCRIPTION
## Summary

- Upgrades Dockerfile base image from `node:22-bookworm-slim` to `node:22-trixie-slim`, reducing Snyk OS-level CVEs from 48 to ~32 (all low severity)
- Removes stale `path-to-regexp@0.1.13` override from `package.json` — this was added under Express 4 and was silently preventing Express 5 / `router@2.2.0` from getting its required `path-to-regexp@^8.0.0`; the old running container only worked because it was built before the Express 5 Dependabot bump took effect
- Updates the catch-all SPA route from `"*"` to `"/*path"` to comply with `path-to-regexp@8`, which requires named wildcards

## Test plan

- [x] Docker image builds successfully on `node:22-trixie-slim`
- [x] Container starts and runs without errors
- [x] App verified working locally before opening PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)