### PR TITLE
feat: watchlisted date sorting and per-user collection order overrides

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -85,6 +85,34 @@ Read-only. Safe to run against a live instance.
 
 ---
 
+### `tests/playwright/settings.spec.ts` — Settings tabs
+
+Read-only. Safe to run against a live instance.
+
+| Test | What it checks |
+|---|---|
+| All six tabs are visible | Navigates to `/settings`, asserts all six tab buttons (General, Plex, Collections, Logs, Jobs, About) are rendered |
+| Clicking a tab updates the URL | Clicks Plex, Jobs, and About tabs in turn; asserts the URL gains the expected `?tab=` parameter |
+| General tab shows Startup Sync toggle and History Retention field | Navigates to `/settings?tab=general`, waits for load, asserts both setting labels are visible |
+| Jobs tab shows the jobs table | Navigates to `/settings?tab=jobs`, asserts the "Job Name" column header is visible |
+| About tab shows version and support info | Navigates to `/settings?tab=about`, asserts "About Hubarr" and "Version" headings are visible |
+| Collections tab shows watchlisted date sort options | Navigates to `/settings?tab=collections`, asserts the ordering `<select>` contains the "Watchlisted Date (New to Old)" and "Watchlisted Date (Old to New)" options |
+
+---
+
+### `tests/playwright/users.spec.ts` — Users page structure
+
+Read-only. Safe to run against a live instance.
+
+| Test | What it checks |
+|---|---|
+| Active users section heading is visible | Asserts the "Active (N)" heading renders |
+| Disabled users accordion toggle is visible | Asserts the "Disabled (N)" toggle button renders |
+| Refresh Users button is present | Asserts the Refresh Users button renders |
+| Edit modal shows collection ordering override section | Clicks the first user's edit button, asserts the "Collection Ordering" section is visible in the modal, and that the dropdown contains the two watchlist date sort options |
+
+---
+
 ### `tests/playwright/posters.spec.ts` — Image cache
 
 Tests that cached images are served correctly from `/images/`, that the route is protected, and that user avatars load. Images are cached at sync time — tests log and skip gracefully if no images have been cached yet (run a full sync first).

--- a/src/client/components/CollectionsConfigForm.tsx
+++ b/src/client/components/CollectionsConfigForm.tsx
@@ -108,6 +108,8 @@ export default function CollectionsConfigForm({
             <option value="date-desc">Release Date (New to Old)</option>
             <option value="date-asc">Release Date (Old to New)</option>
             <option value="title">Title (A–Z)</option>
+            <option value="watchlist-date-desc">Watchlisted Date (New to Old)</option>
+            <option value="watchlist-date-asc">Watchlisted Date (Old to New)</option>
           </SelectInput>
         </Field>
 

--- a/src/client/pages/Users.tsx
+++ b/src/client/pages/Users.tsx
@@ -2,8 +2,18 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, Edit2, Play, RefreshCw, X } from "lucide-react";
 import { apiGet, apiPatch, apiPost } from "../lib/api";
 import { getPlexImageSrc } from "../lib/plexImage";
-import { Field, ToggleField } from "../components/FormControls";
-import type { UserRecord, ManagedUserRecord, SettingsResponse, VisibilityConfig } from "../../shared/types";
+import { Field, SelectInput, ToggleField } from "../components/FormControls";
+import type { CollectionSortOrder, UserRecord, ManagedUserRecord, SettingsResponse, VisibilityConfig } from "../../shared/types";
+
+/** Human-readable labels for each CollectionSortOrder value, matching the
+ *  dropdown text used in CollectionsConfigForm and the EditModal. */
+const SORT_ORDER_LABELS: Record<string, string> = {
+  "date-desc": "Release Date (New to Old)",
+  "date-asc": "Release Date (Old to New)",
+  "title": "Title (A\u2013Z)",
+  "watchlist-date-desc": "Watchlisted Date (New to Old)",
+  "watchlist-date-asc": "Watchlisted Date (Old to New)"
+};
 
 export default function Users() {
   const [users, setUsers] = useState<UserRecord[]>([]);
@@ -386,6 +396,9 @@ function EditModal({
   const [visibilityOverride, setVisibilityOverride] = useState<VisibilityConfig | null>(
     user.visibilityOverride ?? null
   );
+  const [collectionSortOrderOverride, setCollectionSortOrderOverride] = useState<CollectionSortOrder | null>(
+    user.collectionSortOrderOverride ?? null
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -403,7 +416,8 @@ function EditModal({
         enabled,
         displayNameOverride: displayNameOverride.trim() || null,
         collectionNameOverride: collectionNameOverride.trim() || null,
-        visibilityOverride
+        visibilityOverride,
+        collectionSortOrderOverride
       });
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
@@ -497,6 +511,35 @@ function EditModal({
                 }
               />
             </div>
+          </div>
+
+          <div className="border-t border-outline-variant/10 pt-4">
+            <div className="flex items-center justify-between mb-3">
+              <div className="text-sm font-medium text-on-surface">Collection Ordering</div>
+              {collectionSortOrderOverride && (
+                <button
+                  onClick={() => setCollectionSortOrderOverride(null)}
+                  className="text-xs text-primary hover:text-primary-dim"
+                >
+                  Restore to global default
+                </button>
+              )}
+            </div>
+            <Field hint={`Global default: ${SORT_ORDER_LABELS[settings.collections.collectionSortOrder] ?? settings.collections.collectionSortOrder}`}>
+              <SelectInput
+                value={collectionSortOrderOverride ?? ""}
+                onChange={(value) =>
+                  setCollectionSortOrderOverride((value as CollectionSortOrder) || null)
+                }
+              >
+                <option value="">Use global default</option>
+                <option value="date-desc">Release Date (New to Old)</option>
+                <option value="date-asc">Release Date (Old to New)</option>
+                <option value="title">Title (A–Z)</option>
+                <option value="watchlist-date-desc">Watchlisted Date (New to Old)</option>
+                <option value="watchlist-date-asc">Watchlisted Date (Old to New)</option>
+              </SelectInput>
+            </Field>
           </div>
         </div>
 

--- a/src/client/pages/Users.tsx
+++ b/src/client/pages/Users.tsx
@@ -525,7 +525,7 @@ function EditModal({
                 </button>
               )}
             </div>
-            <Field hint={`Global default: ${SORT_ORDER_LABELS[settings.collections.collectionSortOrder] ?? settings.collections.collectionSortOrder}`}>
+            <Field label="Collection ordering" hint={`Global default: ${SORT_ORDER_LABELS[settings.collections.collectionSortOrder] ?? settings.collections.collectionSortOrder}`}>
               <SelectInput
                 value={collectionSortOrderOverride ?? ""}
                 onChange={(value) =>

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -5,6 +5,7 @@ import express, { type NextFunction, type Request, type Response } from "express
 import { rateLimit } from "express-rate-limit";
 import helmet from "helmet";
 import type {
+  CollectionSortOrder,
   HealthResponse,
   PlexConfigPayload,
   PlexConnectionOption,
@@ -422,7 +423,18 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   app.patch("/api/users/:id", requireAuth, (req, res) => {
     try {
-      const user = db.updateUser(Number(req.params.id), req.body);
+      const body = req.body as Record<string, unknown>;
+      // Validate collectionSortOrderOverride if provided — reject unknown values.
+      const validSortOrders: CollectionSortOrder[] = ["date-desc", "date-asc", "title", "watchlist-date-desc", "watchlist-date-asc"];
+      if (
+        "collectionSortOrderOverride" in body &&
+        body.collectionSortOrderOverride !== null &&
+        !validSortOrders.includes(body.collectionSortOrderOverride as CollectionSortOrder)
+      ) {
+        res.status(400).json({ error: "Invalid collectionSortOrderOverride value." });
+        return;
+      }
+      const user = db.updateUser(Number(req.params.id), body);
       res.json(user);
     } catch (error) {
       res.status(404).json({ error: error instanceof Error ? error.message : String(error) });
@@ -586,9 +598,9 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         // Accept new date-* values and normalize legacy year-* values on ingest.
         const legacyMap: Record<string, string> = { "year-desc": "date-desc", "year-asc": "date-asc" };
         const normalized = legacyMap[body.collections.collectionSortOrder] ?? body.collections.collectionSortOrder;
-        const valid = ["date-desc", "date-asc", "title"];
-        if (valid.includes(normalized)) {
-          patch.collectionSortOrder = normalized as "date-desc" | "date-asc" | "title";
+        const valid: CollectionSortOrder[] = ["date-desc", "date-asc", "title", "watchlist-date-desc", "watchlist-date-asc"];
+        if (valid.includes(normalized as CollectionSortOrder)) {
+          patch.collectionSortOrder = normalized as CollectionSortOrder;
         }
       }
       if ("movieLibraryId" in body.collections) {

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -167,7 +167,7 @@ export class HubarrDatabase {
     patch: Partial<
       Pick<
         UserRecord,
-        "enabled" | "movieLibraryId" | "showLibraryId" | "visibilityOverride" | "displayNameOverride" | "collectionNameOverride"
+        "enabled" | "movieLibraryId" | "showLibraryId" | "visibilityOverride" | "displayNameOverride" | "collectionNameOverride" | "collectionSortOrderOverride"
       >
     >
   ): UserRecord | null {

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -201,6 +201,16 @@ const migrations: Migration[] = [
         VALUES ('activity-cache-fetch', NULL, NULL, datetime('now'));
       `);
     }
+  },
+  {
+    version: 6,
+    up(db) {
+      // Stores an optional per-user collection sort order override.
+      // NULL means the user inherits the global collectionSortOrder setting.
+      db.exec(`
+        ALTER TABLE users ADD COLUMN collection_sort_order_override TEXT;
+      `);
+    }
   }
 ];
 

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -39,7 +39,7 @@ export const defaultAppSettings: AppSettings = {
 function normalizeSortOrder(value: string): AppSettings["collectionSortOrder"] {
   if (value === "year-desc") return "date-desc";
   if (value === "year-asc") return "date-asc";
-  if (value === "date-desc" || value === "date-asc" || value === "title") return value;
+  if (value === "date-desc" || value === "date-asc" || value === "title" || value === "watchlist-date-desc" || value === "watchlist-date-asc") return value;
   return "date-desc";
 }
 

--- a/src/server/db/users.ts
+++ b/src/server/db/users.ts
@@ -82,6 +82,7 @@ export function listUsers(db: Database.Database): UserRecord[] {
         u.visibility_override AS visibilityOverride,
         u.collection_name_override AS collectionNameOverride,
         u.collection_name AS collectionName,
+        u.collection_sort_order_override AS collectionSortOrderOverride,
         u.last_synced_at AS lastSyncedAt,
         u.last_sync_error AS lastSyncError
       FROM users u
@@ -116,7 +117,14 @@ export function updateUser(
   patch: Partial<
     Pick<
       UserRecord,
-      "enabled" | "movieLibraryId" | "showLibraryId" | "visibilityOverride" | "displayNameOverride" | "collectionNameOverride"
+      | "enabled"
+      | "movieLibraryId"
+      | "showLibraryId"
+      | "visibilityOverride"
+      | "displayNameOverride"
+      | "collectionNameOverride"
+      // null means "follow global setting"; a value overrides it for this user only
+      | "collectionSortOrderOverride"
     >
   >
 ): UserRecord | null {
@@ -135,7 +143,8 @@ export function updateUser(
   db.prepare(`
     UPDATE users
     SET enabled = ?, movie_library_id = ?, show_library_id = ?,
-        visibility_override = ?, display_name_override = ?, collection_name_override = ?, collection_name = ?
+        visibility_override = ?, display_name_override = ?, collection_name_override = ?,
+        collection_name = ?, collection_sort_order_override = ?
     WHERE id = ?
   `).run(
     next.enabled ? 1 : 0,
@@ -145,6 +154,7 @@ export function updateUser(
     next.displayNameOverride ?? null,
     next.collectionNameOverride ?? null,
     collectionName,
+    next.collectionSortOrderOverride ?? null,
     id
   );
 

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1076,7 +1076,15 @@ export class PlexIntegration {
    * is consistent and deterministic regardless of direction.
    */
   async updateCollectionContentSort(ratingKey: string, sortOrder: CollectionSortOrder): Promise<void> {
-    const plexSort: Record<CollectionSortOrder, number> = { "date-desc": 2, "date-asc": 2, title: 1 };
+    const plexSort: Record<CollectionSortOrder, number> = {
+      "date-desc": 2,
+      "date-asc": 2,
+      "title": 1,
+      // Watchlist date sorts use Plex's custom order mode (2) so item positions
+      // can be pushed explicitly via reorderCollectionItems.
+      "watchlist-date-desc": 2,
+      "watchlist-date-asc": 2
+    };
     await this.requestServer(
       `/library/collections/${ratingKey}/prefs?collectionSort=${plexSort[sortOrder]}`,
       { method: "PUT" }

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -26,6 +26,53 @@ import { RssCache, type RssFeedItem } from "./rss-cache.js";
  * Items with a null releaseDate are placed at the end of the list in both
  * directions. This ensures they do not interfere with properly-dated items.
  */
+/** Sentinel value used for items whose watchlist date is unknown.
+ *  Treated as "no date" and sorted to the end regardless of direction,
+ *  mirroring how a null releaseDate is handled in compareByReleaseDate. */
+const UNKNOWN_ADDED_AT = "2001-01-01T00:00:00.000Z";
+
+function compareByWatchlistDate(
+  a: WatchlistItem,
+  b: WatchlistItem,
+  direction: Extract<CollectionSortOrder, "watchlist-date-desc" | "watchlist-date-asc">
+): number {
+  const aSentinel = a.addedAt === UNKNOWN_ADDED_AT;
+  const bSentinel = b.addedAt === UNKNOWN_ADDED_AT;
+
+  // Both sentinel — unknown watchlist date, sort stably by title then ID.
+  if (aSentinel && bSentinel) {
+    const titleCmp = a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+    return titleCmp !== 0 ? titleCmp : a.plexItemId.localeCompare(b.plexItemId);
+  }
+  // One sentinel — push it to the end regardless of direction.
+  if (aSentinel) return 1;
+  if (bSentinel) return -1;
+
+  // Use numeric timestamps rather than localeCompare so that minor date-string
+  // format variations (timezone offset vs Z, missing milliseconds, etc.) don't
+  // produce incorrect ordering. Treat unparseable strings as sentinel.
+  const aTime = new Date(a.addedAt).getTime();
+  const bTime = new Date(b.addedAt).getTime();
+  const aInvalid = isNaN(aTime);
+  const bInvalid = isNaN(bTime);
+  if (aInvalid && bInvalid) {
+    const titleCmp = a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+    return titleCmp !== 0 ? titleCmp : a.plexItemId.localeCompare(b.plexItemId);
+  }
+  if (aInvalid) return 1;
+  if (bInvalid) return -1;
+
+  const dateCmp = direction === "watchlist-date-desc"
+    ? bTime - aTime // newest watchlist date first
+    : aTime - bTime; // oldest watchlist date first
+
+  if (dateCmp !== 0) return dateCmp;
+
+  // Tie-break by title then ID for a fully stable result.
+  const titleCmp = a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+  return titleCmp !== 0 ? titleCmp : a.plexItemId.localeCompare(b.plexItemId);
+}
+
 function compareByReleaseDate(
   a: WatchlistItem,
   b: WatchlistItem,
@@ -577,12 +624,24 @@ export class HubarrServices {
     plex = this.getPlexIntegration()
   ) {
     const appSettings = this.db.getAppSettings();
+    // Per-user override takes precedence over the global setting; null means use global.
+    const effectiveSortOrder = friend.collectionSortOrderOverride ?? appSettings.collectionSortOrder ?? "date-desc";
     this.logger.info("Publishing Plex collections for user", {
       userId: friend.id,
       displayName: friend.displayName,
       isSelf: friend.isSelf,
-      totalItems: items.length
+      totalItems: items.length,
+      effectiveSortOrder,
+      sortOrderOverride: friend.collectionSortOrderOverride
     });
+    if (friend.collectionSortOrderOverride) {
+      this.logger.info("Using per-user collection sort order override", {
+        userId: friend.id,
+        displayName: friend.displayName,
+        override: friend.collectionSortOrderOverride,
+        globalDefault: appSettings.collectionSortOrder
+      });
+    }
 
     const effectiveLibraries = this.getEffectiveLibraryIds(friend);
 
@@ -592,14 +651,27 @@ export class HubarrServices {
         continue;
       }
 
-      const sortOrder = appSettings.collectionSortOrder ?? "date-desc";
       const filteredItems = items.filter((item) => item.type === mediaType && item.matchedRatingKey);
-      // Sort locally for both date directions so Hubarr — not Plex — owns the
-      // ordering logic. The sorted ratingKey list is then pushed into Plex via
-      // reorderCollectionItems, with Plex's collectionSort set to custom (2) so
-      // it honours that explicit position rather than re-sorting on its own.
-      if (sortOrder === "date-desc" || sortOrder === "date-asc") {
-        filteredItems.sort((a, b) => compareByReleaseDate(a, b, sortOrder));
+      // Sort locally so Hubarr — not Plex — owns the ordering logic. The sorted
+      // ratingKey list is then pushed into Plex via reorderCollectionItems, with
+      // Plex's collectionSort set to custom (2) so it honours explicit positioning.
+      if (effectiveSortOrder === "date-desc" || effectiveSortOrder === "date-asc") {
+        filteredItems.sort((a, b) => compareByReleaseDate(a, b, effectiveSortOrder));
+      } else if (effectiveSortOrder === "watchlist-date-desc" || effectiveSortOrder === "watchlist-date-asc") {
+        // Warn about items whose watchlist date is unknown before sorting — they
+        // will sort to the end. This usually means the item was added before the
+        // activity cache feature existed and a full re-sync hasn't resolved it.
+        const unknownDateItems = filteredItems.filter((item) => item.addedAt === UNKNOWN_ADDED_AT);
+        if (unknownDateItems.length > 0) {
+          this.logger.warn("Some items have no resolved watchlist date and will sort to the end of the collection", {
+            userId: friend.id,
+            displayName: friend.displayName,
+            mediaType,
+            count: unknownDateItems.length,
+            titles: unknownDateItems.map((item) => item.title)
+          });
+        }
+        filteredItems.sort((a, b) => compareByWatchlistDate(a, b, effectiveSortOrder));
       }
       const matchedRatingKeys = filteredItems.map((item) => item.matchedRatingKey as string);
       const collectionName = friend.collectionName;
@@ -617,13 +689,12 @@ export class HubarrServices {
         collectionRatingKey
       });
       await plex.updateCollectionSortTitle(collectionRatingKey, `!10_${collectionName}`);
-      await plex.updateCollectionContentSort(collectionRatingKey, sortOrder);
+      await plex.updateCollectionContentSort(collectionRatingKey, effectiveSortOrder);
       await plex.syncCollectionItems(collectionRatingKey, matchedRatingKeys);
-      // Explicitly push item positions into Plex for both date-sort modes.
-      // Previously only date-desc (formerly year-desc) called reorder;
-      // date-asc now also uses Hubarr-managed ordering rather than relying on
-      // Plex's native release-date ascending sort, keeping both directions consistent.
-      if (sortOrder === "date-desc" || sortOrder === "date-asc") {
+      // Explicitly push item positions into Plex for all custom-ordered modes.
+      // Title sort uses Plex's native alphabetical sort (collectionSort=1) and
+      // doesn't need explicit reordering; all other modes use collectionSort=2.
+      if (effectiveSortOrder !== "title") {
         await plex.reorderCollectionItems(collectionRatingKey, matchedRatingKeys);
       }
       this.logger.info("Collection items synced", {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -26,18 +26,13 @@ import { RssCache, type RssFeedItem } from "./rss-cache.js";
  * Items with a null releaseDate are placed at the end of the list in both
  * directions. This ensures they do not interfere with properly-dated items.
  */
-/** Sentinel value used for items whose watchlist date is unknown.
- *  Treated as "no date" and sorted to the end regardless of direction,
- *  mirroring how a null releaseDate is handled in compareByReleaseDate. */
-const UNKNOWN_ADDED_AT = "2001-01-01T00:00:00.000Z";
-
 function compareByWatchlistDate(
   a: WatchlistItem,
   b: WatchlistItem,
   direction: Extract<CollectionSortOrder, "watchlist-date-desc" | "watchlist-date-asc">
 ): number {
-  const aSentinel = a.addedAt === UNKNOWN_ADDED_AT;
-  const bSentinel = b.addedAt === UNKNOWN_ADDED_AT;
+  const aSentinel = a.addedAt === WATCHLIST_DATE_UNKNOWN_SENTINEL;
+  const bSentinel = b.addedAt === WATCHLIST_DATE_UNKNOWN_SENTINEL;
 
   // Both sentinel — unknown watchlist date, sort stably by title then ID.
   if (aSentinel && bSentinel) {
@@ -661,7 +656,7 @@ export class HubarrServices {
         // Warn about items whose watchlist date is unknown before sorting — they
         // will sort to the end. This usually means the item was added before the
         // activity cache feature existed and a full re-sync hasn't resolved it.
-        const unknownDateItems = filteredItems.filter((item) => item.addedAt === UNKNOWN_ADDED_AT);
+        const unknownDateItems = filteredItems.filter((item) => item.addedAt === WATCHLIST_DATE_UNKNOWN_SENTINEL);
         if (unknownDateItems.length > 0) {
           this.logger.warn("Some items have no resolved watchlist date and will sort to the end of the collection", {
             userId: friend.id,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -49,7 +49,7 @@ export interface VisibilityConfig {
   shared: boolean;
 }
 
-export type CollectionSortOrder = "date-desc" | "date-asc" | "title";
+export type CollectionSortOrder = "date-desc" | "date-asc" | "title" | "watchlist-date-desc" | "watchlist-date-asc";
 
 export type WatchlistSortBy = "added-desc" | "added-asc" | "title-asc" | "title-desc" | "year-desc" | "year-asc";
 
@@ -84,6 +84,8 @@ export interface UserRecord {
   visibilityOverride: VisibilityConfig | null;
   collectionNameOverride: string | null;
   collectionName: string;
+  /** Per-user collection sort order. null means fall back to the global collectionSortOrder setting. */
+  collectionSortOrderOverride: CollectionSortOrder | null;
   lastSyncedAt: string | null;
   lastSyncError: string | null;
 }

--- a/tests/playwright/settings.spec.ts
+++ b/tests/playwright/settings.spec.ts
@@ -51,4 +51,14 @@ test.describe("Settings tabs", () => {
     await expect(page.getByText("About Hubarr")).toBeVisible();
     await expect(page.getByText("Version")).toBeVisible();
   });
+
+  test("Collections tab shows watchlisted date sort options in the ordering dropdown", async ({ page }) => {
+    await page.goto("/settings?tab=collections");
+    await expect(page.getByText("Loading settings...")).not.toBeVisible({ timeout: 10_000 });
+
+    const select = page.getByRole("combobox").first();
+    await expect(select).toBeVisible();
+    await expect(select.locator("option[value='watchlist-date-desc']")).toHaveText("Watchlisted Date (New to Old)");
+    await expect(select.locator("option[value='watchlist-date-asc']")).toHaveText("Watchlisted Date (Old to New)");
+  });
 });

--- a/tests/playwright/users.spec.ts
+++ b/tests/playwright/users.spec.ts
@@ -26,4 +26,26 @@ test.describe("Users page structure", () => {
   test("Refresh Users button is present", async ({ page }) => {
     await expect(page.getByRole("button", { name: /refresh users/i })).toBeVisible();
   });
+
+  test("Edit modal shows collection ordering override section", async ({ page }) => {
+    // Open the first user's edit modal via the "Edit user" button
+    const editButton = page.getByTitle("Edit user").first();
+    await expect(editButton).toBeVisible();
+    await editButton.click();
+
+    // The modal should appear
+    await expect(page.getByRole("heading", { name: /^Edit / })).toBeVisible();
+
+    // The Collection Ordering section header should be present
+    await expect(page.getByText("Collection Ordering")).toBeVisible();
+
+    // The ordering dropdown should include watchlist date options
+    const select = page.getByRole("combobox", { name: "" }).last();
+    await expect(select.locator("option[value='watchlist-date-desc']")).toHaveText("Watchlisted Date (New to Old)");
+    await expect(select.locator("option[value='watchlist-date-asc']")).toHaveText("Watchlisted Date (Old to New)");
+
+    // "Restore to global default" button should not appear when no override is set
+    // (the modal opens with user's current state; just verify the section renders correctly)
+    await expect(page.getByRole("button", { name: "Cancel" })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds two new collection sort modes — **Watchlisted Date (New to Old)** and **Watchlisted Date (Old to New)** — sorting each user's Plex collection by when they added items to their watchlist, using the `addedAt` timestamp already tracked by the activity cache
- Adds a **per-user collection ordering override** (`collection_sort_order_override` column, DB migration v6); null means inherit the global setting, matching the existing pattern for `visibilityOverride`
- Items with no resolved watchlist date (added before the activity cache existed) sort to the end and emit a `warn` log listing their titles so the cause is visible

## Changes

- `src/shared/types.ts` — extended `CollectionSortOrder`, added `collectionSortOrderOverride` to `UserRecord`
- `src/server/db/migrations.ts` — migration v6 adds `collection_sort_order_override TEXT` to `users`
- `src/server/db/users.ts` — `listUsers()` and `updateUser()` updated for the new column
- `src/server/app.ts` — whitelist updated in `PATCH /api/settings`; validation added in `PATCH /api/users/:id`
- `src/server/services.ts` — new `compareByWatchlistDate()` using `Date.getTime()` for format-robust comparison; `publishUserCollections()` resolves effective sort order from per-user override and logs when active
- `src/server/integrations/plex.ts` — `plexSort` map extended for both new values (→ `collectionSort=2`)
- `src/client/components/CollectionsConfigForm.tsx` — two new options in the global ordering dropdown
- `src/client/pages/Users.tsx` — sort override section in the user edit modal; hint shows human-readable label for the global default
- `tests/playwright/settings.spec.ts` / `users.spec.ts` — structural smoke tests for the new UI elements
- `TESTING.md` — test table updated

## Test plan

- [ ] Settings → Collections tab: verify "Watchlisted Date (New to Old)" and "Watchlisted Date (Old to New)" appear in the ordering dropdown
- [ ] Users page → edit a user: verify "Collection Ordering" section appears with dropdown and "Restore to global default" reset; hint shows the global sort label in plain English (e.g. "Release Date (New to Old)")
- [ ] Set global sort to a watchlist date mode and trigger a collection publish; verify Plex ordering reflects each user's `addedAt`
- [ ] Set a per-user override and verify that user's collection uses the override while others use the global setting
- [ ] Items with no watchlist date appear at the end and a `warn` log entry lists them by title
- [ ] Run `npm run test:e2e` against a live instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)