### PR TITLE
fix: move session secret from file to database

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -49,6 +49,7 @@ function signedValue(secret: string, value: string) {
 export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   const logger = new Logger(config.dataDir);
   const db = new HubarrDatabase(config);
+  const sessionSecret = db.getSessionSecret();
   const imageCache = new ImageCacheService(config.dataDir, db, logger);
   const services = new HubarrServices(db, logger, imageCache);
   const app = express();
@@ -93,7 +94,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       return next();
     }
     const [sessionId, signature] = raw.split(".");
-    if (!sessionId || !signature || signedValue(config.sessionSecret, sessionId) !== signature) {
+    if (!sessionId || !signature || signedValue(sessionSecret, sessionId) !== signature) {
       req.sessionUser = null;
       return next();
     }
@@ -110,7 +111,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   }
 
   function setSessionCookie(res: Response, sessionId: string) {
-    const signed = `${sessionId}.${signedValue(config.sessionSecret, sessionId)}`;
+    const signed = `${sessionId}.${signedValue(sessionSecret, sessionId)}`;
     res.setHeader(
       "Set-Cookie",
       `${config.sessionCookieName}=${encodeURIComponent(signed)}; HttpOnly; Path=/; SameSite=Strict; Max-Age=${Math.floor(config.sessionTtlMs / 1000)}`

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,38 +1,12 @@
-import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
 export interface RuntimeConfig {
   port: number;
   dataDir: string;
-  sessionSecret: string;
   sessionCookieName: string;
   sessionTtlMs: number;
   logLevel: "debug" | "info" | "warn" | "error";
-}
-
-function resolveSessionSecret(dataDir: string): string {
-  if (process.env.SESSION_SECRET) {
-    return process.env.SESSION_SECRET;
-  }
-  const secretFile = path.join(dataDir, ".session_secret");
-  const generated = crypto.randomBytes(48).toString("hex");
-
-  try {
-    const handle = fs.openSync(secretFile, "wx", 0o600);
-    try {
-      fs.writeFileSync(handle, generated, "utf8");
-    } finally {
-      fs.closeSync(handle);
-    }
-    return generated;
-  } catch (error) {
-    const nodeError = error as NodeJS.ErrnoException;
-    if (nodeError.code !== "EEXIST") {
-      throw error;
-    }
-    return fs.readFileSync(secretFile, "utf8").trim();
-  }
 }
 
 export function loadRuntimeConfig(): RuntimeConfig {
@@ -45,7 +19,6 @@ export function loadRuntimeConfig(): RuntimeConfig {
   return {
     port: Number(process.env.PORT || 9301),
     dataDir,
-    sessionSecret: resolveSessionSecret(dataDir),
     sessionCookieName: "hubarr_session",
     sessionTtlMs: 1000 * 60 * 60 * 24 * 14,
     logLevel:

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -29,6 +29,7 @@ import * as watchlistRepo from "./watchlist.js";
 
 export class HubarrDatabase {
   private readonly db: Database.Database;
+  private readonly sessionSecret: string;
 
   constructor(config: RuntimeConfig) {
     this.db = new Database(path.join(config.dataDir, "hubarr.db"));
@@ -36,6 +37,11 @@ export class HubarrDatabase {
     this.db.pragma("foreign_keys = ON");
     runMigrations(this.db);
     settingsRepo.seedDefaultSettings(this.db);
+    this.sessionSecret = settingsRepo.resolveSessionSecret(this.db, config.dataDir);
+  }
+
+  getSessionSecret(): string {
+    return this.sessionSecret;
   }
 
   // -------------------------------------------------------------------------

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -1,3 +1,6 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import type Database from "better-sqlite3";
 import type {
   AppSettings,
@@ -9,7 +12,7 @@ import type {
   SessionUser
 } from "../../shared/types.js";
 
-export type SettingKey = "admin" | "plex" | "app";
+export type SettingKey = "admin" | "plex" | "app" | "session_secret";
 
 export const defaultAppSettings: AppSettings = {
   reconciliationIntervalMinutes: 60,
@@ -64,6 +67,35 @@ export function seedDefaultSettings(db: Database.Database): void {
   if (!getSetting<AppSettings>(db, "app")) {
     setSetting(db, "app", defaultAppSettings);
   }
+}
+
+/**
+ * Resolve the session signing secret from the database.
+ *
+ * On the first run after migrating from the file-based approach, any existing
+ * .session_secret file is read into the database and then deleted so that
+ * existing sessions remain valid. If no secret exists anywhere a new one is
+ * generated and persisted.
+ */
+export function resolveSessionSecret(db: Database.Database, dataDir: string): string {
+  const stored = getSetting<string>(db, "session_secret");
+  if (stored) {
+    return stored;
+  }
+
+  // One-time migration: pull the value out of the legacy file if it exists.
+  const legacyFile = path.join(dataDir, ".session_secret");
+  let secret: string;
+  try {
+    secret = fs.readFileSync(legacyFile, "utf8").trim();
+    fs.unlinkSync(legacyFile);
+  } catch {
+    // File didn't exist — generate a fresh secret.
+    secret = crypto.randomBytes(48).toString("hex");
+  }
+
+  setSetting(db, "session_secret", secret);
+  return secret;
 }
 
 // -------------------------------------------------------------------------

--- a/tests/server/test-db.ts
+++ b/tests/server/test-db.ts
@@ -9,7 +9,6 @@ export function createTestDatabase(): { db: HubarrDatabase; cleanup: () => void 
   const config: RuntimeConfig = {
     port: 9301,
     dataDir,
-    sessionSecret: "test-session-secret",
     sessionCookieName: "hubarr_session",
     sessionTtlMs: 1000 * 60 * 60,
     logLevel: "error"


### PR DESCRIPTION
## Summary

Moves the session signing secret out of a standalone `.session_secret` file in the config directory and into the existing `settings` table in the SQLite database. The file-on-disk approach was flagged in #49 as feeling unusual compared to how similar self-hosted apps manage this kind of internal secret. Keeping everything in one database file is cleaner, easier to reason about for backups, and removes a loose file that users might notice or be unsure about.

The `SESSION_SECRET` environment variable override has been removed as part of this change — the database is now the single source of truth and there is no longer a mechanism to externally override the secret.

## Changes

- **`src/server/config.ts`** — removed `sessionSecret` field from `RuntimeConfig` and deleted the `resolveSessionSecret` file-based implementation entirely.
- **`src/server/db/settings.ts`** — added `"session_secret"` to `SettingKey`, added `resolveSessionSecret(db, dataDir)` which handles the one-time migration from file to DB and generates a new secret when neither exists.
- **`src/server/db/index.ts`** — calls `resolveSessionSecret` during construction and exposes `getSessionSecret()` so the app layer can access it.
- **`src/server/app.ts`** — replaces `config.sessionSecret` references with `db.getSessionSecret()` called once after `HubarrDatabase` is constructed.
- **`tests/server/test-db.ts`** — removed the now-nonexistent `sessionSecret` field from the test `RuntimeConfig` fixture.

## Test plan

- [ ] Fresh install: start the app with no existing database or config files. Confirm `hubarr.db` is created, no `.session_secret` file appears in `/config`, and the app is fully functional (login works, session persists across page reloads).
- [ ] Upgrade from existing install: place a `.session_secret` file in the data directory before starting. Confirm on first boot the file is deleted and the secret value has been migrated into the database (check via `sqlite3 hubarr.db "SELECT value FROM settings WHERE key='session_secret'"`). Confirm existing sessions remain valid (no forced re-login).
- [ ] Confirm setting `SESSION_SECRET` as an environment variable has no effect (it is no longer read).

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)