### PR TITLE
feat: apply isolation filters to Plex Home managed users

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Hubarr uses a few background jobs:
 
 - **Watchlist RSS Sync** watches Plex RSS feeds for quick watchlist changes and stores new items fast
 - **Watchlist GraphQL Sync** regularly performs a fuller watchlist reconciliation to catch anything RSS missed
-- **Plex library scans** help Hubarr notice when something from a watchlist has now actually appeared in your Plex libraries
+- **Plex Library Scans** help Hubarr notice when something from a watchlist has now actually appeared in your Plex libraries
 - **Collection Sync** is the job that updates the Plex collections and hub rows
 
 Together, that means Hubarr can react quickly when watchlists change, while still having a slower safety net that keeps everything accurate over time.
@@ -101,6 +101,14 @@ Hubarr is configured through its web UI after first run. The two things you may 
 5. Run a sync, or wait for the scheduled jobs to start working
 
 ## Important Limitations
+
+### Plex Home Managed Users
+
+Plex Home managed users (sub-accounts with no independent Plex account) have two limitations:
+
+- **Watchlists cannot be synced.** Managed users have no presence in the Plex community API, so Hubarr cannot read their watchlist. They will appear in the Users page as read-only and cannot be enabled.
+- **Label exclusions are applied automatically.** Even though their watchlist can't be synced, Hubarr will still apply label exclusion filters to managed users so that other users' watchlist collections don't appear for them. This happens as part of the normal collection sync.
+- **Restriction Profiles block label exclusions.** If a managed user has a Plex restriction profile set (e.g. Younger Kid, Older Kid, Teen), Plex prevents label-based filter changes for that account. Hubarr skips those users entirely — the restriction profile itself is usually sufficient exclusion anyway.
 
 ### Plex Friends Home Privacy Caveat
 

--- a/src/client/pages/Users.tsx
+++ b/src/client/pages/Users.tsx
@@ -310,21 +310,12 @@ function ManagedUserRow({ user }: { user: ManagedUserRecord }) {
       )}
 
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="font-medium text-on-surface text-sm truncate">{user.displayName}</span>
-          <span className="text-xs bg-surface-container-high text-on-surface-variant px-1.5 py-0.5 rounded font-medium">
-            Managed Account
-          </span>
-          {user.hasRestrictionProfile && (
-            <span className="text-xs bg-on-surface/10 text-on-surface-variant px-1.5 py-0.5 rounded font-medium">
-              Restriction Profile
-            </span>
-          )}
-        </div>
+        <span className="font-medium text-on-surface text-sm truncate">{user.displayName}</span>
         <p className="text-xs text-on-surface-variant mt-0.5">
+          {"Watchlists not available for managed users \u2014 "}
           {user.hasRestrictionProfile
-            ? "Restriction profile active — isolation filters not applied"
-            : "Watchlists not available for managed users — isolation filters applied automatically"}
+            ? "Label exclusion cannot be applied to user with Restriction Profile"
+            : "Label exclusion filter applied"}
         </p>
       </div>
     </div>

--- a/src/client/pages/Users.tsx
+++ b/src/client/pages/Users.tsx
@@ -3,10 +3,11 @@ import { ChevronDown, ChevronRight, Edit2, Play, RefreshCw, X } from "lucide-rea
 import { apiGet, apiPatch, apiPost } from "../lib/api";
 import { getPlexImageSrc } from "../lib/plexImage";
 import { Field, ToggleField } from "../components/FormControls";
-import type { UserRecord, SettingsResponse, VisibilityConfig } from "../../shared/types";
+import type { UserRecord, ManagedUserRecord, SettingsResponse, VisibilityConfig } from "../../shared/types";
 
 export default function Users() {
   const [users, setUsers] = useState<UserRecord[]>([]);
+  const [managedUsers, setManagedUsers] = useState<ManagedUserRecord[]>([]);
   const [settings, setSettings] = useState<SettingsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -15,15 +16,18 @@ export default function Users() {
   const [syncingId, setSyncingId] = useState<number | null>(null);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [disabledOpen, setDisabledOpen] = useState(false);
+  const [managedOpen, setManagedOpen] = useState(false);
 
   async function load() {
     setLoading(true);
     try {
-      const [usersResult, settingsResult] = await Promise.all([
+      const [usersResult, managedResult, settingsResult] = await Promise.all([
         apiGet<UserRecord[]>("/api/users"),
+        apiGet<ManagedUserRecord[]>("/api/users/managed"),
         apiGet<SettingsResponse>("/api/settings")
       ]);
       setUsers(usersResult);
+      setManagedUsers(managedResult);
       setSettings(settingsResult);
       setError(null);
     } catch (caught) {
@@ -172,6 +176,25 @@ export default function Users() {
         )}
       </div>
 
+      {managedUsers.length > 0 && (
+        <div className="mt-6">
+          <button
+            onClick={() => setManagedOpen((open) => !open)}
+            className="flex items-center gap-2 text-sm font-medium text-on-surface-variant mb-3"
+          >
+            {managedOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+            Managed Home Users ({managedUsers.length})
+          </button>
+          {managedOpen && (
+            <div className="space-y-2">
+              {managedUsers.map((user) => (
+                <ManagedUserRow key={user.plexUserId} user={user} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
       {editingId !== null && settings && (
         <EditModal
           user={users.find((user) => user.id === editingId)!}
@@ -264,6 +287,45 @@ function UserRow({
         >
           <Edit2 size={15} />
         </button>
+      </div>
+    </div>
+  );
+}
+
+function ManagedUserRow({ user }: { user: ManagedUserRecord }) {
+  return (
+    <div className="bg-surface-container rounded-xl border border-outline-variant/20 flex items-center gap-4 px-4 py-3 opacity-80">
+      {user.avatarUrl ? (
+        <img
+          src={getPlexImageSrc(user.avatarUrl) ?? undefined}
+          alt={user.displayName}
+          className="w-8 h-8 rounded-full object-cover"
+        />
+      ) : (
+        <div className="w-8 h-8 rounded-full bg-surface-container-highest flex items-center justify-center">
+          <span className="text-on-surface-variant text-xs font-medium">
+            {user.displayName.charAt(0).toUpperCase()}
+          </span>
+        </div>
+      )}
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium text-on-surface text-sm truncate">{user.displayName}</span>
+          <span className="text-xs bg-surface-container-high text-on-surface-variant px-1.5 py-0.5 rounded font-medium">
+            Managed Account
+          </span>
+          {user.hasRestrictionProfile && (
+            <span className="text-xs bg-on-surface/10 text-on-surface-variant px-1.5 py-0.5 rounded font-medium">
+              Restriction Profile
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-on-surface-variant mt-0.5">
+          {user.hasRestrictionProfile
+            ? "Restriction profile active — isolation filters not applied"
+            : "Watchlists not available for managed users — isolation filters applied automatically"}
+        </p>
       </div>
     </div>
   );

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -635,13 +635,8 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     res.json({ updated });
   });
 
-  app.get("/api/users/managed", requireAuth, async (_req, res) => {
-    try {
-      const users = await services.getManagedUsers();
-      res.json(users);
-    } catch (error) {
-      res.status(400).json({ error: error instanceof Error ? error.message : String(error) });
-    }
+  app.get("/api/users/managed", requireAuth, (_req, res) => {
+    res.json(services.getManagedUsers());
   });
 
   app.patch("/api/users/:id", requireAuth, (req, res) => {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -635,6 +635,15 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     res.json({ updated });
   });
 
+  app.get("/api/users/managed", requireAuth, async (_req, res) => {
+    try {
+      const users = await services.getManagedUsers();
+      res.json(users);
+    } catch (error) {
+      res.status(400).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
   app.patch("/api/users/:id", requireAuth, (req, res) => {
     try {
       const user = db.updateUser(Number(req.params.id), req.body);

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -4,6 +4,7 @@ import type {
   AppSettings,
   BootstrapStatus,
   DashboardResponse,
+  ManagedUserRecord,
   OnboardingStep,
   PlexCollectionRecord,
   PlexOwnerRecord,
@@ -138,6 +139,21 @@ export class HubarrDatabase {
 
   listUsers(): UserRecord[] {
     return usersRepo.listUsers(this.db);
+  }
+
+  upsertManagedUsers(
+    users: Array<{
+      plexUserId: string;
+      displayName: string;
+      avatarUrl: string | null;
+      hasRestrictionProfile: boolean;
+    }>
+  ): ManagedUserRecord[] {
+    return usersRepo.upsertManagedUsers(this.db, users);
+  }
+
+  listManagedUsers(): ManagedUserRecord[] {
+    return usersRepo.listManagedUsers(this.db);
   }
 
   getUser(id: number): UserRecord | null {

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -130,6 +130,20 @@ const migrations: Migration[] = [
         );
       `);
     }
+  },
+  {
+    version: 2,
+    up(db) {
+      db.exec(`
+        CREATE TABLE managed_users (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          plex_user_id TEXT NOT NULL UNIQUE,
+          display_name TEXT NOT NULL,
+          avatar_url TEXT,
+          has_restriction_profile INTEGER NOT NULL DEFAULT 0
+        );
+      `);
+    }
   }
 ];
 

--- a/src/server/db/users.ts
+++ b/src/server/db/users.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import type { UserRecord } from "../../shared/types.js";
+import type { ManagedUserRecord, UserRecord } from "../../shared/types.js";
 import { getAppSettings } from "./settings.js";
 
 function buildCollectionName(
@@ -191,4 +191,46 @@ export function refreshDerivedCollectionNames(db: Database.Database): void {
 export function markUserSyncResult(db: Database.Database, userId: number, error: string | null): void {
   db.prepare("UPDATE users SET last_synced_at = ?, last_sync_error = ? WHERE id = ?")
     .run(new Date().toISOString(), error, userId);
+}
+
+export function upsertManagedUsers(
+  db: Database.Database,
+  users: Array<{
+    plexUserId: string;
+    displayName: string;
+    avatarUrl: string | null;
+    hasRestrictionProfile: boolean;
+  }>
+): ManagedUserRecord[] {
+  const stmt = db.prepare(`
+    INSERT INTO managed_users (plex_user_id, display_name, avatar_url, has_restriction_profile)
+    VALUES (@plexUserId, @displayName, @avatarUrl, @hasRestrictionProfile)
+    ON CONFLICT(plex_user_id) DO UPDATE SET
+      display_name = excluded.display_name,
+      avatar_url = excluded.avatar_url,
+      has_restriction_profile = excluded.has_restriction_profile
+  `);
+
+  db.transaction(() => {
+    for (const user of users) {
+      stmt.run({ ...user, hasRestrictionProfile: user.hasRestrictionProfile ? 1 : 0 });
+    }
+  })();
+
+  return listManagedUsers(db);
+}
+
+export function listManagedUsers(db: Database.Database): ManagedUserRecord[] {
+  return (db
+    .prepare(`
+      SELECT
+        plex_user_id AS plexUserId,
+        display_name AS displayName,
+        avatar_url AS avatarUrl,
+        has_restriction_profile AS hasRestrictionProfile
+      FROM managed_users
+      ORDER BY LOWER(display_name) ASC
+    `)
+    .all() as Array<Omit<ManagedUserRecord, "hasRestrictionProfile"> & { hasRestrictionProfile: number }>)
+    .map((row) => ({ ...row, hasRestrictionProfile: Boolean(row.hasRestrictionProfile) }));
 }

--- a/src/server/db/users.ts
+++ b/src/server/db/users.ts
@@ -211,9 +211,18 @@ export function upsertManagedUsers(
       has_restriction_profile = excluded.has_restriction_profile
   `);
 
+  const activePlexUserIds = users.map((u) => u.plexUserId);
+
   db.transaction(() => {
     for (const user of users) {
       stmt.run({ ...user, hasRestrictionProfile: user.hasRestrictionProfile ? 1 : 0 });
+    }
+    // Remove any managed users no longer returned by Plex
+    if (activePlexUserIds.length > 0) {
+      const placeholders = activePlexUserIds.map(() => "?").join(", ");
+      db.prepare(`DELETE FROM managed_users WHERE plex_user_id NOT IN (${placeholders})`).run(...activePlexUserIds);
+    } else {
+      db.prepare("DELETE FROM managed_users").run();
     }
   })();
 

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1614,6 +1614,12 @@ export class PlexIntegration {
     // Also clear from Plex Home managed users
     const homeUsers = await this.getHomeOnlyManagedUsers();
     for (const user of homeUsers) {
+      // Restriction profile users are skipped in sync — don't attempt to clear them either
+      if (user.hasRestrictionProfile) {
+        skipped++;
+        continue;
+      }
+
       const finalMovieFilter = removeHubarrLabelsFromFilter(user.filterMovies);
       const finalShowFilter = removeHubarrLabelsFromFilter(user.filterTelevision);
 

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -98,6 +98,7 @@ const DISCOVER_ORIGIN = "https://discover.provider.plex.tv";
 const DISCOVER_RSS_PATH = "/rss";
 const RSS_PLEX_ORIGIN = "https://rss.plex.tv";
 const PLEX_TV_ACCOUNT_URL = "https://plex.tv/users/account.json";
+const PLEX_TV_USERS_URL = "https://plex.tv/api/users";
 const PLEX_TV_PING_URL = "https://plex.tv/api/v2/ping";
 const PLEX_TV_RESOURCES_URL = "https://plex.tv/api/v2/resources";
 
@@ -1308,6 +1309,113 @@ export class PlexIntegration {
   }
 
   /**
+   * Fetch Plex Home managed users who have no independent Plex account.
+   * Uses the plex.tv/api/users endpoint and filters for home-only managed
+   * accounts (home="1", no username/email), scoped to this server.
+   */
+  private async getHomeOnlyManagedUsers(): Promise<Array<{
+    plexUserId: string;
+    displayName: string;
+    avatarUrl: string | null;
+    filterMovies: string;
+    filterTelevision: string;
+    filterMusic: string;
+    filterPhotos: string;
+    filterAll: string;
+    allowSync: boolean;
+    allowChannels: boolean;
+    allowCameraUpload: boolean;
+    allowSubtitleAdmin: boolean;
+    allowTuners: number;
+    hasRestrictionProfile: boolean;
+  }>> {
+    const machineIdentifier = await this.getMachineIdentifier();
+
+    const url = new URL(PLEX_TV_USERS_URL);
+    url.searchParams.set("X-Plex-Token", this.settings.token);
+
+    const response = await fetch(url.toString(), {
+      headers: { Accept: "application/xml", "User-Agent": PLEX_USER_AGENT }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch Plex users list: ${response.status} ${response.statusText}`);
+    }
+
+    const xml = await response.text();
+    const parsed = await parseStringPromise(xml) as {
+      MediaContainer?: {
+        User?: Array<{
+          $: {
+            id: string;
+            title?: string;
+            thumb?: string;
+            home?: string;
+            username?: string;
+            email?: string;
+            filterMovies?: string;
+            filterTelevision?: string;
+            filterMusic?: string;
+            filterPhotos?: string;
+            filterAll?: string;
+            allowSync?: string;
+            allowChannels?: string;
+            allowCameraUpload?: string;
+            allowSubtitleAdmin?: string;
+            allowTuners?: string;
+          };
+          Server?: Array<{ $: { machineIdentifier: string } }>;
+        }>;
+      };
+    };
+
+    const users = parsed.MediaContainer?.User ?? [];
+
+    return users
+      .filter((u) =>
+        u.$.home === "1" &&
+        !u.$.username &&
+        !u.$.email &&
+        (u.Server ?? []).some((s) => s.$.machineIdentifier === machineIdentifier)
+      )
+      .map((u) => {
+        const filterMovies = decodeURIComponent(u.$.filterMovies ?? "");
+        const filterTelevision = decodeURIComponent(u.$.filterTelevision ?? "");
+        return {
+          plexUserId: u.$.id,
+          displayName: u.$.title ?? u.$.id,
+          avatarUrl: u.$.thumb ?? null,
+          filterMovies,
+          filterTelevision,
+          filterMusic: u.$.filterMusic ?? "",
+          filterPhotos: u.$.filterPhotos ?? "",
+          filterAll: u.$.filterAll ?? "",
+          allowSync: u.$.allowSync === "1",
+          allowChannels: u.$.allowChannels === "1",
+          allowCameraUpload: u.$.allowCameraUpload === "1",
+          allowSubtitleAdmin: u.$.allowSubtitleAdmin === "1",
+          allowTuners: parseInt(u.$.allowTuners ?? "0", 10),
+          hasRestrictionProfile: filterMovies.includes("contentRating=") || filterTelevision.includes("contentRating=")
+        };
+      });
+  }
+
+  async fetchManagedUsers(): Promise<Array<{
+    plexUserId: string;
+    displayName: string;
+    avatarUrl: string | null;
+    hasRestrictionProfile: boolean;
+  }>> {
+    const users = await this.getHomeOnlyManagedUsers();
+    return users.map(({ plexUserId, displayName, avatarUrl, hasRestrictionProfile }) => ({
+      plexUserId,
+      displayName,
+      avatarUrl,
+      hasRestrictionProfile
+    }));
+  }
+
+  /**
    * Apply per-user label exclusion filters so each Plex managed user only
    * sees their own watchlist hub row, not other users' rows.
    *
@@ -1393,6 +1501,58 @@ export class PlexIntegration {
       updated++;
     }
 
+    // Also apply to Plex Home managed users who have no independent Plex account.
+    // These can't be reached via the email-based sharing_settings path, but the
+    // same endpoint accepts invitedId (numeric user ID) as an alternative.
+    const homeUsers = await this.getHomeOnlyManagedUsers();
+    for (const user of homeUsers) {
+      // Skip users with a restriction profile — Plex prevents label filter changes for them
+      if (user.hasRestrictionProfile) {
+        skipped++;
+        continue;
+      }
+
+      // Managed users are never Hubarr-enabled, so always exclude all labels
+      const cleanedMovieFilter = removeHubarrLabelsFromFilter(user.filterMovies);
+      const cleanedShowFilter = removeHubarrLabelsFromFilter(user.filterTelevision);
+      const finalMovieFilter = addHubarrLabelExclusions(cleanedMovieFilter, allLabels);
+      const finalShowFilter = addHubarrLabelExclusions(cleanedShowFilter, allLabels);
+
+      if (finalMovieFilter === user.filterMovies && finalShowFilter === user.filterTelevision) {
+        skipped++;
+        continue;
+      }
+
+      const payload = {
+        invitedId: user.plexUserId,
+        settings: {
+          filterMovies: finalMovieFilter,
+          filterTelevision: finalShowFilter,
+          filterMusic: user.filterMusic,
+          filterPhotos: user.filterPhotos,
+          filterAll: user.filterAll || null,
+          allowSync: user.allowSync,
+          allowChannels: user.allowChannels,
+          allowCameraUpload: user.allowCameraUpload,
+          allowSubtitleAdmin: user.allowSubtitleAdmin,
+          allowTuners: user.allowTuners
+        }
+      };
+
+      const response = await fetch(updateUrl.toString(), {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Failed to update sharing filters for managed user ${user.displayName} (${user.plexUserId}): ${response.status} ${text}`);
+      }
+
+      updated++;
+    }
+
     return { updated, skipped };
   }
 
@@ -1446,6 +1606,47 @@ export class PlexIntegration {
       if (!response.ok) {
         const text = await response.text();
         throw new Error(`Failed to clear sharing filters for ${user.invitedEmail}: ${response.status} ${text}`);
+      }
+
+      updated++;
+    }
+
+    // Also clear from Plex Home managed users
+    const homeUsers = await this.getHomeOnlyManagedUsers();
+    for (const user of homeUsers) {
+      const finalMovieFilter = removeHubarrLabelsFromFilter(user.filterMovies);
+      const finalShowFilter = removeHubarrLabelsFromFilter(user.filterTelevision);
+
+      if (finalMovieFilter === user.filterMovies && finalShowFilter === user.filterTelevision) {
+        skipped++;
+        continue;
+      }
+
+      const payload = {
+        invitedId: user.plexUserId,
+        settings: {
+          filterMovies: finalMovieFilter,
+          filterTelevision: finalShowFilter,
+          filterMusic: user.filterMusic,
+          filterPhotos: user.filterPhotos,
+          filterAll: user.filterAll || null,
+          allowSync: user.allowSync,
+          allowChannels: user.allowChannels,
+          allowCameraUpload: user.allowCameraUpload,
+          allowSubtitleAdmin: user.allowSubtitleAdmin,
+          allowTuners: user.allowTuners
+        }
+      };
+
+      const response = await fetch(updateUrl.toString(), {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Failed to clear sharing filters for managed user ${user.displayName} (${user.plexUserId}): ${response.status} ${text}`);
       }
 
       updated++;

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -59,12 +59,21 @@ export class HubarrServices {
 
   async discoverUsers() {
     const plex = this.getPlexIntegration();
-    const [friends, managed] = await Promise.all([
+    const [friendsResult, managedResult] = await Promise.allSettled([
       plex.discoverUsers(),
       plex.fetchManagedUsers()
     ]);
-    this.db.upsertManagedUsers(managed);
-    return this.db.upsertUsers(friends);
+
+    if (friendsResult.status === "rejected") throw friendsResult.reason as Error;
+
+    if (managedResult.status === "fulfilled") {
+      this.db.upsertManagedUsers(managedResult.value);
+    } else {
+      const message = managedResult.reason instanceof Error ? managedResult.reason.message : String(managedResult.reason);
+      this.logger.warn("Managed user fetch failed during discover — cache not updated", { message });
+    }
+
+    return this.db.upsertUsers(friendsResult.value);
   }
 
   getManagedUsers() {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -59,13 +59,16 @@ export class HubarrServices {
 
   async discoverUsers() {
     const plex = this.getPlexIntegration();
-    const friends = await plex.discoverUsers();
+    const [friends, managed] = await Promise.all([
+      plex.discoverUsers(),
+      plex.fetchManagedUsers()
+    ]);
+    this.db.upsertManagedUsers(managed);
     return this.db.upsertUsers(friends);
   }
 
-  async getManagedUsers() {
-    const plex = this.getPlexIntegration();
-    return plex.fetchManagedUsers();
+  getManagedUsers() {
+    return this.db.listManagedUsers();
   }
 
   async refreshPlexToken() {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -63,6 +63,11 @@ export class HubarrServices {
     return this.db.upsertUsers(friends);
   }
 
+  async getManagedUsers() {
+    const plex = this.getPlexIntegration();
+    return plex.fetchManagedUsers();
+  }
+
   async refreshPlexToken() {
     const owner = this.db.getPlexOwner();
     if (!owner?.plexToken) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -87,6 +87,13 @@ export interface UserRecord {
   lastSyncError: string | null;
 }
 
+export interface ManagedUserRecord {
+  plexUserId: string;
+  displayName: string;
+  avatarUrl: string | null;
+  hasRestrictionProfile: boolean;
+}
+
 export interface WatchlistItem {
   plexItemId: string;
   title: string;


### PR DESCRIPTION
## Summary

- Plex Home managed users (sub-accounts with no independent Plex.tv account) were being silently skipped during isolation filter sync because the `sharing_settings` API requires an email address to identify the user — managed accounts have none
- Investigation revealed the same `sharing_settings` endpoint also accepts `invitedId` (numeric user ID) as an alternative identifier, which works for managed accounts
- Managed users with a restriction profile (e.g. "Younger Kid") are intentionally skipped — Plex prevents label filter changes on those accounts anyway
- A new read-only "Managed Home Users" section is added to the Users page so they're visible, with a note explaining watchlists aren't available for managed accounts

## Changes

- **`plex.ts`**: Added `getHomeOnlyManagedUsers()` which fetches `plex.tv/api/users`, filters for `home="1"` accounts with no username/email on this server, and detects restriction profiles via `contentRating=` in filter strings. Updated `syncIsolationFilters()` and `clearHubarrIsolationFilters()` to process these users using `invitedId` in the payload.
- **`services.ts`**: Added `getManagedUsers()` method.
- **`app.ts`**: Added `GET /api/users/managed` endpoint (registered before `/:id` to avoid route conflict).
- **`shared/types.ts`**: Added `ManagedUserRecord` interface.
- **`Users.tsx`**: Fetches managed users on load and renders a collapsible read-only section at the bottom of the Users page.

## Test plan

- [ ] Run a publish pass and confirm managed users without a restriction profile now have `label!=hubarr:*` exclusion filters applied in Plex
- [ ] Confirm managed users with a restriction profile (e.g. Hugo) are skipped and their existing filters are untouched
- [ ] Check the Users page shows a "Managed Home Users" section listing managed accounts as read-only
- [ ] Confirm "Refresh Users" still works and the managed section updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)