### PR TITLE
feat: improve version display for develop and branch builds

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -60,5 +60,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_CHANNEL=develop
+            COMMIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,5 +58,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_CHANNEL=stable
+            COMMIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV NODE_ENV=production
 ENV PORT=9301
 ENV DATA_DIR=/config
 # Build metadata — overridden by CI workflows via --build-arg
-ARG BUILD_CHANNEL=local
+ARG BUILD_CHANNEL=custom
 ARG COMMIT_SHA=local
 ENV BUILD_CHANNEL=$BUILD_CHANNEL
 ENV COMMIT_SHA=$COMMIT_SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=9301
 ENV DATA_DIR=/config
+# Build metadata — overridden by CI workflows via --build-arg
+ARG BUILD_CHANNEL=local
+ARG COMMIT_SHA=local
+ENV BUILD_CHANNEL=$BUILD_CHANNEL
+ENV COMMIT_SHA=$COMMIT_SHA
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -7,7 +7,9 @@ import {
   History,
   Settings,
   LogOut,
-  Server
+  Server,
+  Beaker,
+  Code2
 } from "lucide-react";
 import { apiGet } from "../lib/api";
 import { getPlexImageSrc } from "../lib/plexImage";
@@ -132,14 +134,41 @@ export default function Sidebar({ user, onLogout, mobileOpen, onMobileClose }: S
   );
 }
 
+const CHANNEL_CONFIG = {
+  stable: {
+    label: "Hubarr Stable",
+    Icon: Server,
+  },
+  develop: {
+    label: "Hubarr Develop",
+    Icon: Beaker,
+  },
+  local: {
+    label: "Local Build",
+    Icon: Code2,
+  },
+} as const;
+
 function VersionFooter({ onMobileClose }: { onMobileClose: () => void }) {
-  const [version, setVersion] = useState<string | null>(null);
+  const [info, setInfo] = useState<AboutInfo | null>(null);
 
   useEffect(() => {
     apiGet<AboutInfo>("/api/settings/about")
-      .then((info) => setVersion(info.version))
+      .then((data) => setInfo(data))
       .catch(() => null);
   }, []);
+
+  const channel = info?.buildChannel ?? "stable";
+  const { label, Icon } = CHANNEL_CONFIG[channel];
+
+  // Show the commit SHA for develop/local builds, version number for stable
+  const subLabel = !info
+    ? "..."
+    : channel === "stable"
+      ? `v${info.version}`
+      : info.commitSha === "local"
+        ? "local"
+        : info.commitSha;
 
   return (
     <div className="px-3 pb-3">
@@ -149,13 +178,11 @@ function VersionFooter({ onMobileClose }: { onMobileClose: () => void }) {
         className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-surface-container-high transition-colors group"
       >
         <div className="w-8 h-8 rounded-lg bg-surface-container-highest flex items-center justify-center flex-shrink-0">
-          <Server size={16} strokeWidth={1.75} className="text-on-surface-variant group-hover:text-on-surface transition-colors" />
+          <Icon size={16} strokeWidth={1.75} className="text-on-surface-variant group-hover:text-on-surface transition-colors" />
         </div>
         <div className="flex-1 min-w-0">
-          <div className="text-xs font-semibold text-on-surface leading-tight">Hubarr Stable</div>
-          <div className="text-xs text-on-surface-variant leading-tight mt-0.5">
-            {version ? `v${version}` : "..."}
-          </div>
+          <div className="text-xs font-semibold text-on-surface leading-tight">{label}</div>
+          <div className="text-xs text-on-surface-variant leading-tight mt-0.5 font-mono">{subLabel}</div>
         </div>
       </Link>
     </div>

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -143,8 +143,8 @@ const CHANNEL_CONFIG = {
     label: "Hubarr Develop",
     Icon: Beaker,
   },
-  local: {
-    label: "Local Build",
+  custom: {
+    label: "Custom Build",
     Icon: Code2,
   },
 } as const;
@@ -158,17 +158,31 @@ function VersionFooter({ onMobileClose }: { onMobileClose: () => void }) {
       .catch(() => null);
   }, []);
 
-  const channel = info?.buildChannel ?? "stable";
-  const { label, Icon } = CHANNEL_CONFIG[channel];
+  // Don't render a channel label until the API has responded — any guess
+  // before that point could misrepresent the build (e.g. showing "Stable"
+  // for a develop image during the load window).
+  if (!info) {
+    return (
+      <div className="px-3 pb-3">
+        <div className="flex items-center gap-3 px-3 py-2.5 rounded-lg">
+          <div className="w-8 h-8 rounded-lg bg-surface-container-highest flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-xs font-semibold text-on-surface-variant leading-tight">Hubarr</div>
+            <div className="text-xs text-on-surface-variant leading-tight mt-0.5">...</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
-  // Show the commit SHA for develop/local builds, version number for stable
-  const subLabel = !info
-    ? "..."
-    : channel === "stable"
-      ? `v${info.version}`
-      : info.commitSha === "local"
-        ? "local"
-        : info.commitSha;
+  const { label, Icon } = CHANNEL_CONFIG[info.buildChannel];
+
+  // Show the commit SHA for develop/custom builds, version number for stable
+  const subLabel = info.buildChannel === "stable"
+    ? `v${info.version}`
+    : info.commitSha === "local"
+      ? "local"
+      : info.commitSha;
 
   return (
     <div className="px-3 pb-3">

--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -856,6 +856,14 @@ function AboutTab() {
             {info?.version ?? "..."}
           </a>
         </InfoRow>
+        <InfoRow label="Build Channel">
+          <span className="text-sm text-on-surface capitalize">{info?.buildChannel ?? "..."}</span>
+        </InfoRow>
+        {info?.buildChannel !== "stable" && (
+          <InfoRow label="Commit">
+            <code className="text-sm text-on-surface bg-surface-container-high px-2 py-0.5 rounded font-mono">{info?.commitSha ?? "..."}</code>
+          </InfoRow>
+        )}
         <InfoRow label="Data Directory">
           <code className="text-sm text-on-surface bg-surface-container-high px-2 py-0.5 rounded">{info?.dataDir ?? "..."}</code>
         </InfoRow>

--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -927,7 +927,7 @@ function AboutTab() {
               {index === 0 && (
                 <span className="flex-shrink-0 text-xs font-medium text-success bg-success/10 px-2 py-0.5 rounded-full border border-success/20">Latest</span>
               )}
-              {info?.version && (release.name === info.version || release.tag_name === `v${info.version}` || release.tag_name === info.version) && (
+              {info?.buildChannel === "stable" && info?.version && (release.name === info.version || release.tag_name === `v${info.version}` || release.tag_name === info.version) && (
                 <span className="flex-shrink-0 text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded-full border border-primary/20">Current</span>
               )}
               <span className="flex-shrink-0 text-xs text-on-surface-variant">

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -21,7 +21,7 @@ import { JobScheduler } from "./job-scheduler.js";
 import { Logger } from "./logger.js";
 import { ImageCacheService } from "./image-cache.js";
 import { HubarrServices } from "./services.js";
-import { APP_VERSION } from "./version.js";
+import { APP_VERSION, BUILD_CHANNEL, BUILD_COMMIT } from "./version.js";
 
 declare module "express-serve-static-core" {
   interface Request {
@@ -980,6 +980,8 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   app.get("/api/settings/about", requireAuth, (_req, res) => {
     res.json({
       version: APP_VERSION,
+      buildChannel: BUILD_CHANNEL,
+      commitSha: BUILD_COMMIT,
       nodeVersion: process.version,
       platform: process.platform,
       dataDir: config.dataDir,

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -20,8 +20,8 @@ export const APP_VERSION = readPackageVersion();
 export const PLEX_USER_AGENT = `Hubarr/${APP_VERSION}`;
 
 // BUILD_CHANNEL is baked into the Docker image at CI build time via --build-arg.
-// Values: "stable" (release workflow), "develop" (develop workflow), "local" (no arg passed, e.g. dev environment).
-export const BUILD_CHANNEL = (process.env.BUILD_CHANNEL ?? "local") as "stable" | "develop" | "local";
+// Values: "stable" (release workflow), "develop" (develop workflow), "custom" (no arg passed — any non-CI build).
+export const BUILD_CHANNEL = (process.env.BUILD_CHANNEL ?? "custom") as "stable" | "develop" | "custom";
 
 // Full commit SHA baked in at build time. "local" when running outside CI.
 const rawCommitSha = process.env.COMMIT_SHA ?? "local";

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -18,3 +18,12 @@ function readPackageVersion() {
 
 export const APP_VERSION = readPackageVersion();
 export const PLEX_USER_AGENT = `Hubarr/${APP_VERSION}`;
+
+// BUILD_CHANNEL is baked into the Docker image at CI build time via --build-arg.
+// Values: "stable" (release workflow), "develop" (develop workflow), "local" (no arg passed, e.g. dev environment).
+export const BUILD_CHANNEL = (process.env.BUILD_CHANNEL ?? "local") as "stable" | "develop" | "local";
+
+// Full commit SHA baked in at build time. "local" when running outside CI.
+const rawCommitSha = process.env.COMMIT_SHA ?? "local";
+// Shorten to 7 chars for display, unless it's already "local".
+export const BUILD_COMMIT = rawCommitSha === "local" ? "local" : rawCommitSha.slice(0, 7);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -331,6 +331,8 @@ export interface JobInfo {
 
 export interface AboutInfo {
   version: string;
+  buildChannel: "stable" | "develop" | "local";
+  commitSha: string;
   nodeVersion: string;
   platform: string;
   dataDir: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -331,7 +331,7 @@ export interface JobInfo {
 
 export interface AboutInfo {
   version: string;
-  buildChannel: "stable" | "develop" | "local";
+  buildChannel: "stable" | "develop" | "custom";
   commitSha: string;
   nodeVersion: string;
   platform: string;


### PR DESCRIPTION
## Summary

Closes #48

Hubarr previously had no way to distinguish whether a running instance was built from `main`, `develop`, or a local dev environment — the sidebar and About page always showed `v1.0.2 / Hubarr Stable` regardless. This PR bakes build channel metadata into the Docker image at CI time and surfaces it throughout the UI.

## Changes

**CI / Docker (`Dockerfile`, `develop.yml`, `release.yml`)**
- Added `ARG BUILD_CHANNEL` and `ARG COMMIT_SHA` to the Dockerfile runtime stage, exposed as `ENV` vars (defaulting to `local` when no arg is passed)
- `develop.yml` now passes `BUILD_CHANNEL=develop` and the full commit SHA as Docker build args
- `release.yml` now passes `BUILD_CHANNEL=stable` and the full commit SHA

**Server (`src/server/version.ts`, `src/server/app.ts`)**
- `version.ts` exports `BUILD_CHANNEL` (`"stable" | "develop" | "local"`) and `BUILD_COMMIT` (7-char short SHA, or `"local"`) read from the baked-in env vars
- `/api/settings/about` now includes `buildChannel` and `commitSha` in its response

**Shared types (`src/shared/types.ts`)**
- `AboutInfo` extended with `buildChannel: "stable" | "develop" | "local"` and `commitSha: string`

**Frontend (`src/client/components/Sidebar.tsx`, `src/client/pages/Settings.tsx`)**
- Sidebar `VersionFooter` now dynamically shows:
  - **"Hubarr Stable"** + Server icon, `v1.0.x` sub-label (release builds)
  - **"Hubarr Develop"** + Beaker icon, short commit SHA sub-label (develop builds)
  - **"Local Build"** + Code2 icon, `local` sub-label (no build args, e.g. dev environment)
- Settings → About tab now shows a **Build Channel** row, and a **Commit** row (visible only on non-stable builds)

## Test plan

- [ ] Build the image locally without `--build-arg` — sidebar shows **Local Build** with Code2 icon, About tab shows channel: `local`, no Commit row
- [ ] Build with `--build-arg BUILD_CHANNEL=develop --build-arg COMMIT_SHA=abc1234567` — sidebar shows **Hubarr Develop** with Beaker icon and short SHA `abc1234`, About tab shows channel: `develop` and commit row
- [ ] Build with `--build-arg BUILD_CHANNEL=stable --build-arg COMMIT_SHA=abc1234567` — sidebar shows **Hubarr Stable** with Server icon and `v1.0.x`, About tab shows channel: `stable` with no Commit row
- [ ] Confirm the `develop` GitHub Actions workflow triggers correctly on push to `develop` and the image is tagged with the new build args
- [ ] Confirm the `release` workflow passes `stable` correctly on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)