### PR TITLE
feat: preserve original watchlist addedAt dates via activity cache and RSS

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,9 +4,13 @@
 
 Hubarr is a single-purpose Plex companion app.
 
-It tracks the owner's Plex watchlist and selected friends' watchlists, stores that watchlist state locally, matches items against Plex libraries, and keeps per-user Plex collections and hub rows up to date.
+It tracks the owner's Plex watchlist and selected friends' watchlists, stores
+that watchlist state locally, matches items against Plex libraries, and keeps
+per-user Plex collections and hub rows up to date.
 
 Hubarr does not request or download media.
+
+---
 
 ## Core Model
 
@@ -15,6 +19,8 @@ Hubarr does not request or download media.
 - Each enabled user gets one movie collection and one TV collection
 - Both collections share the same visible name for that user
 - Hubarr is a single-owner app: the first Plex account to onboard becomes the only admin
+
+---
 
 ## Deployment Model
 
@@ -29,12 +35,13 @@ Hubarr runs as a single self-hosted container:
 
 Persistent data is stored in `/config`.
 
+---
+
 ## Database Migrations
 
 Hubarr uses SQLite `PRAGMA user_version` for schema migrations.
 
 - Versioned migrations live in `src/server/db/migrations.ts`
-- The current baseline schema is migration `1`
 - `runMigrations(db)` runs on startup, applies any migration whose version is higher than the current `user_version`, and advances `user_version` after each successful migration
 - Each migration runs inside a transaction so a failure should leave the database unchanged
 
@@ -44,6 +51,8 @@ When changing the schema in the future:
 2. Write the schema change in that migration's `up(db)` function
 3. Do not edit older migrations that may already have shipped
 4. Keep default-setting seeding separate from schema migrations
+
+---
 
 ## Auth And Setup
 
@@ -56,14 +65,19 @@ When changing the schema in the future:
   3. discover and enable users
   4. configure target libraries and visibility defaults
 
+---
+
 ## Major Subsystems
 
 ### Watchlist ingestion
 
-Hubarr ingests watchlist state through:
+Hubarr ingests watchlist state through three complementary mechanisms:
 
-- Watchlist RSS Sync for fast updates
-- Watchlist GraphQL Sync for scheduled reconciliation
+- **Watchlist RSS Sync** — fast path, picks up new additions within seconds
+- **Watchlist GraphQL Sync** — scheduled reconciliation, authoritative list of what is on each watchlist
+- **Activity Cache Fetch** — fetches Plex Community watchlist activity events to resolve when items were originally added (`addedAt`)
+
+See [docs/watchlist.md](watchlist.md) for how these work together, including date resolution priority and the ad-hoc sync flow triggered by the dashboard and per-user sync buttons.
 
 ### Plex matching
 
@@ -77,13 +91,16 @@ Hubarr creates and updates Plex collections, applies Hubarr labels, configures s
 
 Hubarr rewrites Plex shared-user content filters so tracked users only see the watchlist rows intended for them, subject to Plex platform limitations.
 
+---
+
 ## Important Invariants
 
 - Only enabled users participate in syncing and collection updates
 - Matching status is stored per watchlist item
-- Collection updates happen in the dedicated `Collection Sync` job
-- Startup Sync runs three steps in order:
+- The dedicated `Collection Sync` job is the scheduled path for collection updates; RSS and GraphQL syncs also trigger an immediate collection publish when they detect changes, so Plex collections stay current without waiting for the next scheduled job
+- Startup Sync (when enabled) runs three steps in order:
   1. `Plex Full Library Scan`
   2. `Watchlist GraphQL Sync`
   3. `Collection Sync`
+- The Activity Cache is also fetched at startup independently of the Startup Sync sequence
 - Job last-run state is persisted so the Jobs page stays truthful across restarts

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,4 +1,4 @@
-# Hubarr Sync And Publishing
+# Hubarr Sync Architecture
 
 ## Job Model
 
@@ -6,10 +6,17 @@ Hubarr uses separate background jobs so each job has one clear responsibility:
 
 - `Watchlist RSS Sync`
 - `Watchlist GraphQL Sync`
+- `Activity Cache Fetch`
 - `Plex Recently Added Scan`
 - `Plex Full Library Scan`
 - `Collection Sync`
 - `Plex Refresh Token`
+
+For a detailed explanation of how the three watchlist-specific jobs work together
+— including date resolution, RSS deduplication, and the activity feed cache —
+see [docs/watchlist.md](watchlist.md).
+
+---
 
 ## Data And Settings
 
@@ -49,11 +56,14 @@ The most important data groups are:
 
 - `Watchlist RSS Sync` interval
 - `Watchlist GraphQL Sync` interval
+- `Activity Cache Fetch` interval
 - `Collection Sync` interval
 - `Plex Recently Added Scan` interval
 - `Plex Full Library Scan` interval
 
-### Important Terminology
+---
+
+## Important Terminology
 
 #### Watchlist item
 
@@ -61,11 +71,13 @@ A title Hubarr knows is on a user's Plex watchlist.
 
 #### Matched item
 
-A watchlist item that Hubarr has successfully linked to an item already present in a Plex library.
+A watchlist item that Hubarr has successfully linked to an item already present
+in a Plex library.
 
 #### Collection Sync
 
-The job that updates Plex collections and hub visibility from cached Hubarr state.
+The job that updates Plex collections and hub visibility from cached Hubarr
+state.
 
 #### Startup Sync
 
@@ -77,11 +89,15 @@ The boot-time sequence that runs:
 
 #### Sync history
 
-The persisted run history for watchlist and collection operations shown in the History page.
+The persisted run history for watchlist and collection operations shown in the
+History page.
 
 #### Job state
 
-The persisted last-run timestamp and status used by the Jobs page so run times remain truthful across restarts.
+The persisted last-run timestamp and status used by the Jobs page so run times
+remain truthful across restarts.
+
+---
 
 ## Startup Sync
 
@@ -91,38 +107,13 @@ If `Startup Sync` is enabled, Hubarr runs this sequence on boot:
 2. `Watchlist GraphQL Sync`
 3. `Collection Sync`
 
-This gives Hubarr a fresh view of Plex library availability, then a fresh watchlist reconciliation, then a collection update pass.
+This gives Hubarr a fresh view of Plex library availability, then a fresh
+watchlist reconciliation, then a collection update pass.
 
-## Watchlist RSS Sync
+The activity cache is also fetched at startup independently of this sequence,
+before the scheduled job interval kicks in.
 
-Purpose:
-- pick up watchlist changes quickly
-
-How it works:
-- Hubarr primes self and friends RSS caches at startup
-- it polls both feeds on the configured interval
-- new feed items are diffed using stable keys
-- self items are attributed directly to the owner user
-- friends items are attributed using the RSS author field
-- new items are stored in the watchlist cache
-- Hubarr attempts an immediate Plex library match for those items
-
-Notes:
-- RSS is the fast path, not the only source of truth
-- Plex Pass is important for the best RSS experience
-
-## Watchlist GraphQL Sync
-
-Purpose:
-- reconcile watchlist state from Plex more completely
-
-How it works:
-- fetches full watchlists for enabled users through Plex GraphQL
-- enriches metadata separately
-- attempts Plex library matching for all fetched items
-- replaces the cached watchlist state for that user
-
-This is the recovery path for anything RSS missed.
+---
 
 ## Plex Library Scans
 
@@ -145,6 +136,8 @@ How it works:
 - scans full Plex libraries
 - attempts to match any still-unmatched cached watchlist items
 
+---
+
 ## Collection Sync
 
 Purpose:
@@ -157,7 +150,11 @@ How it works:
 - updates Plex hub visibility settings
 - reapplies user visibility isolation rules
 
-Only this job should perform collection updates.
+Only this job should perform collection updates. The watchlist sync jobs
+(RSS and GraphQL) trigger a collection sync immediately after processing
+changes — see [docs/watchlist.md](watchlist.md) for details.
+
+---
 
 ## Matching Behavior
 
@@ -166,9 +163,14 @@ Only this job should perform collection updates.
 - Plex library scans exist to catch items that appear later
 - Availability is represented by whether a watchlist item has a `matchedRatingKey`
 
+---
+
 ## Visibility Isolation
 
-Hubarr uses labels plus Plex shared-user filter exclusions to keep tracked users from seeing each other's watchlist rows where Plex supports that correctly.
+Hubarr uses labels plus Plex shared-user filter exclusions to keep tracked users
+from seeing each other's watchlist rows where Plex supports that correctly.
+
+---
 
 ## History, Jobs, And Logs
 
@@ -178,10 +180,11 @@ History stores higher-level sync runs such as:
 
 - `rss`
 - `full`
+- `user`
 - `publish`
-- `friend`
 
-It also stores per-run detail rows for actions such as watchlist fetches, match failures, and collection updates.
+It also stores per-run detail rows for actions such as watchlist fetches, match
+failures, unresolved `addedAt` dates, and collection updates.
 
 ### Jobs
 
@@ -191,7 +194,8 @@ Jobs shows scheduler-oriented information:
 - last run time
 - last run status
 
-For scheduler-managed jobs, last-run state is persisted so a restart does not reset the truth shown in the UI.
+For scheduler-managed jobs, last-run state is persisted so a restart does not
+reset the truth shown in the UI.
 
 ### Logs
 

--- a/docs/watchlist.md
+++ b/docs/watchlist.md
@@ -1,0 +1,302 @@
+# Watchlist System
+
+This document explains how Hubarr fetches, stores, and maintains watchlist data
+for the admin user and their friends — including how watchlist-added dates are
+resolved and what happens when a date cannot be determined.
+
+---
+
+## Overview
+
+Hubarr maintains watchlists through three complementary mechanisms that run at
+different frequencies and serve different purposes:
+
+| Mechanism | Frequency | Purpose |
+|---|---|---|
+| GraphQL full sync | Configurable (default 1h) | Authoritative list of what is currently on each watchlist |
+| RSS polling | Configurable (default 30s) | Fast detection of new additions |
+| Activity feed cache | Configurable (default 1h), independently scheduled | Historical `addedAt` dates for watchlist items |
+
+The GraphQL sync is the source of truth for what is on a watchlist right now.
+The RSS feeds catch new items quickly between full syncs. The activity feed
+cache fills in when items were added, which GraphQL alone cannot answer.
+
+---
+
+## GraphQL Full Sync
+
+**Endpoint:** `https://community.plex.tv/api` (POST)  
+**Schedule:** Every `reconciliationIntervalMinutes` (default 60 minutes), and
+optionally on startup if `fullSyncOnStartup` is enabled.  
+**Code:** `src/server/integrations/plex.ts` → `fetchGraphqlWatchlist()`,
+`src/server/services.ts` → `syncUser()`
+
+### What it does
+
+For each enabled user (self and friends), Hubarr queries the Plex Community
+GraphQL API for their full watchlist. The query paginates in batches of 100
+until all items are retrieved:
+
+```graphql
+query GetFriendWatchlist($user: UserInput!, $first: PaginationInt!, $after: String) {
+  userV2(user: $user) {
+    ... on User {
+      watchlist(first: $first, after: $after) {
+        nodes { id guid key title type year }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```
+
+Each item is then enriched via `discover.provider.plex.tv` to resolve GUIDs
+(TMDB, TVDB, IMDB), poster URLs, release dates, and year. The enriched list is
+matched against the configured Plex server libraries to find the local
+`ratingKey` for each item.
+
+### Why GraphQL
+
+The GraphQL API is the only endpoint that returns a complete, paginated watchlist
+for both the admin and their friends using a single token. It is used as the
+definitive record of what is on a watchlist at any given moment.
+
+**Limitation:** The GraphQL watchlist response contains no date fields. It cannot
+tell Hubarr when an item was added to the watchlist. The `addedAt` date is
+resolved separately (see [Date Resolution](#date-resolution)).
+
+### Merge behaviour
+
+After fetching, the new list is merged against the existing stored items using
+`mergeFetchedWatchlistItems()`. This preserves:
+- `addedAt` — never overwritten by a later sync if it already holds a real date
+- `matchedRatingKey` — preserved if already resolved, updated if changed
+- `guids` — union of new and existing GUIDs
+- `discoverKey` — preserved if the new fetch doesn't provide one
+
+Items that disappear from the GraphQL response are removed from the stored
+watchlist for that user.
+
+### Ad-hoc sync (button press)
+
+When a sync is triggered manually — either the dashboard "Run Sync" button
+(all users) or the per-user sync button — the flow is extended beyond a plain
+GraphQL fetch:
+
+1. **Activity cache refresh** — the activity feed is fetched incrementally
+   before the GraphQL pass, so date resolution uses the freshest available data.
+2. **RSS date snapshot** — both RSS feeds are fetched once and a per-user date
+   map is built. This covers items watchlisted very recently that may not yet
+   appear in the activity feed.
+3. **GraphQL sync** — runs as normal for each user, with both the activity cache
+   and the RSS date map available for `addedAt` resolution.
+4. **Collection publish** — runs immediately after the sync so Plex collections
+   are updated without waiting for the next scheduled publish job.
+
+The per-user sync button fetches the activity cache for all users (the feed is
+global) but scopes the RSS date map to that specific user's author entries.
+
+---
+
+## RSS Feeds
+
+**Endpoint:** `https://rss.plex.tv/<uuid>` and `https://discover.provider.plex.tv/rss`  
+**Schedule:** Every `rssPollIntervalSeconds` (default 30 seconds)  
+**Requires:** Plex Pass  
+**Code:** `src/server/integrations/plex.ts` → `fetchRssFeedItems()`,
+`src/server/services.ts` → `pollRss()`, `processSelfRssNewItems()`,
+`processRssNewItems()`
+
+### What it does
+
+Hubarr maintains two RSS feeds:
+
+| Feed | Covers | `feedType` |
+|---|---|---|
+| Self watchlist | Admin's own additions only | `watchlist` |
+| Friends watchlist | All enabled friends combined | `friendsWatchlist` |
+
+On startup both caches are primed with the current feed state. On each poll,
+the feed is diffed against the in-memory cache — only new items (those not seen
+in the last fetch) are processed. This diff-based approach means the RSS path
+only triggers work when something actually changed.
+
+### Why RSS feeds
+
+RSS feeds update faster than the GraphQL sync interval. A new item added to a
+watchlist typically appears in the RSS feed within seconds. This gives Hubarr
+near-real-time awareness of new additions without running a full GraphQL sync
+every few seconds.
+
+### Date attribution
+
+Each RSS item includes:
+- `pubDate` — when the item appeared in the feed, used directly as `addedAt`
+- `author` — the Plex UUID of the user who added the item
+
+The `author` field is used to attribute friends-feed items to the correct
+enabled user. Items whose `author` does not match any enabled user are skipped
+by the RSS path — if that user is disabled in Hubarr, they will also not appear
+in the GraphQL sync, so their items are intentionally ignored across both paths.
+
+### Limitation
+
+RSS feeds have a finite window — they do not contain the full history of a
+watchlist, only recent additions. Items that were on a watchlist before Hubarr
+was set up will not appear in the RSS feed and must rely on the activity feed
+cache or fall back to the sentinel value.
+
+### Deduplication
+
+The in-memory RSS cache keys each entry by the combination of the item's GUIDs
+and the `author` field. This means if two friends watchlist the same item within
+the same polling window, both entries are treated as distinct and both are
+processed — one does not silently shadow the other.
+
+### Collection publish on new items
+
+When the background RSS poll detects new items and processes them, a collection
+publish is triggered immediately afterwards. Plex collections are updated as
+soon as the RSS item is ingested rather than waiting for the next scheduled
+publish job.
+
+---
+
+## Activity Feed Cache
+
+**Endpoint:** `https://community.plex.tv/api` (POST)  
+**Schedule:** Runs once on startup, then every `activityCacheFetchIntervalMinutes`
+(default 60 minutes) — configurable independently from the full sync via Settings > Jobs  
+**Code:** `src/server/integrations/plex.ts` → `fetchWatchlistActivityFeed()`,
+`src/server/services.ts` → `syncActivityCache()`  
+**Database:** `watchlist_activity_cache` table (migration v5)
+
+### What it does
+
+The Plex Community GraphQL `activityFeed` query, filtered to `types: [WATCHLIST]`,
+returns a history of watchlist events — each entry records who watchlisted
+something, what they watchlisted, and when:
+
+```graphql
+query GetWatchlistActivity($first: PaginationInt!, $after: String) {
+  activityFeed(first: $first, after: $after, types: [WATCHLIST]) {
+    nodes {
+      date
+      userV2 { id username displayName }
+      metadataItem { id title type key }
+    }
+    pageInfo { endCursor hasNextPage }
+  }
+}
+```
+
+Results are stored locally in `watchlist_activity_cache`:
+
+```sql
+CREATE TABLE watchlist_activity_cache (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  plex_item_id TEXT NOT NULL,
+  plex_user_id TEXT NOT NULL,
+  watchlisted_at TEXT NOT NULL,
+  UNIQUE(plex_item_id, plex_user_id)
+);
+```
+
+One row per user+item pair, keeping only the most recent `watchlisted_at` date.
+If the same item is watchlisted, removed, and re-watchlisted, only the most
+recent event is retained.
+
+### Initial population
+
+On the very first run (`job_run_state.last_run_at` is `NULL` for
+`activity-cache-fetch`), the full feed history is paginated from newest to
+oldest. The feed has been confirmed to retain history going back several years.
+
+### Incremental updates
+
+On subsequent runs, only events newer than `last_run_at` are fetched.
+Since Plex returns events newest-first, the fetch stops as soon as an entry
+older than the last run timestamp is encountered — keeping the incremental cost
+low regardless of total feed size.
+
+### How it is used
+
+During `syncUser()`, after the GraphQL fetch and merge, any item whose `addedAt`
+is still the sentinel value is looked up in the activity cache. If a matching
+`(plex_item_id, plex_user_id)` row exists, its `watchlisted_at` is used as the
+real `addedAt`. Items that remain unresolved after this lookup are recorded in
+the sync run as `watchlist.date_unresolved` and appear in the History page
+(see [Unresolved Dates in History](#unresolved-dates-in-history)).
+
+### Limitation
+
+The activity feed does not retain infinite history. Items watchlisted before the
+feed's earliest record cannot be resolved this way and will permanently carry the
+sentinel value unless added again (creating a new activity event) or resolved via
+the RSS fast path.
+
+---
+
+## Date Resolution
+
+When determining `addedAt` for a watchlist item, sources are checked in priority
+order:
+
+| Priority | Source | Covers |
+|---|---|---|
+| 1 | Already-stored real date | Preserved from any previous resolution |
+| 2 | Activity feed cache | Self and friends — where history exists |
+| 3 | RSS date snapshot | Self and friends — recent items, ad-hoc syncs only |
+| 4 | Sentinel value | No date available from any source |
+
+A stored date is never overwritten unless it is the sentinel. Once a real date
+is written it is permanent.
+
+The activity cache is tried before the RSS snapshot because it covers a much
+longer history. The RSS snapshot is available only during ad-hoc syncs (button
+presses) — during background scheduled GraphQL syncs no RSS snapshot is
+fetched, so only priorities 1, 2, and 4 apply. Background RSS polling resolves
+dates directly at ingest time via `pubDate`, which is stored immediately and
+preserved by all subsequent syncs under priority 1.
+
+### Sentinel value
+
+When no real date can be determined, Hubarr stores:
+
+```
+2001-01-01T00:00:00.000Z
+```
+
+This is an intentionally implausible date that signals "date unknown" rather
+than pretending the item was watchlisted today. The sentinel is treated as
+overwriteable — if a real date arrives later via RSS or an activity cache update,
+it replaces the sentinel.
+
+In the UI, the sentinel is displayed as **Unknown** rather than the raw date.
+
+---
+
+## Unresolved Dates in History
+
+After each GraphQL sync, any items that still carry the sentinel are recorded
+against that sync run as `watchlist.date_unresolved` items. These appear in the
+History page under **Watchlisted At Date Unresolved (N)**, only shown when N > 0.
+
+As the activity feed cache accumulates history over time, this count will
+naturally trend towards zero for most users.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `src/server/integrations/plex.ts` | `fetchGraphqlWatchlist()`, `fetchWatchlistActivityFeed()`, `fetchRssFeedItems()`, `fetchRssUrl()` |
+| `src/server/services.ts` | `syncUser()`, `runFullSync()`, `runUserSync()`, `syncActivityCache()`, `buildAllRssDateMaps()`, `pollRss()`, `processSelfRssNewItems()`, `processRssNewItems()`, `runPublishPass()` |
+| `src/server/db/watchlist.ts` | Watchlist and activity cache DB helpers |
+| `src/server/db/migrations.ts` | Schema — `watchlist_cache` (v1), `watchlist_activity_cache` (v5) |
+| `src/server/rss-cache.ts` | In-memory RSS diff cache — author-keyed deduplication, `prime()`, `diff()` |
+| `src/server/index.ts` | Job registrations for all three sync mechanisms |
+| `src/client/lib/utils.ts` | `formatWatchlistDate()`, `formatWatchlistDateShort()` — sentinel-aware display helpers |
+
+---

--- a/src/client/components/WatchlistItemModal.tsx
+++ b/src/client/components/WatchlistItemModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Film, Tv, X, Star, Clock, Tag } from "lucide-react";
-import { formatRelativeTime } from "../lib/utils";
+import { formatRelativeTime, formatWatchlistDate } from "../lib/utils";
 import { apiGet } from "../lib/api";
 import { getPlexImageSrc } from "../lib/plexImage";
 import type { RichItemMetadata, WatchlistUser } from "../../shared/types";
@@ -191,7 +191,7 @@ export function WatchlistItemModal({
                       </div>
                     )}
                     <span className="text-on-surface text-sm flex-1">{user.displayName}</span>
-                    <span className="text-on-surface-variant text-xs">{formatRelativeTime(user.addedAt)}</span>
+                    <span className="text-on-surface-variant text-xs">{formatWatchlistDate(user.addedAt)}</span>
                   </div>
                 ))}
               </div>

--- a/src/client/components/WatchlistItemModal.tsx
+++ b/src/client/components/WatchlistItemModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Film, Tv, X, Star, Clock, Tag } from "lucide-react";
-import { formatRelativeTime, formatWatchlistDate } from "../lib/utils";
+import { formatWatchlistDate } from "../lib/utils";
 import { apiGet } from "../lib/api";
 import { getPlexImageSrc } from "../lib/plexImage";
 import type { RichItemMetadata, WatchlistUser } from "../../shared/types";

--- a/src/client/lib/utils.ts
+++ b/src/client/lib/utils.ts
@@ -19,6 +19,18 @@ export function cn(...inputs: ClassValue[]): string {
   return clsx(...inputs);
 }
 
+export const WATCHLIST_DATE_UNKNOWN_SENTINEL = "2001-01-01T00:00:00.000Z";
+
+export function formatWatchlistDate(isoString: string): string {
+  if (isoString === WATCHLIST_DATE_UNKNOWN_SENTINEL) return "Unknown";
+  return formatRelativeTime(isoString);
+}
+
+export function formatWatchlistDateShort(isoString: string): string {
+  if (isoString === WATCHLIST_DATE_UNKNOWN_SENTINEL) return "Unknown";
+  return new Date(isoString).toLocaleDateString("en-GB");
+}
+
 export function formatRelativeTime(isoString: string): string {
   const date = new Date(isoString);
   const now = new Date();

--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -3,7 +3,7 @@ import { RefreshCw, Film, Tv, Users, Library, CheckCircle, XCircle } from "lucid
 import { Link } from "react-router-dom";
 import { apiGet, apiPost } from "../lib/api";
 import { getPlexImageSrc } from "../lib/plexImage";
-import { formatRelativeTime } from "../lib/utils";
+import { formatRelativeTime, formatWatchlistDateShort } from "../lib/utils";
 import { WatchlistItemModal } from "../components/WatchlistItemModal";
 import type { DashboardResponse, RecentlyAddedItem, SyncRun } from "../../shared/types";
 
@@ -241,7 +241,7 @@ function PosterCard({
 }) {
   const posterSrc = getPlexImageSrc(item.posterUrl);
 
-  const addedDate = new Date(item.addedAt).toLocaleDateString("en-GB");
+  const addedDate = formatWatchlistDateShort(item.addedAt);
 
   return (
     <button onClick={onClick} className="group text-left w-full">

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -26,6 +26,7 @@ const ACTION_LABELS: Record<string, string> = {
   "watchlist.rss": "RSS item",
   "watchlist.rss.self": "RSS item (self)",
   "watchlist.match.failed": "Match failed",
+  "watchlist.date_unresolved": "Date unresolved",
   "collection.publish": "Collection publish",
   "isolation.filters": "Isolation filters",
   "sync.user": "User sync"
@@ -304,8 +305,13 @@ function RunItems({ items }: { items: SyncRunItem[] }) {
   }
 
   const failures = items.filter((i) => i.action === "watchlist.match.failed");
-  const errors = items.filter((i) => i.status === "error" && i.action !== "watchlist.match.failed");
-  const other = items.filter((i) => i.status === "success" && i.action !== "watchlist.match.failed");
+  const unresolved = items.filter((i) => i.action === "watchlist.date_unresolved");
+  const errors = items.filter(
+    (i) => i.status === "error" && i.action !== "watchlist.match.failed" && i.action !== "watchlist.date_unresolved"
+  );
+  const other = items.filter(
+    (i) => i.status === "success" && i.action !== "watchlist.match.failed" && i.action !== "watchlist.date_unresolved"
+  );
 
   return (
     <div className="space-y-3">
@@ -319,6 +325,11 @@ function RunItems({ items }: { items: SyncRunItem[] }) {
         {failures.length > 0 && (
           <span className="text-warning bg-warning/10 px-2 py-0.5 rounded-full">
             {failures.length} unmatched
+          </span>
+        )}
+        {unresolved.length > 0 && (
+          <span className="text-warning bg-warning/10 px-2 py-0.5 rounded-full">
+            {unresolved.length} date{unresolved.length !== 1 ? "s" : ""} unresolved
           </span>
         )}
         {errors.length > 0 && (
@@ -340,6 +351,18 @@ function RunItems({ items }: { items: SyncRunItem[] }) {
           <div className="space-y-1">
             {failures.map((item) => (
               <MatchFailureRow key={item.id} item={item} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Watchlisted at date unresolved */}
+      {unresolved.length > 0 && (
+        <div>
+          <div className="text-xs text-warning font-medium mb-1.5">Watchlisted At Date Unresolved ({unresolved.length})</div>
+          <div className="space-y-1">
+            {unresolved.map((item) => (
+              <DateUnresolvedRow key={item.id} item={item} />
             ))}
           </div>
         </div>
@@ -448,6 +471,21 @@ function MatchFailureRow({ item }: { item: SyncRunItem }) {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+interface DateUnresolvedDetails {
+  title?: string;
+  type?: string;
+}
+
+function DateUnresolvedRow({ item }: { item: SyncRunItem }) {
+  const d = item.details as DateUnresolvedDetails | null;
+  return (
+    <div className="bg-warning/5 border border-warning/20 rounded-lg px-3 py-2 text-xs">
+      <span className="text-on-surface font-medium">{d?.title ?? "Unknown"}</span>
+      <span className="text-on-surface-variant ml-2">{d?.type}</span>
     </div>
   );
 }

--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -129,6 +129,8 @@ function GeneralTab({
   const [confirmReset, setConfirmReset] = useState(false);
   const [clearingCache, setClearingCache] = useState(false);
   const [clearCacheMessage, setClearCacheMessage] = useState<string | null>(null);
+  const [clearingActivityCache, setClearingActivityCache] = useState(false);
+  const [clearActivityCacheMessage, setClearActivityCacheMessage] = useState<string | null>(null);
 
   useEffect(() => {
     setForm({ ...settings.general });
@@ -188,6 +190,21 @@ function GeneralTab({
     }
   }
 
+  async function clearActivityCache() {
+    setClearingActivityCache(true);
+    setClearActivityCacheMessage(null);
+    try {
+      const result = await apiPost<{ removed: number }>("/api/settings/activity-cache/clear");
+      setClearActivityCacheMessage(
+        `Cleared ${result.removed} activity cache entr${result.removed !== 1 ? "ies" : "y"}. Dates will be re-resolved on the next activity cache fetch.`
+      );
+    } catch (caught) {
+      setClearActivityCacheMessage(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setClearingActivityCache(false);
+    }
+  }
+
   return (
     <div className="space-y-6">
       <SectionCard title="General Settings">
@@ -243,18 +260,35 @@ function GeneralTab({
         </div>
       </SectionCard>
 
-      <SectionCard title="Image Cache">
-        <p className="text-xs text-on-surface-variant mb-3">
-          Hubarr caches poster art and user avatars locally to make loading faster. Clearing the cache forces a re-download on the next sync.
-        </p>
-        <button
-          disabled={clearingCache}
-          onClick={() => void clearImageCache()}
-          className="text-sm font-semibold rounded-xl px-4 py-2 min-w-[160px] transition-colors disabled:opacity-50 bg-surface-container-high hover:bg-surface-bright border border-outline-variant/30 text-on-surface"
-        >
-          {clearingCache ? "Clearing…" : "Clear Image Cache"}
-        </button>
-        {clearCacheMessage && <div className="text-xs text-on-surface-variant mt-3">{clearCacheMessage}</div>}
+      <SectionCard title="Cache">
+        <div className="space-y-4">
+          <div>
+            <p className="text-xs text-on-surface-variant mb-3">
+              Hubarr caches poster art and user avatars locally to make loading faster. Clearing the cache forces a re-download on the next sync.
+            </p>
+            <button
+              disabled={clearingCache}
+              onClick={() => void clearImageCache()}
+              className="text-sm font-semibold rounded-xl px-4 py-2 min-w-[160px] transition-colors disabled:opacity-50 bg-surface-container-high hover:bg-surface-bright border border-outline-variant/30 text-on-surface"
+            >
+              {clearingCache ? "Clearing…" : "Clear Image Cache"}
+            </button>
+            {clearCacheMessage && <div className="text-xs text-on-surface-variant mt-3">{clearCacheMessage}</div>}
+          </div>
+          <div className="border-t border-outline-variant/20 pt-4">
+            <p className="text-xs text-on-surface-variant mb-3">
+              Hubarr caches Plex watchlist activity to resolve when items were added to a watchlist. Clearing this cache removes all stored dates — they will be re-fetched on the next activity cache run.
+            </p>
+            <button
+              disabled={clearingActivityCache}
+              onClick={() => void clearActivityCache()}
+              className="text-sm font-semibold rounded-xl px-4 py-2 min-w-[160px] transition-colors disabled:opacity-50 bg-surface-container-high hover:bg-surface-bright border border-outline-variant/30 text-on-surface"
+            >
+              {clearingActivityCache ? "Clearing…" : "Clear Activity Cache"}
+            </button>
+            {clearActivityCacheMessage && <div className="text-xs text-on-surface-variant mt-3">{clearActivityCacheMessage}</div>}
+          </div>
+        </div>
       </SectionCard>
     </div>
   );
@@ -521,6 +555,7 @@ const JOB_PRESETS: Record<string, { unit: "minutes" | "hours"; values: number[] 
   "plex-full-library-scan": { unit: "hours", values: [60, 120, 240, 360, 720, 1440] },
   "full-sync": { unit: "minutes", values: [5, 10, 15, 20, 30, 60, 120, 240, 360, 720, 1440] },
   "rss-sync":  { unit: "minutes", values: [1, 2, 5, 10, 15, 30] },
+  "activity-cache-fetch": { unit: "minutes", values: [30, 60, 120, 240, 360, 720, 1440] },
 };
 
 function formatPresetLabel(value: number, unit: "minutes" | "hours"): string {

--- a/src/client/pages/Watchlists.tsx
+++ b/src/client/pages/Watchlists.tsx
@@ -10,6 +10,7 @@ import type {
   WatchlistGroupedItem,
   WatchlistSortBy
 } from "../../shared/types";
+import { formatWatchlistDateShort } from "../lib/utils";
 
 const PAGE_SIZE = 24;
 
@@ -255,7 +256,7 @@ function WatchlistPoster({
     selectedUserId !== null
       ? (item.users.find((u) => u.userId === selectedUserId)?.addedAt ?? item.addedAt)
       : item.addedAt;
-  const addedDate = new Date(displayAddedAt).toLocaleDateString("en-GB");
+  const addedDate = formatWatchlistDateShort(displayAddedAt);
 
   return (
     <button onClick={onClick} className="group text-left w-full">

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -813,6 +813,14 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         nextRunAt: scheduler?.getNextRunAt("rss-sync"),
         lastRunAt: lastRss?.completedAt ?? null,
         lastRunStatus: lastRss?.status === "success" || lastRss?.status === "error" ? lastRss.status : null
+      },
+      {
+        id: "activity-cache-fetch",
+        name: "Watchlist Activity Cache",
+        intervalDescription: `Every ${settings.activityCacheFetchIntervalMinutes} minutes`,
+        nextRunAt: scheduler?.getNextRunAt("activity-cache-fetch") ?? null,
+        lastRunAt: scheduler?.getLastRunAt("activity-cache-fetch") ?? null,
+        lastRunStatus: scheduler?.getLastRunStatus("activity-cache-fetch") ?? null
       }
     ];
 
@@ -863,6 +871,11 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
           logger.warn("Manual RSS poll failed", { error: err instanceof Error ? err.message : String(err) });
         });
         res.json({ triggered: true });
+      } else if (jobId === "activity-cache-fetch") {
+        services.syncActivityCache().catch((err) => {
+          logger.warn("Manual activity cache fetch failed", { error: err instanceof Error ? err.message : String(err) });
+        });
+        res.json({ triggered: true });
       } else {
         res.status(404).json({ error: "Unknown job." });
       }
@@ -910,6 +923,13 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         enabled: updated.rssEnabled
       });
       res.json({ updated: true });
+    } else if (jobId === "activity-cache-fetch" && body.intervalMinutes) {
+      const updated = db.updateAppSettings({ activityCacheFetchIntervalMinutes: body.intervalMinutes });
+      scheduler?.updateJob("activity-cache-fetch", {
+        intervalMs: updated.activityCacheFetchIntervalMinutes * 60 * 1000,
+        enabled: true
+      });
+      res.json({ updated: true });
     } else {
       res.status(400).json({ error: "Unknown job or missing interval." });
     }
@@ -929,6 +949,12 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   /** Clear image cache — removes all files and metadata */
   app.post("/api/settings/image-cache/clear", requireAuth, (_req, res) => {
     const removed = imageCache.clearAll();
+    res.json({ removed });
+  });
+
+  /** Clear activity cache — removes all watchlist activity date entries */
+  app.post("/api/settings/activity-cache/clear", requireAuth, (_req, res) => {
+    const removed = db.clearActivityCache();
     res.json({ removed });
   });
 

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -221,6 +221,20 @@ export class HubarrDatabase {
     return watchlistRepo.computeWatchlistHash(this.db, userId, mediaType);
   }
 
+  upsertActivityCacheEntries(
+    entries: Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }>
+  ): void {
+    watchlistRepo.upsertActivityCacheEntries(this.db, entries);
+  }
+
+  getActivityCacheDate(plexItemId: string, plexUserId: string): string | null {
+    return watchlistRepo.getActivityCacheDate(this.db, plexItemId, plexUserId);
+  }
+
+  clearActivityCache(): number {
+    return watchlistRepo.clearActivityCache(this.db);
+  }
+
   // -------------------------------------------------------------------------
   // Image Cache
   // -------------------------------------------------------------------------

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -182,6 +182,25 @@ const migrations: Migration[] = [
         CREATE INDEX idx_image_cache_kind_entity ON image_cache(kind, entity_id);
       `);
     }
+  },
+  {
+    version: 5,
+    up(db) {
+      db.exec(`
+        CREATE TABLE watchlist_activity_cache (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          plex_item_id TEXT NOT NULL,
+          plex_user_id TEXT NOT NULL,
+          watchlisted_at TEXT NOT NULL,
+          UNIQUE(plex_item_id, plex_user_id)
+        );
+
+        CREATE INDEX idx_wac_item_user ON watchlist_activity_cache(plex_item_id, plex_user_id);
+
+        INSERT OR IGNORE INTO job_run_state (job_id, last_run_at, last_run_status, updated_at)
+        VALUES ('activity-cache-fetch', NULL, NULL, datetime('now'));
+      `);
+    }
   }
 ];
 

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -13,6 +13,7 @@ export type SettingKey = "admin" | "plex" | "app";
 
 export const defaultAppSettings: AppSettings = {
   reconciliationIntervalMinutes: 60,
+  activityCacheFetchIntervalMinutes: 60,
   rssPollIntervalSeconds: 300,
   rssEnabled: true,
   collectionPublishIntervalMinutes: 5,

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -27,7 +27,11 @@ export function upsertWatchlistItem(db: Database.Database, userId: number, item:
       thumb = excluded.thumb,
       matched_rating_key = COALESCE(excluded.matched_rating_key, matched_rating_key),
       source = excluded.source,
-      raw_payload = excluded.raw_payload
+      raw_payload = excluded.raw_payload,
+      added_at = CASE
+        WHEN added_at = '2001-01-01T00:00:00.000Z' THEN excluded.added_at
+        ELSE added_at
+      END
   `).run({ userId, ...item, rawPayload: JSON.stringify(item) });
 }
 
@@ -298,4 +302,52 @@ export function computeWatchlistHash(db: Database.Database, userId: number, medi
     .createHash("sha256")
     .update(JSON.stringify(items.map((item) => [item.plexItemId, item.matchedRatingKey])))
     .digest("hex");
+}
+
+/**
+ * Upsert a batch of activity cache entries into watchlist_activity_cache.
+ * On conflict (same plex_item_id + plex_user_id) keeps the more recent date.
+ */
+export function upsertActivityCacheEntries(
+  db: Database.Database,
+  entries: Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }>
+): void {
+  const stmt = db.prepare(`
+    INSERT INTO watchlist_activity_cache (plex_item_id, plex_user_id, watchlisted_at)
+    VALUES (@plexItemId, @plexUserId, @watchlistedAt)
+    ON CONFLICT(plex_item_id, plex_user_id) DO UPDATE SET
+      watchlisted_at = CASE
+        WHEN excluded.watchlisted_at > watchlisted_at THEN excluded.watchlisted_at
+        ELSE watchlisted_at
+      END
+  `);
+  db.transaction(() => {
+    for (const entry of entries) stmt.run(entry);
+  })();
+}
+
+/**
+ * Look up the watchlisted_at date from the activity cache for a specific
+ * plex_item_id + plex_user_id pair. Returns null if not found.
+ */
+export function getActivityCacheDate(
+  db: Database.Database,
+  plexItemId: string,
+  plexUserId: string
+): string | null {
+  const row = db
+    .prepare("SELECT watchlisted_at FROM watchlist_activity_cache WHERE plex_item_id = ? AND plex_user_id = ?")
+    .get(plexItemId, plexUserId) as { watchlisted_at: string } | undefined;
+  return row?.watchlisted_at ?? null;
+}
+
+/**
+ * Delete all rows from watchlist_activity_cache and reset the job run state
+ * so the next scheduled fetch performs a full re-population.
+ * Returns the number of rows deleted.
+ */
+export function clearActivityCache(db: Database.Database): number {
+  const result = db.prepare("DELETE FROM watchlist_activity_cache").run();
+  db.prepare("UPDATE job_run_state SET last_run_at = NULL, updated_at = datetime('now') WHERE job_id = 'activity-cache-fetch'").run();
+  return result.changes;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -69,6 +69,27 @@ scheduler.registerDailyJob({
   }
 });
 
+// Activity cache — run on startup (full fetch on first run, incremental thereafter)
+services.syncActivityCache().catch((error) => {
+  logger.warn("Activity cache sync failed at startup", {
+    error: error instanceof Error ? error.message : String(error)
+  });
+});
+
+scheduler.registerRecurringJob({
+  id: "activity-cache-fetch",
+  intervalMs: appSettings.activityCacheFetchIntervalMinutes * 60 * 1000,
+  task: async () => {
+    try {
+      await services.syncActivityCache();
+    } catch (error) {
+      logger.warn("Activity cache sync failed", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+});
+
 if (appSettings.rssEnabled) {
   services.initRss().catch((error) => {
     logger.warn("RSS initialization failed at startup", {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -80,13 +80,7 @@ scheduler.registerRecurringJob({
   id: "activity-cache-fetch",
   intervalMs: appSettings.activityCacheFetchIntervalMinutes * 60 * 1000,
   task: async () => {
-    try {
-      await services.syncActivityCache();
-    } catch (error) {
-      logger.warn("Activity cache sync failed", {
-        error: error instanceof Error ? error.message : String(error)
-      });
-    }
+    await services.syncActivityCache();
   }
 });
 

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -81,6 +81,31 @@ type PlexFriendWatchlistResponse = {
   };
 };
 
+interface PlexActivityFeedNode {
+  date: string;
+  userV2: {
+    id: string;
+    username: string;
+    displayName: string;
+  };
+  metadataItem: {
+    id: string;
+    title: string;
+    type: string;
+    key: string | null;
+  } | null;
+}
+
+type PlexActivityFeedResponse = {
+  activityFeed: {
+    nodes: PlexActivityFeedNode[];
+    pageInfo: {
+      endCursor: string | null;
+      hasNextPage: boolean;
+    };
+  };
+};
+
 export interface PlexLibrary {
   key: string;
   title: string;
@@ -103,6 +128,10 @@ const PLEX_TV_PING_URL = "https://plex.tv/api/v2/ping";
 const PLEX_TV_RESOURCES_URL = "https://plex.tv/api/v2/resources";
 
 const RSS_PLEX_UUID_PATH = /^\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+// Sentinel value used when no real watchlist date can be determined.
+// Stored in the DB so it can be overwritten later if a real date is found.
+export const WATCHLIST_DATE_UNKNOWN_SENTINEL = "2001-01-01T00:00:00.000Z";
 
 export class PlexIntegration {
   private resolvedMachineIdentifier: string | null = null;
@@ -332,7 +361,7 @@ export class PlexIntegration {
       }
     }
 
-    return new Date().toISOString();
+    return WATCHLIST_DATE_UNKNOWN_SENTINEL;
   }
 
   private buildPlexItemId(fallbackId: string, guids?: string[]): string {
@@ -683,7 +712,7 @@ export class PlexIntegration {
           guids,
           discoverKey: item.key,
           source: "graphql",
-          addedAt: new Date().toISOString(),
+          addedAt: WATCHLIST_DATE_UNKNOWN_SENTINEL,
           matchedRatingKey: null
         });
       }
@@ -697,6 +726,62 @@ export class PlexIntegration {
 
   async fetchUserWatchlist(userId: string): Promise<WatchlistItem[]> {
     return this.fetchGraphqlWatchlist(userId);
+  }
+
+  /**
+   * Fetch WATCHLIST activity feed entries from the Plex Community GraphQL API.
+   *
+   * On the initial call (since = null) paginates the full history.
+   * On incremental calls, pass the ISO timestamp from the previous run —
+   * pagination stops when entries older than that timestamp are reached.
+   * Plex returns entries newest-first so this is safe to short-circuit.
+   *
+   * Returns one tuple per event. The caller is responsible for upserting into
+   * watchlist_activity_cache, keeping only the most recent date per user+item.
+   */
+  async fetchWatchlistActivityFeed(
+    since: string | null
+  ): Promise<Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }>> {
+    const results: Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }> = [];
+    let after: string | null = null;
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+      const data: PlexActivityFeedResponse = await this.requestCommunity<PlexActivityFeedResponse>(
+        `query GetWatchlistActivity($first: PaginationInt!, $after: String) {
+           activityFeed(first: $first, after: $after, types: [WATCHLIST]) {
+             nodes {
+               date
+               userV2 { id username displayName }
+               metadataItem { id title type key }
+             }
+             pageInfo { endCursor hasNextPage }
+           }
+         }`,
+        { first: 100, after }
+      );
+
+      let reachedSince = false;
+      for (const node of data.activityFeed.nodes) {
+        // Incremental mode: stop once we pass entries older than last fetch
+        if (since && node.date <= since) {
+          reachedSince = true;
+          break;
+        }
+        if (!node.metadataItem) continue;
+        const plexItemId = this.buildPlexItemId(node.metadataItem.key ?? node.metadataItem.id);
+        results.push({
+          plexItemId,
+          plexUserId: node.userV2.id,
+          watchlistedAt: node.date
+        });
+      }
+
+      hasNextPage = !reachedSince && data.activityFeed.pageInfo.hasNextPage;
+      after = data.activityFeed.pageInfo.endCursor;
+    }
+
+    return results;
   }
 
   async enrichWatchlistItem(item: WatchlistItem): Promise<WatchlistItem> {
@@ -1102,6 +1187,18 @@ export class PlexIntegration {
   async fetchSelfWatchlist(): Promise<WatchlistItem[]> {
     const account = await this.fetchSelfAccountData();
     return this.fetchGraphqlWatchlist(account.plexUuid);
+  }
+
+  /**
+   * Return the UUID of the authenticated admin account.
+   * Plex internally uses two ID formats for the same account: a legacy numeric
+   * ID (stored in the `users` table as plexUserId) and a hex UUID (used by the
+   * GraphQL API and the activityFeed). This method returns the UUID form so
+   * callers can look up the activity cache using the correct identifier.
+   */
+  async fetchSelfPlexUuid(): Promise<string> {
+    const account = await this.fetchSelfAccountData();
+    return account.plexUuid;
   }
 
   /**

--- a/src/server/job-scheduler.ts
+++ b/src/server/job-scheduler.ts
@@ -175,7 +175,9 @@ export class JobScheduler {
       this.persistState(job);
       return true;
     } catch {
-      job.lastRunAt = new Date().toISOString();
+      // Do not advance lastRunAt on failure — it serves as the incremental
+      // fetch cursor for jobs like activity-cache-fetch and must not skip
+      // the failed window on the next run.
       job.lastRunStatus = "error";
       this.persistState(job);
       return false;

--- a/src/server/rss-cache.ts
+++ b/src/server/rss-cache.ts
@@ -13,14 +13,17 @@ export interface RssFeedItem {
 }
 
 /**
- * Generate a stable deduplication key from a set of GUIDs.
+ * Generate a stable deduplication key from a set of GUIDs and an optional author.
+ * Including the author means two different friends watchlisting the same item
+ * produce distinct cache entries, so both are treated as new and processed.
  * Normalized, sorted, deduplicated, and joined so the key is stable
  * regardless of GUID ordering in the feed.
  */
-function stableKey(guids: string[]): string {
-  return Array.from(new Set(guids.map((g) => g.toLowerCase().trim()).filter(Boolean)))
+function stableKey(guids: string[], author?: string): string {
+  const guidPart = Array.from(new Set(guids.map((g) => g.toLowerCase().trim()).filter(Boolean)))
     .sort()
     .join("|");
+  return author ? `${author}::${guidPart}` : guidPart;
 }
 
 /**
@@ -37,7 +40,7 @@ export class RssCache {
   private items = new Map<string, RssFeedItem>();
 
   prime(items: RssFeedItem[]): void {
-    this.items = new Map(items.map((item) => [stableKey(item.guids), item]));
+    this.items = new Map(items.map((item) => [stableKey(item.guids, item.author || undefined), item]));
   }
 
   diff(items: RssFeedItem[]): Array<RssFeedItem & { stableKey: string }> {
@@ -45,7 +48,7 @@ export class RssCache {
     const next = new Map<string, RssFeedItem>();
 
     for (const item of items) {
-      const key = stableKey(item.guids);
+      const key = stableKey(item.guids, item.author || undefined);
       next.set(key, item);
       if (!this.items.has(key)) {
         newItems.push({ ...item, stableKey: key });

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -972,8 +972,10 @@ export class HubarrServices {
       this.logger.info("Activity cache sync complete", { isInitial, fetched: entries.length });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      // Preserve the pre-failure cursor so the next run retries from the same
+      // point rather than permanently skipping any events in the failed window.
       this.db.saveJobRunState("activity-cache-fetch", {
-        lastRunAt: new Date().toISOString(),
+        lastRunAt: since,
         lastRunStatus: "error"
       });
       this.logger.error("Activity cache sync failed", { message });

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -8,7 +8,7 @@ import type {
 import { HubarrDatabase } from "./db/index.js";
 import { ImageCacheService } from "./image-cache.js";
 import { Logger } from "./logger.js";
-import { PlexIntegration, type PlexLibraryItemMatch, type ResolvedWatchlistItem } from "./integrations/plex.js";
+import { PlexIntegration, WATCHLIST_DATE_UNKNOWN_SENTINEL, type PlexLibraryItemMatch, type ResolvedWatchlistItem } from "./integrations/plex.js";
 import { RssCache, type RssFeedItem } from "./rss-cache.js";
 
 /**
@@ -216,7 +216,15 @@ export class HubarrServices {
         guids: item.guids && item.guids.length > 0 ? item.guids : existing?.guids,
         discoverKey: item.discoverKey ?? existing?.discoverKey,
         source: existing?.source ?? item.source,
-        addedAt: existing?.addedAt ?? item.addedAt,
+        // Prefer a real date over the sentinel. A stored real date is always
+        // preserved; the sentinel can be overwritten if a real date arrives later.
+        addedAt: (() => {
+          const existingDate = existing?.addedAt;
+          const incomingDate = item.addedAt;
+          if (existingDate && existingDate !== WATCHLIST_DATE_UNKNOWN_SENTINEL) return existingDate;
+          if (incomingDate && incomingDate !== WATCHLIST_DATE_UNKNOWN_SENTINEL) return incomingDate;
+          return WATCHLIST_DATE_UNKNOWN_SENTINEL;
+        })(),
         matchedRatingKey: item.matchedRatingKey ?? existing?.matchedRatingKey ?? null
       };
     });
@@ -365,7 +373,7 @@ export class HubarrServices {
     };
   }
 
-  async syncUser(friend: UserRecord, runId: number) {
+  async syncUser(friend: UserRecord, runId: number, rssDateMap?: Map<string, string>) {
     if (!friend.enabled) {
       throw new Error("Friend must be enabled before syncing.");
     }
@@ -382,19 +390,28 @@ export class HubarrServices {
     });
 
     const plex = this.getPlexIntegration();
-    const syncObservedAt = new Date().toISOString();
 
     // Self and friends both use the same GraphQL-safe watchlist baseline.
-    const rawItems = friend.isSelf
-      ? await plex.fetchSelfWatchlist()
-      : await plex.fetchUserWatchlist(friend.plexUserId);
-    const normalizedRawItems = rawItems.map((item) => ({
-      ...item,
-      addedAt: syncObservedAt
-    }));
+    // addedAt is intentionally left as WATCHLIST_DATE_UNKNOWN_SENTINEL here —
+    // the merge and activity cache lookup below are responsible for resolving it.
+    //
+    // For the self user, also fetch their Plex UUID. Plex uses two ID formats
+    // for the admin account: a legacy numeric ID (stored in users.plex_user_id)
+    // and a hex UUID (used by the GraphQL activityFeed). The activity cache
+    // stores events under the UUID, so we need both to resolve dates.
+    const [rawItems, selfPlexUuid] = await (async () => {
+      if (friend.isSelf) {
+        const [items, uuid] = await Promise.all([
+          plex.fetchSelfWatchlist(),
+          plex.fetchSelfPlexUuid()
+        ]);
+        return [items, uuid] as const;
+      }
+      return [await plex.fetchUserWatchlist(friend.plexUserId), null] as const;
+    })();
 
-    const movieItems = await plex.resolveWatchlistItems(normalizedRawItems, "movie", movieLibraryId);
-    const showItems = await plex.resolveWatchlistItems(normalizedRawItems, "show", showLibraryId);
+    const movieItems = await plex.resolveWatchlistItems(rawItems, "movie", movieLibraryId);
+    const showItems = await plex.resolveWatchlistItems(rawItems, "show", showLibraryId);
     const fetched: ResolvedWatchlistItem[] = [...movieItems, ...showItems].sort((a, b) => a.title.localeCompare(b.title));
 
     const matchedCount = fetched.filter((i) => i.matchedRatingKey).length;
@@ -410,11 +427,65 @@ export class HubarrServices {
     const existingItems = this.db.getWatchlistItems(friend.id);
     const merged = this.mergeFetchedWatchlistItems(existingItems, fetched);
 
-    this.db.replaceWatchlistItems(friend.id, merged);
+    // Step 1: Resolve addedAt from the activity cache for items still carrying the sentinel.
+    // The activity cache stores discover-key IDs (/library/metadata/<hex>) while the
+    // watchlist cache stores plex:// GUIDs (plex://movie/<hex>). Try both so that
+    // items fetched via either path can be matched.
+    const afterActivityCache = merged.map((item) => {
+      if (item.addedAt !== WATCHLIST_DATE_UNKNOWN_SENTINEL) return item;
+      // Try all combinations of ID format (plex:// GUID vs discover key) and
+      // user ID format (numeric legacy vs UUID). The activity cache stores
+      // discover-key item IDs under the UUID form of the user ID, so for the
+      // self user we must try both plexUserId ("8448953") and plexUuid ("77b5c…").
+      const tryLookup = (userId: string) =>
+        this.db.getActivityCacheDate(item.plexItemId, userId) ??
+        (item.discoverKey ? this.db.getActivityCacheDate(item.discoverKey, userId) : null);
+      const cached =
+        tryLookup(friend.plexUserId) ??
+        (selfPlexUuid ? tryLookup(selfPlexUuid) : null);
+      if (cached) {
+        this.logger.debug("Resolved addedAt from activity cache", { title: item.title, watchlistedAt: cached });
+        return { ...item, addedAt: cached };
+      }
+      return item;
+    });
+
+    // Step 2: RSS date resolution — only available during ad-hoc syncs where a fresh
+    // RSS snapshot was fetched before this call. Covers items added very recently that
+    // have not yet propagated to the activity feed, keyed by any guid or plexItemId.
+    const afterRss = rssDateMap
+      ? afterActivityCache.map((item) => {
+          if (item.addedAt !== WATCHLIST_DATE_UNKNOWN_SENTINEL) return item;
+          const candidates = [
+            item.plexItemId,
+            ...(item.discoverKey ? [item.discoverKey] : []),
+            ...(item.guids ?? [])
+          ];
+          for (const candidate of candidates) {
+            const rssDate = rssDateMap.get(candidate.toLowerCase());
+            if (rssDate) {
+              this.logger.debug("Resolved addedAt from RSS date map", { title: item.title, pubDate: rssDate });
+              return { ...item, addedAt: rssDate };
+            }
+          }
+          return item;
+        })
+      : afterActivityCache;
+
+    // Step 3: Track items still unresolved after all date sources have been tried.
+    const unresolvedItems: Array<{ title: string; type: string }> = [];
+    const mergedWithDates = afterRss.map((item) => {
+      if (item.addedAt === WATCHLIST_DATE_UNKNOWN_SENTINEL) {
+        unresolvedItems.push({ title: item.title, type: item.type });
+      }
+      return item;
+    });
+
+    this.db.replaceWatchlistItems(friend.id, mergedWithDates);
 
     const plexSettings = this.db.getPlexSettings();
     if (plexSettings) {
-      for (const item of merged) {
+      for (const item of mergedWithDates) {
         if (!item.thumb) continue;
         if (item.thumb.startsWith("/")) {
           await this.imageCache.ensurePosterCached(item.plexItemId, {
@@ -439,7 +510,7 @@ export class HubarrServices {
       {
         userId: friend.id,
         isSelf: friend.isSelf,
-        itemCount: merged.length,
+        itemCount: mergedWithDates.length,
         matched: matchedCount,
         unmatched: unmatchedItems.length
       },
@@ -471,6 +542,23 @@ export class HubarrServices {
       );
     }
 
+    for (const item of unresolvedItems) {
+      this.db.addSyncRunItem(
+        runId,
+        "watchlist.date_unresolved",
+        "error",
+        { title: item.title, type: item.type },
+        friend.id
+      );
+    }
+
+    if (unresolvedItems.length > 0) {
+      this.logger.warn("Some watchlist items have no resolved addedAt date", {
+        userId: friend.id,
+        count: unresolvedItems.length
+      });
+    }
+
     this.db.markUserSyncResult(friend.id, null);
 
     this.logger.info("Watchlist sync complete", {
@@ -479,7 +567,7 @@ export class HubarrServices {
       durationMs: Date.now() - syncStart
     });
 
-    return merged;
+    return mergedWithDates;
   }
 
   private async publishUserCollections(
@@ -604,9 +692,36 @@ export class HubarrServices {
     // Refresh self user account info (including avatar) on every full sync
     await this.upsertSelfUser();
 
+    // Refresh the activity cache before syncing so date resolution uses the
+    // freshest data available — avoids a second background pass just for dates.
+    await this.syncActivityCache().catch((err) => {
+      this.logger.warn("Activity cache sync failed before full sync — continuing with stale cache", {
+        message: err instanceof Error ? err.message : String(err)
+      });
+    });
+
+    // Fetch current RSS items once and build per-user date maps.
+    // These catch items added very recently that haven't propagated to the
+    // activity feed yet. Non-fatal — missing RSS data just means those items
+    // fall back to the activity cache or sentinel as usual.
+    let rssMaps: { self: Map<string, string>; byAuthor: Map<string, Map<string, string>> } | null = null;
+    try {
+      const owner = this.db.getPlexOwner();
+      if (owner) {
+        rssMaps = await this.buildAllRssDateMaps(owner.plexToken);
+      }
+    } catch (err) {
+      this.logger.warn("RSS date map fetch failed before full sync — continuing without RSS date resolution", {
+        message: err instanceof Error ? err.message : String(err)
+      });
+    }
+
     for (const friend of friends) {
+      const rssDateMap = rssMaps
+        ? (friend.isSelf ? rssMaps.self : (rssMaps.byAuthor.get(friend.plexUserId) ?? new Map()))
+        : undefined;
       try {
-        await this.syncUser(friend, runId);
+        await this.syncUser(friend, runId, rssDateMap);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         this.logger.error("Friend sync failed during full sync — continuing with remaining users", {
@@ -637,6 +752,14 @@ export class HubarrServices {
       });
     }
 
+    // Publish collections immediately so the updated watchlist is live in Plex
+    // without waiting for the next scheduled collection-publish job.
+    await this.runPublishPass().catch((err) => {
+      this.logger.warn("Collection publish after full sync failed", {
+        message: err instanceof Error ? err.message : String(err)
+      });
+    });
+
     return this.db.listSyncRuns(1)[0];
   }
 
@@ -649,8 +772,40 @@ export class HubarrServices {
     const label = friend.isSelf ? "self" : friend.displayName;
     const runId = this.db.createSyncRun("user", `Manual sync for ${label}.`);
     try {
-      const items = await this.syncUser(friend, runId);
+      // Refresh the activity cache so date resolution uses the freshest data.
+      await this.syncActivityCache().catch((err) => {
+        this.logger.warn("Activity cache sync failed before user sync — continuing with stale cache", {
+          userId: friend.id,
+          message: err instanceof Error ? err.message : String(err)
+        });
+      });
+
+      // Fetch current RSS items and build a date map scoped to this user.
+      let rssDateMap: Map<string, string> | undefined;
+      try {
+        const owner = this.db.getPlexOwner();
+        if (owner) {
+          const allMaps = await this.buildAllRssDateMaps(owner.plexToken);
+          rssDateMap = friend.isSelf ? allMaps.self : allMaps.byAuthor.get(friend.plexUserId);
+        }
+      } catch (err) {
+        this.logger.warn("RSS date map fetch failed before user sync — continuing without RSS date resolution", {
+          userId: friend.id,
+          message: err instanceof Error ? err.message : String(err)
+        });
+      }
+
+      const items = await this.syncUser(friend, runId, rssDateMap);
       this.db.completeSyncRun(runId, "success", `Manual sync finished for ${label}.`, null);
+
+      // Publish collections immediately so the result is live in Plex.
+      await this.runPublishPass().catch((err) => {
+        this.logger.warn("Collection publish after user sync failed", {
+          userId: friend.id,
+          message: err instanceof Error ? err.message : String(err)
+        });
+      });
+
       return { run: this.db.listSyncRuns(1)[0], items };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -711,6 +866,119 @@ export class HubarrServices {
     }
 
     return this.db.listSyncRuns(1)[0];
+  }
+
+  // ---------------------------------------------------------------------------
+  // RSS — date map helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch both Plex RSS feeds and build per-user date maps that can be passed
+   * into syncUser() to fill in sentinel dates for recently watchlisted items.
+   *
+   * Both feeds are fetched in parallel. Failures are surfaced so the caller
+   * can decide whether to continue with a partial map or skip RSS resolution.
+   *
+   * Returns:
+   *   self      — Map<lowercased-guid, ISO date> for the admin user
+   *   byAuthor  — Map<plexUserId, Map<lowercased-guid, ISO date>> for friends
+   */
+  private async buildAllRssDateMaps(ownerToken: string): Promise<{
+    self: Map<string, string>;
+    byAuthor: Map<string, Map<string, string>>;
+  }> {
+    const plex = this.getPlexIntegration();
+
+    const [selfResult, friendsResult] = await Promise.all([
+      plex.fetchRssUrl("watchlist", ownerToken).then((url) =>
+        url ? plex.fetchRssFeedItems(url) : null
+      ),
+      plex.fetchRssUrl("friendsWatchlist", ownerToken).then((url) =>
+        url ? plex.fetchRssFeedItems(url) : null
+      )
+    ]);
+
+    const self = new Map<string, string>();
+    if (selfResult?.ok) {
+      for (const item of selfResult.items) {
+        if (!item.pubDate) continue;
+        const date = new Date(item.pubDate);
+        if (Number.isNaN(date.getTime())) continue;
+        const iso = date.toISOString();
+        for (const guid of item.guids) {
+          self.set(guid.toLowerCase(), iso);
+        }
+      }
+      this.logger.debug("Built self RSS date map", { itemCount: self.size });
+    }
+
+    const byAuthor = new Map<string, Map<string, string>>();
+    if (friendsResult?.ok) {
+      for (const item of friendsResult.items) {
+        if (!item.pubDate || !item.author) continue;
+        const date = new Date(item.pubDate);
+        if (Number.isNaN(date.getTime())) continue;
+        const iso = date.toISOString();
+        if (!byAuthor.has(item.author)) byAuthor.set(item.author, new Map());
+        const authorMap = byAuthor.get(item.author)!;
+        for (const guid of item.guids) {
+          authorMap.set(guid.toLowerCase(), iso);
+        }
+      }
+      this.logger.debug("Built friends RSS date map", { authorCount: byAuthor.size });
+    }
+
+    return { self, byAuthor };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Activity Feed Cache
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch WATCHLIST activity events from the Plex Community API and upsert
+   * them into the local watchlist_activity_cache table.
+   *
+   * On the first run (no prior job_run_state) the entire feed history is
+   * paginated. On subsequent runs only events since the last fetch are pulled,
+   * keeping the incremental cost low.
+   */
+  async syncActivityCache(): Promise<void> {
+    const plexSettings = this.db.getPlexSettings();
+    if (!plexSettings) {
+      this.logger.warn("Activity cache sync skipped — Plex is not configured yet.");
+      return;
+    }
+
+    const plex = new PlexIntegration(plexSettings, this.logger);
+    const lastState = this.db.getJobRunState("activity-cache-fetch");
+    const since = lastState?.lastRunAt ?? null;
+    const isInitial = since === null;
+
+    this.logger.info("Activity cache sync started", { isInitial, since });
+
+    try {
+      const entries = await plex.fetchWatchlistActivityFeed(since);
+
+      if (entries.length > 0) {
+        this.db.upsertActivityCacheEntries(entries);
+      }
+
+      this.db.saveJobRunState("activity-cache-fetch", {
+        lastRunAt: new Date().toISOString(),
+        lastRunStatus: "success"
+      });
+
+      this.logger.info("Activity cache sync complete", { isInitial, fetched: entries.length });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.db.saveJobRunState("activity-cache-fetch", {
+        lastRunAt: new Date().toISOString(),
+        lastRunStatus: "error"
+      });
+      this.logger.error("Activity cache sync failed", { message });
+      throw err;
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -851,6 +1119,20 @@ export class HubarrServices {
       }
 
       const total = selfProcessed + friendsProcessed;
+
+      // Publish collections immediately when new items were found so the
+      // watchlist is live in Plex without waiting for the next scheduled publish.
+      if (total > 0) {
+        this.logger.info("New RSS items processed — triggering collection publish", { count: total });
+        try {
+          await this.runPublishPass();
+        } catch (publishErr) {
+          this.logger.warn("Collection publish after RSS sync failed", {
+            message: publishErr instanceof Error ? publishErr.message : String(publishErr)
+          });
+        }
+      }
+
       this.db.completeSyncRun(
         runId,
         "success",
@@ -921,7 +1203,7 @@ export class HubarrServices {
         source: "rss",
         addedAt: item.pubDate && !Number.isNaN(new Date(item.pubDate).getTime())
           ? new Date(item.pubDate).toISOString()
-          : new Date().toISOString(),
+          : WATCHLIST_DATE_UNKNOWN_SENTINEL,
         matchedRatingKey: null
       };
 
@@ -1044,7 +1326,7 @@ export class HubarrServices {
         source: "rss",
         addedAt: item.pubDate && !Number.isNaN(new Date(item.pubDate).getTime())
           ? new Date(item.pubDate).toISOString()
-          : new Date().toISOString(),
+          : WATCHLIST_DATE_UNKNOWN_SENTINEL,
         matchedRatingKey: null
       };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -55,6 +55,7 @@ export type WatchlistSortBy = "added-desc" | "added-asc" | "title-asc" | "title-
 
 export interface AppSettings {
   reconciliationIntervalMinutes: number;
+  activityCacheFetchIntervalMinutes: number;
   rssPollIntervalSeconds: number;
   rssEnabled: boolean;
   collectionPublishIntervalMinutes: number;


### PR DESCRIPTION
## Summary

- Introduces a `watchlist_activity_cache` table populated from the Plex Community `activityFeed` GraphQL query, storing the real date each item was watchlisted per user
- Uses a sentinel value (`2001-01-01`) for unknown dates rather than today's date, so real dates can be resolved later and the UI can show "Unknown" meaningfully
- Ad-hoc sync buttons (dashboard and per-user) now run a full pipeline: refresh activity cache → RSS date snapshot → GraphQL sync → immediate collection publish
- RSS and GraphQL syncs trigger an immediate collection publish when changes are detected, rather than waiting for the next scheduled job
- Fixes RSS deduplication so two friends watchlisting the same item are both detected and processed
- Adds History page section surfacing items whose `addedAt` date could not be resolved
- Replaces `plans/` docs with proper `docs/` reference documentation covering the full watchlist pipeline

## Changes

### Server
- `migrations.ts` — v5: `watchlist_activity_cache` and `job_run_state` tables; v6: `activityCacheFetchIntervalMinutes` setting
- `plex.ts` — `fetchWatchlistActivityFeed()`, `fetchSelfPlexUuid()`, `fetchSelfWatchlist()`
- `services.ts` — `syncActivityCache()`, `buildAllRssDateMaps()`, extended `syncUser()` with three-step date resolution, `runFullSync()` and `runUserSync()` now chain activity cache + RSS + publish, `pollRss()` triggers publish on new items
- `rss-cache.ts` — author included in stable key so two friends watchlisting the same item are distinct entries
- `db/` — `getActivityCacheDate()`, `upsertActivityCacheEntries()`, `getJobRunState()`, `saveJobRunState()`
- `app.ts` — activity cache and job state API endpoints

### Client
- Settings: Activity Cache Fetch interval configurable under Jobs
- History: Watchlisted At Date Unresolved collapsible section
- Watchlists / Dashboard / WatchlistItemModal: sentinel-aware `addedAt` display ("Unknown" instead of 01/01/2001)

### Docs
- `docs/watchlist.md` — full end-to-end watchlist pipeline reference
- `docs/sync.md` — sync architecture, job model, settings, startup sequence
- `docs/architecture.md` — high-level architecture overview
- `plans/` directory removed

## Test plan

- [ ] First setup: dashboard sync button fetches activity cache, resolves dates, publishes collections in one shot
- [ ] Per-user sync button does the same scoped to that user
- [ ] Items with no resolvable date show "Unknown" in UI and appear in History under "Watchlisted At Date Unresolved"
- [ ] Items with resolved dates show correct date and do not appear in unresolved section
- [ ] RSS new item detection works for two friends watchlisting the same item (both processed)
- [ ] RSS processing triggers immediate collection publish
- [ ] Scheduled GraphQL sync triggers immediate collection publish when items change
- [ ] Activity Cache Fetch interval is configurable in Settings > Jobs

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)