### PR TITLE
chore: move Playwright artifacts under tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@ LOCAL.md
 
 # Playwright
 tests/playwright/.auth/
-playwright-report/
 tests/test-results/
+tests/playwright-report/
 .devcontainer/devcontainer.json

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@ LOCAL.md
 # Playwright
 tests/playwright/.auth/
 playwright-report/
-test-results/
+tests/test-results/
 .devcontainer/devcontainer.json

--- a/TESTING.md
+++ b/TESTING.md
@@ -45,6 +45,7 @@ Playwright-generated files are kept under `tests/` so the repo root stays tidy:
 
 - `tests/playwright/.auth/storageState.json` — saved authenticated session state
 - `tests/test-results/` — Playwright run artifacts
+- `tests/playwright-report/` — Playwright HTML report output
 
 Both are gitignored.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -27,7 +27,7 @@ Hubarr uses [Playwright](https://playwright.dev/) for end-to-end tests. Tests ru
    npm run test:e2e
    ```
 
-   The first run validates the cookie and saves the session to `tests/playwright/.auth/storageState.json` (gitignored). All subsequent runs reuse the saved session automatically.
+   The first run validates the cookie and saves the session to `tests/playwright/.auth/storageState.json` (gitignored). Test run artifacts are written to `tests/test-results/` (also gitignored). All subsequent runs reuse the saved session automatically.
 
 ## Re-authenticating
 
@@ -38,6 +38,15 @@ rm tests/playwright/.auth/storageState.json
 # Update SESSION_COOKIE in .env.playwright with a fresh value, then:
 npm run test:e2e
 ```
+
+## Generated test files
+
+Playwright-generated files are kept under `tests/` so the repo root stays tidy:
+
+- `tests/playwright/.auth/storageState.json` — saved authenticated session state
+- `tests/test-results/` — Playwright run artifacts
+
+Both are gitignored.
 
 ## Commands
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ const baseURL = process.env.BASE_URL ?? "http://localhost:3000";
 
 export default defineConfig({
   testDir: "./tests/playwright",
+  outputDir: "./tests/test-results",
   fullyParallel: false,
   retries: 0,
   reporter: "list",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,10 @@ export default defineConfig({
   outputDir: "./tests/test-results",
   fullyParallel: false,
   retries: 0,
-  reporter: "list",
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "tests/playwright-report", open: "never" }]
+  ],
 
   use: {
     baseURL,


### PR DESCRIPTION
## Summary
- move Playwright run artifacts from the repo root into `tests/test-results/`
- keep Playwright auth state under `tests/playwright/.auth/` so generated files live under a single `tests/` root
- update `.gitignore` and `TESTING.md` to match the new artifact layout

## Verification
- `npm run check`
- `npm run test:e2e`

## Note
This change was prepared by Codex.
