### PR TITLE
docs: finish technical docs strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,13 @@ When implementing new functionality, the agent should treat logging and code cla
 - Keep comments clear and purposeful; do not add comments that only restate what the code already says
 - When a future maintainer might reasonably ask "why is this written this way?", prefer a short comment that answers that question at the point of implementation
 
+#### Technical docs
+
+- Treat technical documentation as part of the implementation for major or long-lived changes, not optional follow-up work
+- If a change affects architecture, sync flow, persistence, external integrations, or runtime behavior in a lasting way, update the relevant file under `docs/` in the same branch/PR
+- Start from `docs/README.md` when deciding where documentation belongs
+- If no existing technical doc fits the change cleanly, add a new topic doc under `docs/` and link it from `docs/README.md`
+
 ---
 
 ### End-to-End Tests — Playwright

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,15 @@ The app is designed to run with persistent data stored under `/config` in contai
 
 See [TESTING.md](TESTING.md) for the full guide — setup, authentication, commands, and a breakdown of every test.
 
+## Technical Docs
+
+See [docs/README.md](docs/README.md) for the technical reference area.
+
+If you are changing architecture, sync behavior, persistence, integrations, or
+other long-lived internal behavior, update the relevant `docs/*.md` page in the
+same branch/PR. If no existing page fits, add a new topic doc and link it from
+`docs/README.md`.
+
 ## Coding Notes
 
 - Keep changes scoped to the task at hand

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Technical Docs
+
+This folder is Hubarr's long-term technical reference area.
+
+Use these docs for implementation details, subsystem behavior, and architecture
+notes that should stay useful after the branch or issue that introduced them is
+long gone.
+
+## What's Here
+
+- [architecture.md](architecture.md) — high-level system shape, core
+  invariants, deployment model, and the main subsystems that make Hubarr work
+- [sync.md](sync.md) — background jobs, startup sequencing, terminology, sync
+  orchestration, and how history/jobs/logs fit together
+- [watchlist.md](watchlist.md) — deep reference for watchlist ingestion,
+  GraphQL/RSS/activity-cache behavior, date resolution, and sync flows
+- [image-caching.md](image-caching.md) — poster/avatar caching design, stale
+  refresh behavior, storage model, and cache lifecycle details
+
+## When To Read Which Doc
+
+- Start with [architecture.md](architecture.md) if you need the big-picture
+  mental model before touching the code.
+- Read [sync.md](sync.md) when changing scheduled jobs, startup behavior, or
+  how work moves through the system.
+- Read [watchlist.md](watchlist.md) when changing watchlist fetching, matching,
+  `addedAt` handling, or collection publish triggers.
+- Read [image-caching.md](image-caching.md) when changing poster/avatar fetch,
+  storage, refresh, or serving behavior.
+
+## Maintenance Rule
+
+When a major feature or long-lived internal behavior changes, update the
+relevant doc in this folder in the same branch/PR. If no existing doc fits, add
+a new topic doc here and link it from this index.


### PR DESCRIPTION
## Summary

- add a dedicated `docs/README.md` landing page for Hubarr's technical reference docs
- point contributors at the technical docs area from `CONTRIBUTING.md`
- add `AGENTS.md` guidance so major long-lived internal changes update `docs/` in the same branch/PR

## Why

PR #57 completed the migration away from `plans/`, but issue #52 still had follow-through work around discoverability and maintenance expectations for the technical docs area.

## Verify

- confirm `docs/README.md` links to the current technical docs set
- confirm contributor-facing guidance points major internal changes toward `docs/`

Closes #52

Created by Codex
