### PR TITLE
fix: normalise Plex identifier formats across watchlist and activity cache

### DIFF
--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -211,6 +211,92 @@ const migrations: Migration[] = [
         ALTER TABLE users ADD COLUMN collection_sort_order_override TEXT;
       `);
     }
+  },
+  {
+    version: 7,
+    up(db) {
+      // Add a dedicated discover_key column to watchlist_cache so the
+      // /library/metadata/<hex> form of each item's ID is queryable without
+      // JSON-parsing raw_payload. Populated from raw_payload on migration.
+      db.exec(`
+        ALTER TABLE watchlist_cache ADD COLUMN discover_key TEXT;
+
+        UPDATE watchlist_cache
+        SET discover_key = json_extract(raw_payload, '$.discoverKey')
+        WHERE discover_key IS NULL;
+      `);
+
+      // Normalise RSS item plex_item_ids that were stored as stableKeys
+      // (e.g. "<userUUID>::imdb://...|tmdb://...") to the canonical plex://
+      // GUID format used by all GraphQL items. The plex:// GUID is already
+      // present in the raw_payload guids array after enrichment.
+      //
+      // If a row with the target plex:// ID already exists for the same user
+      // (i.e. the item was also cached via GraphQL), the stale RSS row is
+      // deleted to eliminate the duplicate. Otherwise the plex_item_id and
+      // discover_key are updated in place.
+      //
+      // image_cache poster entries keyed on the old stableKey are updated or
+      // removed to match.
+      const rssRows = db.prepare(`
+        SELECT id, user_id, plex_item_id, raw_payload
+        FROM watchlist_cache
+        WHERE plex_item_id NOT LIKE 'plex://%'
+          AND source = 'rss'
+      `).all() as Array<{ id: number; user_id: number; plex_item_id: string; raw_payload: string }>;
+
+      const findExisting = db.prepare(
+        "SELECT id FROM watchlist_cache WHERE user_id = ? AND plex_item_id = ?"
+      );
+      const updateRow = db.prepare(
+        "UPDATE watchlist_cache SET plex_item_id = ?, discover_key = ? WHERE id = ?"
+      );
+      const deleteRow = db.prepare("DELETE FROM watchlist_cache WHERE id = ?");
+      const updateImageCache = db.prepare(
+        "UPDATE image_cache SET cache_key = ?, entity_id = ? WHERE cache_key = ?"
+      );
+      const deleteImageCache = db.prepare(
+        "DELETE FROM image_cache WHERE cache_key = ?"
+      );
+
+      db.transaction(() => {
+        for (const row of rssRows) {
+          let payload: { guids?: string[]; discoverKey?: string };
+          try {
+            payload = JSON.parse(row.raw_payload) as typeof payload;
+          } catch {
+            continue;
+          }
+
+          const plexGuid = payload.guids?.find((g) => g.startsWith("plex://"));
+          if (!plexGuid) continue;
+
+          const discoverKey = payload.discoverKey ?? null;
+          const oldCacheKey = `poster:${row.plex_item_id}`;
+          const newCacheKey = `poster:${plexGuid}`;
+
+          const existing = findExisting.get(row.user_id, plexGuid) as { id: number } | undefined;
+          if (existing) {
+            // A canonical GraphQL row already exists — delete the stale RSS duplicate.
+            deleteRow.run(row.id);
+            deleteImageCache.run(oldCacheKey);
+          } else {
+            updateRow.run(plexGuid, discoverKey, row.id);
+            updateImageCache.run(newCacheKey, plexGuid, oldCacheKey);
+          }
+        }
+      })();
+
+      // Clear the activity cache so it repopulates with normalised plex://
+      // IDs on the next scheduled fetch (the fetcher now requests the guid
+      // field and prefers it over the raw /library/metadata/ key).
+      db.exec(`
+        DELETE FROM watchlist_activity_cache;
+        UPDATE job_run_state
+        SET last_run_at = NULL, updated_at = datetime('now')
+        WHERE job_id = 'activity-cache-fetch';
+      `);
+    }
   }
 ];
 

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -258,6 +258,9 @@ const migrations: Migration[] = [
       const deleteImageCache = db.prepare(
         "DELETE FROM image_cache WHERE cache_key = ?"
       );
+      const checkImageCacheKey = db.prepare(
+        "SELECT 1 FROM image_cache WHERE cache_key = ?"
+      );
 
       db.transaction(() => {
         for (const row of rssRows) {
@@ -282,7 +285,14 @@ const migrations: Migration[] = [
             deleteImageCache.run(oldCacheKey);
           } else {
             updateRow.run(plexGuid, discoverKey, row.id);
-            updateImageCache.run(newCacheKey, plexGuid, oldCacheKey);
+            if (checkImageCacheKey.get(newCacheKey)) {
+              // The canonical poster key already exists (from a prior GraphQL fetch or a
+              // sibling RSS row processed earlier in this loop) — drop the stale duplicate
+              // rather than attempting a rename that would violate the UNIQUE constraint.
+              deleteImageCache.run(oldCacheKey);
+            } else {
+              updateImageCache.run(newCacheKey, plexGuid, oldCacheKey);
+            }
           }
         }
       })();

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -17,11 +17,12 @@ export function getWatchlistDiscoverKey(db: Database.Database, plexItemId: strin
 }
 
 export function upsertWatchlistItem(db: Database.Database, userId: number, item: WatchlistItem): void {
+  const discoverKey = item.discoverKey ?? null;
   db.prepare(`
     INSERT INTO watchlist_cache (
-      user_id, plex_item_id, title, type, year, thumb, source, added_at, matched_rating_key, raw_payload
+      user_id, plex_item_id, title, type, year, thumb, source, added_at, matched_rating_key, raw_payload, discover_key
     )
-    VALUES (@userId, @plexItemId, @title, @type, @year, @thumb, @source, @addedAt, @matchedRatingKey, @rawPayload)
+    VALUES (@userId, @plexItemId, @title, @type, @year, @thumb, @source, @addedAt, @matchedRatingKey, @rawPayload, @discoverKey)
     ON CONFLICT(user_id, plex_item_id) DO UPDATE SET
       title = excluded.title,
       year = excluded.year,
@@ -29,26 +30,27 @@ export function upsertWatchlistItem(db: Database.Database, userId: number, item:
       matched_rating_key = COALESCE(excluded.matched_rating_key, matched_rating_key),
       source = excluded.source,
       raw_payload = excluded.raw_payload,
+      discover_key = COALESCE(excluded.discover_key, discover_key),
       added_at = CASE
         WHEN added_at = '2001-01-01T00:00:00.000Z' THEN excluded.added_at
         ELSE added_at
       END
-  `).run({ userId, ...item, rawPayload: JSON.stringify(item) });
+  `).run({ userId, ...item, rawPayload: JSON.stringify(item), discoverKey });
 }
 
 export function replaceWatchlistItems(db: Database.Database, userId: number, items: WatchlistItem[]): void {
   const del = db.prepare("DELETE FROM watchlist_cache WHERE user_id = ?");
   const insert = db.prepare(`
     INSERT INTO watchlist_cache (
-      user_id, plex_item_id, title, type, year, thumb, source, added_at, matched_rating_key, raw_payload
+      user_id, plex_item_id, title, type, year, thumb, source, added_at, matched_rating_key, raw_payload, discover_key
     )
-    VALUES (@userId, @plexItemId, @title, @type, @year, @thumb, @source, @addedAt, @matchedRatingKey, @rawPayload)
+    VALUES (@userId, @plexItemId, @title, @type, @year, @thumb, @source, @addedAt, @matchedRatingKey, @rawPayload, @discoverKey)
   `);
 
   db.transaction(() => {
     del.run(userId);
     for (const item of items) {
-      insert.run({ userId, ...item, rawPayload: JSON.stringify(item) });
+      insert.run({ userId, ...item, rawPayload: JSON.stringify(item), discoverKey: item.discoverKey ?? null });
     }
   })();
 }
@@ -56,11 +58,13 @@ export function replaceWatchlistItems(db: Database.Database, userId: number, ite
 export function getWatchlistItems(db: Database.Database, userId?: number): WatchlistItem[] {
   const query = userId
     ? db.prepare(`
-        SELECT plex_item_id AS plexItemId, title, type, year, thumb, source, added_at AS addedAt, matched_rating_key AS matchedRatingKey, raw_payload AS rawPayload
+        SELECT plex_item_id AS plexItemId, title, type, year, thumb, source, added_at AS addedAt,
+               matched_rating_key AS matchedRatingKey, raw_payload AS rawPayload, discover_key AS discoverKey
         FROM watchlist_cache WHERE user_id = ? ORDER BY added_at DESC, title ASC
       `)
     : db.prepare(`
-        SELECT plex_item_id AS plexItemId, title, type, year, thumb, source, added_at AS addedAt, matched_rating_key AS matchedRatingKey, raw_payload AS rawPayload
+        SELECT plex_item_id AS plexItemId, title, type, year, thumb, source, added_at AS addedAt,
+               matched_rating_key AS matchedRatingKey, raw_payload AS rawPayload, discover_key AS discoverKey
         FROM watchlist_cache ORDER BY added_at DESC, title ASC
       `);
 
@@ -73,13 +77,11 @@ export function getWatchlistItems(db: Database.Database, userId?: number): Watch
       const parsed = JSON.parse(rawPayload) as Partial<WatchlistItem>;
       return {
         ...row,
-        // guids and discoverKey are stored only in raw_payload (not dedicated columns)
-        // because they are wide/variable-length arrays not needed for SQL filtering.
+        // guids and releaseDate are stored only in raw_payload — they are wide/variable-length
+        // arrays not needed for SQL filtering. discoverKey is now a dedicated column but
+        // we fall back to raw_payload for any rows written before migration v7.
         guids: Array.isArray(parsed.guids) ? parsed.guids : undefined,
-        discoverKey: typeof parsed.discoverKey === "string" ? parsed.discoverKey : undefined,
-        // releaseDate is persisted inside raw_payload (the full serialised WatchlistItem)
-        // rather than as a dedicated column. Restore it here so the rest of the app
-        // can rely on it without a schema migration.
+        discoverKey: row.discoverKey ?? (typeof parsed.discoverKey === "string" ? parsed.discoverKey : undefined),
         releaseDate: typeof parsed.releaseDate === "string" ? parsed.releaseDate : (row.releaseDate ?? null)
       };
     } catch {

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -93,6 +93,7 @@ interface PlexActivityFeedNode {
     title: string;
     type: string;
     key: string | null;
+    guid: string | null;
   } | null;
 }
 
@@ -753,7 +754,7 @@ export class PlexIntegration {
              nodes {
                date
                userV2 { id username displayName }
-               metadataItem { id title type key }
+               metadataItem { id title type key guid }
              }
              pageInfo { endCursor hasNextPage }
            }
@@ -769,7 +770,8 @@ export class PlexIntegration {
           break;
         }
         if (!node.metadataItem) continue;
-        const plexItemId = this.buildPlexItemId(node.metadataItem.key ?? node.metadataItem.id);
+        const guids = node.metadataItem.guid ? [node.metadataItem.guid] : undefined;
+        const plexItemId = this.buildPlexItemId(node.metadataItem.key ?? node.metadataItem.id, guids);
         results.push({
           plexItemId,
           plexUserId: node.userV2.id,

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1277,12 +1277,12 @@ export class HubarrServices {
 
     for (const item of newItems) {
       const libraryId = item.type === "movie" ? selfLibraries.movieLibraryId : selfLibraries.showLibraryId;
-      const plexGuid = item.guids.find((g) => g.startsWith("plex://"));
-      const plexItemId = plexGuid ?? item.stableKey;
 
       let matchedRatingKey: string | null = null;
       let watchlistItem: WatchlistItem = {
-        plexItemId,
+        // Use stableKey as a temporary ID — replaced below after enrichment
+        // adds the plex:// GUID to the guids array if the RSS feed omitted it.
+        plexItemId: item.stableKey,
         title: item.title,
         type: item.type,
         year: item.year,
@@ -1299,6 +1299,19 @@ export class HubarrServices {
       };
 
       watchlistItem = await plex.enrichWatchlistItem(watchlistItem);
+
+      // Resolve the canonical plex:// GUID now that enrichment has populated
+      // the full guids array. The RSS feed itself often omits the plex:// GUID,
+      // so we defer this until after enrichment rather than using item.guids.
+      const enrichedPlexGuid = watchlistItem.guids?.find((g) => g.startsWith("plex://"));
+      if (enrichedPlexGuid) {
+        const hex = enrichedPlexGuid.replace(/^plex:\/\/(?:movie|show)\//, "");
+        watchlistItem = {
+          ...watchlistItem,
+          plexItemId: enrichedPlexGuid,
+          discoverKey: `/library/metadata/${hex}`
+        };
+      }
 
       try {
         const match = await plex.searchLibraryItem(item.title, item.type, libraryId, watchlistItem.year || undefined, item.guids);
@@ -1400,12 +1413,12 @@ export class HubarrServices {
       }
 
       const libraryId = item.type === "movie" ? effectiveLibraries.movieLibraryId : effectiveLibraries.showLibraryId;
-      const plexGuid = item.guids.find((g) => g.startsWith("plex://"));
-      const plexItemId = plexGuid ?? item.stableKey;
 
       let matchedRatingKey: string | null = null;
       let watchlistItem: WatchlistItem = {
-        plexItemId,
+        // Use stableKey as a temporary ID — replaced below after enrichment
+        // adds the plex:// GUID to the guids array if the RSS feed omitted it.
+        plexItemId: item.stableKey,
         title: item.title,
         type: item.type,
         year: item.year,
@@ -1422,6 +1435,19 @@ export class HubarrServices {
       };
 
       watchlistItem = await plex.enrichWatchlistItem(watchlistItem);
+
+      // Resolve the canonical plex:// GUID now that enrichment has populated
+      // the full guids array. The RSS feed itself often omits the plex:// GUID,
+      // so we defer this until after enrichment rather than using item.guids.
+      const enrichedPlexGuid = watchlistItem.guids?.find((g) => g.startsWith("plex://"));
+      if (enrichedPlexGuid) {
+        const hex = enrichedPlexGuid.replace(/^plex:\/\/(?:movie|show)\//, "");
+        watchlistItem = {
+          ...watchlistItem,
+          plexItemId: enrichedPlexGuid,
+          discoverKey: `/library/metadata/${hex}`
+        };
+      }
 
       try {
         const match = await plex.searchLibraryItem(item.title, item.type, libraryId, watchlistItem.year || undefined, item.guids);


### PR DESCRIPTION
## Summary

Fixes the identifier format mismatch identified in #54. Two tables were storing the same Plex item under different ID formats:

- `watchlist_cache` stored items as `plex://movie/<hex>` / `plex://show/<hex>` (from the GraphQL watchlist API, which returns a `guid` field)
- `watchlist_activity_cache` stored items as `/library/metadata/<hex>` (from the `activityFeed` API, which was not requesting the `guid` field)
- RSS-sourced items fell back to an unstable compound staleKey (`<userUUID>::imdb://...|tmdb://...|tvdb://...`) when the RSS feed omitted the `plex://` GUID — which it routinely does

The hex portion is identical across all three formats — they all refer to the same underlying Plex metadata record. By normalising everything to `plex://` format, direct lookups work without fallback hacks, and the schema is consistent regardless of which source ingested the item.

## Changes

**`src/server/integrations/plex.ts`**
- Added `guid` field to the `activityFeed` GraphQL query's `metadataItem` selection (confirmed available via live API test)
- Updated `PlexActivityFeedNode.metadataItem` type to include `guid: string | null`
- Passes the GUID to `buildPlexItemId()` so new activity cache entries are stored as `plex://` rather than `/library/metadata/`

**`src/server/db/migrations.ts`** — migration v7
- Adds a `discover_key TEXT` column to `watchlist_cache`, populated from `json_extract(raw_payload, '$.discoverKey')` for all existing rows
- Normalises existing RSS staleKey `plex_item_id` values to their `plex://` GUID (extracted from the guids array in `raw_payload`). If a canonical GraphQL row already exists for the same user+item the stale RSS row is deleted; otherwise the `plex_item_id` and `discover_key` are updated in place
- Updates `image_cache` poster entries to match the new `plex_item_id` so cached poster images remain reachable
- Clears `watchlist_activity_cache` and resets the fetch job cursor so the next scheduled sync repopulates it using the corrected format

**`src/server/services.ts`**
- `processSelfRssNewItems` and `processRssNewItems` now defer `plexItemId` selection until after `enrichWatchlistItem` has run. Enrichment fetches full metadata from the Plex discover API and adds the `plex://` GUID to the item's guids array — previously the ID was set before enrichment, leaving a staleKey when the RSS feed itself didn't include the GUID
- After the plex:// GUID is resolved, `discoverKey` is also derived from it (`/library/metadata/<hex>`) and set on the item

**`src/server/db/watchlist.ts`**
- `upsertWatchlistItem` and `replaceWatchlistItems` now write `discover_key` to the new column
- `getWatchlistItems` reads `discover_key` directly from the column (with a fallback to `raw_payload` for any rows written before the migration)

## Test plan

- [ ] Rebuild and restart the container — confirm migration v7 runs cleanly (check logs for migration errors)
- [ ] Inspect `watchlist_cache`: confirm all `plex_item_id` values start with `plex://`, no staleKey rows remain, and `discover_key` is populated for every row
- [ ] Inspect `watchlist_activity_cache`: confirm the table is empty immediately after migration, then trigger an activity cache sync and verify new entries use `plex://` format
- [ ] Add a new item to the RSS watchlist feed and trigger a sync — confirm it lands with a `plex://` `plex_item_id` and a populated `discover_key`
- [ ] Run a full sync and verify `added_at` dates resolve correctly (no items stuck on the sentinel `2001-01-01` date that have a corresponding activity cache entry)
- [ ] Confirm the watchlist dashboard still displays correctly with no duplicate entries

🤖 Generated with Claude Code
