### PR TITLE
fix: align dashboard sync labels with history 🤖 Generated with Codex

### DIFF
--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -192,10 +192,10 @@ function StatChip({
 }
 
 const KIND_LABELS: Record<string, string> = {
-  full: "Full",
+  full: "GraphQL",
   rss: "RSS",
   user: "Manual",
-  publish: "Publish"
+  publish: "Collection"
 };
 
 function formatCompactSummary(run: SyncRun): string {


### PR DESCRIPTION
## Summary
- align dashboard sync labels with the shorter naming used alongside History
- rename full to GraphQL and publish to Collection on the dashboard

## Verification
- npm run check
- npm run build

🤖 Generated with Codex