### PR TITLE
feat: add trust proxy setting to resolve X-Forwarded-For warning

### DIFF
--- a/src/client/components/FormControls.tsx
+++ b/src/client/components/FormControls.tsx
@@ -92,12 +92,14 @@ export function ToggleField({
   label,
   hint,
   checked,
-  onChange
+  onChange,
+  restartRequired = false
 }: {
   label: string;
   hint?: string;
   checked: boolean;
   onChange: (value: boolean) => void;
+  restartRequired?: boolean;
 }) {
   return (
     <label className="flex items-start gap-3 cursor-pointer">
@@ -120,7 +122,14 @@ export function ToggleField({
         />
       </div>
       <div>
-        <div className="text-sm font-medium text-on-surface">{label}</div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-on-surface">{label}</span>
+          {restartRequired && (
+            <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-warning/15 text-warning">
+              Restart Required
+            </span>
+          )}
+        </div>
         {hint && <div className="text-xs text-on-surface-variant mt-0.5">{hint}</div>}
       </div>
     </label>

--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -142,7 +142,7 @@ function GeneralTab({
     setError(null);
     setSuccess(false);
     try {
-      await apiPatch("/api/settings", { general: form });
+      await apiPatch("/api/settings", { general: { fullSyncOnStartup: form.fullSyncOnStartup, historyRetentionDays: form.historyRetentionDays, trustProxy: form.trustProxy } });
       setSuccess(true);
       await onSave();
     } catch (caught) {
@@ -208,7 +208,17 @@ function GeneralTab({
 
   return (
     <div className="space-y-6">
-      <SectionCard title="General Settings">
+      <SectionCard
+        title="General Settings"
+        description="Changes to proxy support require a container restart to take effect."
+      >
+        <ToggleField
+          label="Trust Proxy"
+          hint="Enable when Hubarr is running behind a reverse proxy (e.g. Nginx, Traefik, Caddy) so that rate limiting uses the real client IP from X-Forwarded-For headers."
+          checked={form.trustProxy}
+          onChange={(value) => setForm((current) => ({ ...current, trustProxy: value }))}
+          restartRequired
+        />
         <ToggleField
           label="Startup Sync"
           hint="When Hubarr starts, run a Plex full library scan, then a watchlist GraphQL sync, then a collection sync."

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -52,6 +52,15 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   const imageCache = new ImageCacheService(config.dataDir, db, logger);
   const services = new HubarrServices(db, logger, imageCache);
   const app = express();
+
+  // Enable trust proxy if configured — required for express-rate-limit to
+  // correctly identify clients by their real IP when Hubarr runs behind a
+  // reverse proxy that injects X-Forwarded-For headers.
+  if (db.getAppSettings().trustProxy) {
+    app.set("trust proxy", true);
+    logger.info("Trust proxy enabled — using X-Forwarded-For for client IP identification");
+  }
+
   app.use(helmet({
     contentSecurityPolicy: {
       directives: {
@@ -543,7 +552,8 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     const payload: SettingsResponse = {
       general: {
         fullSyncOnStartup: app.fullSyncOnStartup,
-        historyRetentionDays: app.historyRetentionDays
+        historyRetentionDays: app.historyRetentionDays,
+        trustProxy: app.trustProxy
       },
       sync: {
         reconciliationIntervalMinutes: app.reconciliationIntervalMinutes,
@@ -564,7 +574,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   app.patch("/api/settings", requireAuth, (req, res) => {
     const body = req.body as {
-      general?: { fullSyncOnStartup?: boolean; historyRetentionDays?: number };
+      general?: { fullSyncOnStartup?: boolean; historyRetentionDays?: number; trustProxy?: boolean };
       collections?: {
         collectionNamePattern?: string;
         collectionSortOrder?: string;
@@ -587,6 +597,9 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       }
       if (body.general.historyRetentionDays !== undefined) {
         patch.historyRetentionDays = Math.max(1, Math.floor(body.general.historyRetentionDays));
+      }
+      if (typeof body.general.trustProxy === "boolean") {
+        patch.trustProxy = body.general.trustProxy;
       }
     }
 

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -29,7 +29,8 @@ export const defaultAppSettings: AppSettings = {
   },
   fullSyncOnStartup: false,
   defaultMovieLibraryId: null,
-  defaultShowLibraryId: null
+  defaultShowLibraryId: null,
+  trustProxy: false
 };
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -68,6 +68,7 @@ export interface AppSettings {
   fullSyncOnStartup: boolean;
   defaultMovieLibraryId: string | null;
   defaultShowLibraryId: string | null;
+  trustProxy: boolean;
 }
 
 export interface UserRecord {
@@ -341,6 +342,7 @@ export interface SettingsResponse {
   general: {
     fullSyncOnStartup: boolean;
     historyRetentionDays: number;
+    trustProxy: boolean;
   };
   sync: {
     reconciliationIntervalMinutes: number;


### PR DESCRIPTION
## Summary

Adds a **Trust Proxy** toggle to General Settings that resolves the `express-rate-limit` `ValidationError` logged when Hubarr runs behind a reverse proxy. When enabled, Hubarr calls `app.set("trust proxy", true)` at startup so that rate limiting correctly identifies clients by their real IP from `X-Forwarded-For` headers rather than the proxy's IP. The setting defaults to off (no behaviour change for existing installs) and an amber **Restart Required** badge is shown in the UI since the setting is read once at process start.

The approach mirrors how Jellyseerr handles the same problem — a user-opt-in toggle rather than silently trusting all proxies, which would be a security concern in direct-access deployments.

## Changes

- **`src/shared/types.ts`** — added `trustProxy: boolean` to `AppSettings` and `SettingsResponse.general`
- **`src/server/db/settings.ts`** — added `trustProxy: false` to `defaultAppSettings` (safe default, no change for existing installs)
- **`src/server/app.ts`** — reads `trustProxy` from settings at startup and calls `app.set("trust proxy", true)` with an info log line if enabled; exposes the field via `GET /api/settings` and accepts it in `PATCH /api/settings`
- **`src/client/components/FormControls.tsx`** — added `restartRequired?: boolean` prop to `ToggleField`; renders an amber "Restart Required" badge inline next to the label when set
- **`src/client/pages/Settings.tsx`** — added Trust Proxy toggle at the top of General Settings with `restartRequired` badge and a one-sentence section description; wired into save/load

## Test plan

- [x] Open Settings → General — confirm "Trust Proxy" toggle appears at the top with the amber "Restart Required" badge and the hint text
- [x] Enable Trust Proxy and save — confirm "Saved" feedback appears with no errors
- [x] Restart the container — confirm the log shows `Trust proxy enabled — using X-Forwarded-For for client IP identification`
- [x] Disable Trust Proxy, save, restart — confirm the log line is absent and no `express-rate-limit` ValidationError appears
- [x] Confirm existing settings (Startup Sync, History Retention) are unaffected

Closes #53

🤖 Generated with Claude Code