### PR TITLE
feat: introduce true release-date sorting for Plex collections

### DIFF
--- a/src/client/components/CollectionsConfigForm.tsx
+++ b/src/client/components/CollectionsConfigForm.tsx
@@ -105,8 +105,8 @@ export default function CollectionsConfigForm({
               setForm((current) => ({ ...current, collectionSortOrder: value as CollectionSortOrder }))
             }
           >
-            <option value="year-desc">Release Year (New to Old)</option>
-            <option value="year-asc">Release Year (Old to New)</option>
+            <option value="date-desc">Release Date (New to Old)</option>
+            <option value="date-asc">Release Date (Old to New)</option>
             <option value="title">Title (A–Z)</option>
           </SelectInput>
         </Field>

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -583,9 +583,12 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         patch.collectionNamePattern = body.collections.collectionNamePattern;
       }
       if (body.collections.collectionSortOrder !== undefined) {
-        const valid = ["year-desc", "year-asc", "title"];
-        if (valid.includes(body.collections.collectionSortOrder)) {
-          patch.collectionSortOrder = body.collections.collectionSortOrder as "year-desc" | "year-asc" | "title";
+        // Accept new date-* values and normalize legacy year-* values on ingest.
+        const legacyMap: Record<string, string> = { "year-desc": "date-desc", "year-asc": "date-asc" };
+        const normalized = legacyMap[body.collections.collectionSortOrder] ?? body.collections.collectionSortOrder;
+        const valid = ["date-desc", "date-asc", "title"];
+        if (valid.includes(normalized)) {
+          patch.collectionSortOrder = normalized as "date-desc" | "date-asc" | "title";
         }
       }
       if ("movieLibraryId" in body.collections) {

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -20,7 +20,7 @@ export const defaultAppSettings: AppSettings = {
   plexFullLibraryScanIntervalMinutes: 1440,
   historyRetentionDays: 7,
   collectionNamePattern: "{user}s Watchlist",
-  collectionSortOrder: "year-desc",
+  collectionSortOrder: "date-desc",
   visibilityDefaults: {
     recommended: true,
     home: true,
@@ -30,6 +30,17 @@ export const defaultAppSettings: AppSettings = {
   defaultMovieLibraryId: null,
   defaultShowLibraryId: null
 };
+
+/**
+ * Normalize legacy collection sort order values to the current date-based names.
+ * Existing installs may have "year-desc" or "year-asc" stored in settings.
+ */
+function normalizeSortOrder(value: string): AppSettings["collectionSortOrder"] {
+  if (value === "year-desc") return "date-desc";
+  if (value === "year-asc") return "date-asc";
+  if (value === "date-desc" || value === "date-asc" || value === "title") return value;
+  return "date-desc";
+}
 
 export function getSetting<T>(db: Database.Database, key: SettingKey): T | null {
   const row = db.prepare("SELECT value FROM settings WHERE key = ?").get(key) as
@@ -157,7 +168,12 @@ export function deleteAllSessions(db: Database.Database): void {
 
 export function getAppSettings(db: Database.Database): AppSettings {
   const stored = getSetting<AppSettings>(db, "app");
-  return { ...defaultAppSettings, ...stored };
+  const merged = { ...defaultAppSettings, ...stored };
+  // Normalize on every read so existing installs that stored the old "year-desc" /
+  // "year-asc" values automatically upgrade to "date-desc" / "date-asc" without
+  // requiring a schema migration or a manual settings save.
+  merged.collectionSortOrder = normalizeSortOrder(merged.collectionSortOrder);
+  return merged;
 }
 
 export function updateAppSettings(db: Database.Database, patch: Partial<AppSettings>): AppSettings {

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -68,8 +68,14 @@ export function getWatchlistItems(db: Database.Database, userId?: number): Watch
       const parsed = JSON.parse(rawPayload) as Partial<WatchlistItem>;
       return {
         ...row,
+        // guids and discoverKey are stored only in raw_payload (not dedicated columns)
+        // because they are wide/variable-length arrays not needed for SQL filtering.
         guids: Array.isArray(parsed.guids) ? parsed.guids : undefined,
-        discoverKey: typeof parsed.discoverKey === "string" ? parsed.discoverKey : undefined
+        discoverKey: typeof parsed.discoverKey === "string" ? parsed.discoverKey : undefined,
+        // releaseDate is persisted inside raw_payload (the full serialised WatchlistItem)
+        // rather than as a dedicated column. Restore it here so the rest of the app
+        // can rely on it without a schema migration.
+        releaseDate: typeof parsed.releaseDate === "string" ? parsed.releaseDate : (row.releaseDate ?? null)
       };
     } catch {
       return row;

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -340,7 +340,18 @@ export class PlexIntegration {
     return plexGuid ?? fallbackId;
   }
 
-  private async fetchDiscoverMetadata(item: WatchlistItem): Promise<{ posterUrl: string | null; year: number | null; guids: string[] } | null> {
+  /**
+   * Hit the Plex discover API to retrieve poster, year, release date, and
+   * cross-database GUIDs for a watchlist item.
+   *
+   * `originallyAvailableAt` is the authoritative release-date source. When it
+   * is a full YYYY-MM-DD string we use it directly; when only a year is available
+   * we synthesise `YYYY-01-01` as a sortable fallback. Both cases populate
+   * `releaseDate` so collection ordering is always deterministic.
+   *
+   * Best-effort: returns null when all endpoint attempts fail.
+   */
+  private async fetchDiscoverMetadata(item: WatchlistItem): Promise<{ posterUrl: string | null; year: number | null; releaseDate: string | null; guids: string[] } | null> {
     const endpoints = Array.from(new Set([
       item.discoverKey ? item.discoverKey.replace(/^\//, "") : null,
       `library/metadata/${encodeURIComponent(item.plexItemId)}`,
@@ -377,9 +388,21 @@ export class PlexIntegration {
           const guids = (metadata.Guid ?? [])
             .map((g) => g.id)
             .filter((id): id is string => Boolean(id));
+
+          // Derive a full release date from originallyAvailableAt when available,
+          // otherwise synthesize YYYY-01-01 from year as a sortable fallback.
+          const oaa = metadata.originallyAvailableAt;
+          let releaseDate: string | null = null;
+          if (oaa && /^\d{4}-\d{2}-\d{2}$/.test(oaa)) {
+            releaseDate = oaa;
+          } else if (metadata.year) {
+            releaseDate = `${metadata.year}-01-01`;
+          }
+
           return {
             posterUrl: metadata.thumb ?? null,
-            year: metadata.year ?? this.parseYear(metadata.originallyAvailableAt) ?? null,
+            year: metadata.year ?? this.parseYear(oaa) ?? null,
+            releaseDate,
             guids
           };
         }
@@ -442,19 +465,25 @@ export class PlexIntegration {
     return null;
   }
 
+  /**
+   * Enrich a watchlist item with poster, year, release date, and GUIDs from
+   * Plex discover metadata.
+   *
+   * Short-circuit rule: skip the discover lookup only when BOTH thumb AND
+   * releaseDate are already known. Having thumb+year alone is not enough —
+   * RSS items typically arrive with a thumbnail and year extracted from the
+   * feed title, but they have never been through a discover lookup so they
+   * will not yet have a proper releaseDate.
+   */
   private async enrichWatchlistMetadata(item: WatchlistItem) {
-    if (item.thumb && item.year) {
+    // Only skip the discover lookup when we already have everything we need.
+    // Requiring releaseDate (not just year) prevents RSS-ingested items from
+    // permanently bypassing the discover call.
+    if (item.thumb && item.releaseDate) {
       return {
         thumb: item.thumb,
         year: item.year,
-        guids: item.guids ?? []
-      };
-    }
-
-    if (item.thumb) {
-      return {
-        thumb: item.thumb,
-        year: item.year,
+        releaseDate: item.releaseDate,
         guids: item.guids ?? []
       };
     }
@@ -467,9 +496,20 @@ export class PlexIntegration {
       ...(item.guids ?? []),
       ...(discover?.guids ?? [])
     ]));
+
+    // Derive releaseDate: prefer discover metadata, then synthesize from year.
+    let releaseDate = discover?.releaseDate ?? item.releaseDate ?? null;
+    if (!releaseDate) {
+      const year = discover?.year ?? item.year;
+      if (year) {
+        releaseDate = `${year}-01-01`;
+      }
+    }
+
     return {
       thumb: discover?.posterUrl ?? item.thumb,
       year: discover?.year ?? item.year,
+      releaseDate,
       guids: mergedGuids
     };
   }
@@ -638,6 +678,7 @@ export class PlexIntegration {
           title: item.title,
           type: item.type === "SHOW" ? "show" : "movie",
           year: item.year ?? null,
+          releaseDate: null,
           thumb: null,
           guids,
           discoverKey: item.key,
@@ -664,6 +705,7 @@ export class PlexIntegration {
       ...item,
       thumb: enriched.thumb,
       year: enriched.year,
+      releaseDate: enriched.releaseDate,
       guids: enriched.guids
     };
   }
@@ -704,6 +746,7 @@ export class PlexIntegration {
           ...item,
           thumb: enriched.thumb,
           year: enriched.year,
+          releaseDate: enriched.releaseDate,
           guids: enrichedGuids,
           matchedRatingKey
         });
@@ -721,6 +764,7 @@ export class PlexIntegration {
           ...item,
           thumb: enriched.thumb,
           year: enriched.year,
+          releaseDate: enriched.releaseDate,
           guids: enrichedGuids,
           matchedRatingKey: null,
           searchCandidates: match.candidates
@@ -939,12 +983,15 @@ export class PlexIntegration {
 
   /**
    * Set the Plex collection sort mode.
-   *   year-desc → collectionSort=2 (custom order, items then positioned via reorderCollectionItems)
-   *   year-asc  → collectionSort=0 (Plex native release-date ascending)
+   *   date-desc → collectionSort=2 (custom order, items positioned via reorderCollectionItems)
+   *   date-asc  → collectionSort=2 (custom order, items positioned via reorderCollectionItems)
    *   title     → collectionSort=1 (Plex native alphabetical)
+   *
+   * Both date directions use Hubarr-managed custom ordering so the sort behaviour
+   * is consistent and deterministic regardless of direction.
    */
   async updateCollectionContentSort(ratingKey: string, sortOrder: CollectionSortOrder): Promise<void> {
-    const plexSort: Record<CollectionSortOrder, number> = { "year-desc": 2, "year-asc": 0, title: 1 };
+    const plexSort: Record<CollectionSortOrder, number> = { "date-desc": 2, "date-asc": 2, title: 1 };
     await this.requestServer(
       `/library/collections/${ratingKey}/prefs?collectionSort=${plexSort[sortOrder]}`,
       { method: "PUT" }

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1,5 +1,6 @@
 import type {
   AppSettings,
+  CollectionSortOrder,
   UserRecord,
   PlexSettingsInput,
   WatchlistItem
@@ -9,6 +10,49 @@ import { ImageCacheService } from "./image-cache.js";
 import { Logger } from "./logger.js";
 import { PlexIntegration, type PlexLibraryItemMatch, type ResolvedWatchlistItem } from "./integrations/plex.js";
 import { RssCache, type RssFeedItem } from "./rss-cache.js";
+
+/**
+ * Compare two watchlist items by release date for Plex collection ordering.
+ *
+ * YYYY-MM-DD strings compare correctly with a plain lexicographic sort, so no
+ * Date parsing is needed.
+ *
+ * Sort key priority:
+ *   1. releaseDate — primary, direction-aware (date-desc = newest first)
+ *   2. title — secondary, always ascending (A–Z)
+ *   3. plexItemId — tertiary, always ascending (guarantees a fully stable result
+ *      when two items share the same date and title)
+ *
+ * Items with a null releaseDate are placed at the end of the list in both
+ * directions. This ensures they do not interfere with properly-dated items.
+ */
+function compareByReleaseDate(
+  a: WatchlistItem,
+  b: WatchlistItem,
+  direction: Extract<CollectionSortOrder, "date-desc" | "date-asc">
+): number {
+  const aDate = a.releaseDate ?? null;
+  const bDate = b.releaseDate ?? null;
+
+  // Both null — fall through to tie-breakers so order is still deterministic.
+  if (aDate === null && bDate === null) {
+    const titleCmp = a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+    return titleCmp !== 0 ? titleCmp : a.plexItemId.localeCompare(b.plexItemId);
+  }
+  // One null — push it to the end regardless of direction.
+  if (aDate === null) return 1;
+  if (bDate === null) return -1;
+
+  const dateCmp = direction === "date-desc"
+    ? bDate.localeCompare(aDate)   // newest first
+    : aDate.localeCompare(bDate);  // oldest first
+
+  if (dateCmp !== 0) return dateCmp;
+
+  // Tie-break by title then ID for a fully stable result.
+  const titleCmp = a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+  return titleCmp !== 0 ? titleCmp : a.plexItemId.localeCompare(b.plexItemId);
+}
 
 export class HubarrServices {
   // Self RSS feed (admin's own watchlist)
@@ -165,6 +209,9 @@ export class HubarrServices {
         ...item,
         plexItemId: existing?.plexItemId ?? item.plexItemId,
         year: item.year ?? existing?.year ?? null,
+        // Preserve an already-discovered releaseDate across ingestion passes so
+        // a later partial update never drops a real date back to null.
+        releaseDate: item.releaseDate ?? existing?.releaseDate ?? null,
         thumb: item.thumb ?? existing?.thumb ?? null,
         guids: item.guids && item.guids.length > 0 ? item.guids : existing?.guids,
         discoverKey: item.discoverKey ?? existing?.discoverKey,
@@ -457,10 +504,14 @@ export class HubarrServices {
         continue;
       }
 
-      const sortOrder = appSettings.collectionSortOrder ?? "year-desc";
+      const sortOrder = appSettings.collectionSortOrder ?? "date-desc";
       const filteredItems = items.filter((item) => item.type === mediaType && item.matchedRatingKey);
-      if (sortOrder === "year-desc") {
-        filteredItems.sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+      // Sort locally for both date directions so Hubarr — not Plex — owns the
+      // ordering logic. The sorted ratingKey list is then pushed into Plex via
+      // reorderCollectionItems, with Plex's collectionSort set to custom (2) so
+      // it honours that explicit position rather than re-sorting on its own.
+      if (sortOrder === "date-desc" || sortOrder === "date-asc") {
+        filteredItems.sort((a, b) => compareByReleaseDate(a, b, sortOrder));
       }
       const matchedRatingKeys = filteredItems.map((item) => item.matchedRatingKey as string);
       const collectionName = friend.collectionName;
@@ -480,7 +531,11 @@ export class HubarrServices {
       await plex.updateCollectionSortTitle(collectionRatingKey, `!10_${collectionName}`);
       await plex.updateCollectionContentSort(collectionRatingKey, sortOrder);
       await plex.syncCollectionItems(collectionRatingKey, matchedRatingKeys);
-      if (sortOrder === "year-desc") {
+      // Explicitly push item positions into Plex for both date-sort modes.
+      // Previously only date-desc (formerly year-desc) called reorder;
+      // date-asc now also uses Hubarr-managed ordering rather than relying on
+      // Plex's native release-date ascending sort, keeping both directions consistent.
+      if (sortOrder === "date-desc" || sortOrder === "date-asc") {
         await plex.reorderCollectionItems(collectionRatingKey, matchedRatingKeys);
       }
       this.logger.info("Collection items synced", {
@@ -858,6 +913,9 @@ export class HubarrServices {
         title: item.title,
         type: item.type,
         year: item.year,
+        // RSS pubDate is watchlist/feed timing, not the media release date.
+        // releaseDate is populated by enrichWatchlistItem via discover metadata.
+        releaseDate: null,
         thumb: item.thumb,
         guids: item.guids,
         source: "rss",
@@ -978,6 +1036,9 @@ export class HubarrServices {
         title: item.title,
         type: item.type,
         year: item.year,
+        // RSS pubDate is watchlist/feed timing, not the media release date.
+        // releaseDate is populated by enrichWatchlistItem via discover metadata.
+        releaseDate: null,
         thumb: item.thumb,
         guids: item.guids,
         source: "rss",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -49,7 +49,7 @@ export interface VisibilityConfig {
   shared: boolean;
 }
 
-export type CollectionSortOrder = "year-desc" | "year-asc" | "title";
+export type CollectionSortOrder = "date-desc" | "date-asc" | "title";
 
 export type WatchlistSortBy = "added-desc" | "added-asc" | "title-asc" | "title-desc" | "year-desc" | "year-asc";
 
@@ -98,11 +98,25 @@ export interface WatchlistItem {
   plexItemId: string;
   title: string;
   type: MediaType;
+  /** The title's release year. Kept for display, matching, and as a fallback
+   *  when a full releaseDate is not available. Not used for collection ordering. */
   year: number | null;
+  /** ISO date string (YYYY-MM-DD) representing the media's original release date.
+   *  Sourced from Plex discover metadata `originallyAvailableAt`.
+   *  Used for collection sort ordering.
+   *
+   *  Distinct from `addedAt`, which records when the item entered the watchlist/feed
+   *  and must never be used as a proxy for the media release date.
+   *
+   *  null when not yet discovered; synthesised as YYYY-01-01 from `year` as a
+   *  last resort when no full date is available. */
+  releaseDate: string | null;
   thumb: string | null;
   guids?: string[];
   discoverKey?: string;
   source: "graphql" | "rss";
+  /** ISO timestamp of when this item entered the watchlist or RSS feed.
+   *  Used for watchlist recency views and RSS diffing only — not for collection ordering. */
   addedAt: string;
   matchedRatingKey: string | null;
 }


### PR DESCRIPTION
Fixes #37

## Summary

- Replaces year-based collection ordering with full date-precision sorting using `originallyAvailableAt` from Plex discover metadata
- Adds `releaseDate: string | null` to `WatchlistItem`, persisted in `raw_payload` (no schema migration needed)
- Fixes a longstanding inconsistency where ascending and descending sort used completely different code paths (Hubarr-managed vs Plex-native)
- Fixes RSS-ingested items bypassing the discover metadata lookup when they already had `thumb` + `year`, meaning they never gained a real release date

## What changed

**New field — `WatchlistItem.releaseDate`**
ISO date string (`YYYY-MM-DD`) from Plex discover `originallyAvailableAt`. Falls back to synthesised `YYYY-01-01` from `year` when only a year is available. Kept separate from `addedAt` (watchlist entry time) which is not a media release date.

**Enrichment shortcut fixed**
`enrichWatchlistMetadata` previously skipped the discover lookup when `thumb && year` were both set. The new rule is `thumb && releaseDate` — so RSS items with a poster and year still go through discover to get a proper date.

**Both sort directions now Hubarr-managed**
A new `compareByReleaseDate` helper sorts by date → title → plexItemId (nulls last in both directions). Both `date-desc` and `date-asc` set Plex `collectionSort=2` (custom) and explicitly reorder items, rather than `date-asc` delegating to Plex native sort.

**Renamed sort values with backward compat**
`year-desc` → `date-desc`, `year-asc` → `date-asc`. Existing stored settings are normalised on every read in `getAppSettings` — no migration, no user action needed.

**UI labels updated**
"Release Year (New to Old/Old to New)" → "Release Date (New to Old/Old to New)"

## Testing

- Playwright suite passes
- `npm run check` and `npm run build` both clean
- Tested locally against rebuilt container (port 9301); collection syncs running correctly in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)