### PR TITLE
fix: prevent blank page on invalid build channel

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -31,13 +31,20 @@ export default function App() {
         apiGet<BootstrapStatus>("/api/bootstrap/status"),
         apiGet<{ authenticated: boolean; user: SessionUser | null }>("/api/auth/session")
       ]);
+
       setState({
         bootstrap,
         user: session.authenticated ? session.user : null,
         loading: false
       });
+
+      return {
+        bootstrap,
+        session
+      };
     } catch {
       setState((s) => ({ ...s, loading: false }));
+      return null;
     }
   }
 
@@ -46,9 +53,12 @@ export default function App() {
   }, []);
 
   async function onAuthenticated() {
-    await loadState();
-    const updated = await apiGet<BootstrapStatus>("/api/bootstrap/status");
-    if (!updated.setupComplete) {
+    const nextState = await loadState();
+    if (!nextState) {
+      return;
+    }
+
+    if (!nextState.bootstrap.setupComplete) {
       navigate("/onboarding");
     } else {
       navigate("/dashboard");

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -87,7 +87,7 @@ export default function App() {
       <Routes>
         <Route
           path="/onboarding"
-          element={<Onboarding onComplete={onSetupComplete} />}
+          element={<Onboarding authenticated={false} onComplete={onSetupComplete} />}
         />
         <Route path="*" element={<Navigate to="/onboarding" replace />} />
       </Routes>
@@ -113,7 +113,7 @@ export default function App() {
       <Routes>
         <Route
           path="/onboarding"
-          element={<Onboarding onComplete={onSetupComplete} />}
+          element={<Onboarding authenticated onComplete={onSetupComplete} />}
         />
         <Route path="*" element={<Navigate to="/onboarding" replace />} />
       </Routes>

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -149,6 +149,10 @@ const CHANNEL_CONFIG = {
   },
 } as const;
 
+function getChannelConfig(buildChannel: string) {
+  return CHANNEL_CONFIG[buildChannel as keyof typeof CHANNEL_CONFIG] ?? CHANNEL_CONFIG.custom;
+}
+
 function VersionFooter({ onMobileClose }: { onMobileClose: () => void }) {
   const [info, setInfo] = useState<AboutInfo | null>(null);
 
@@ -175,7 +179,7 @@ function VersionFooter({ onMobileClose }: { onMobileClose: () => void }) {
     );
   }
 
-  const { label, Icon } = CHANNEL_CONFIG[info.buildChannel];
+  const { label, Icon } = getChannelConfig(info.buildChannel);
 
   // Show the commit SHA for develop/custom builds, version number for stable
   const subLabel = info.buildChannel === "stable"

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -7,10 +7,11 @@ import CollectionsConfigForm from "../components/CollectionsConfigForm";
 import type { OnboardingStep, SetupStatusResponse, SettingsResponse } from "../../shared/types";
 
 interface OnboardingProps {
+  authenticated?: boolean;
   onComplete: () => Promise<void>;
 }
 
-export default function Onboarding({ onComplete }: OnboardingProps) {
+export default function Onboarding({ authenticated = false, onComplete }: OnboardingProps) {
   const [step, setStep] = useState<OnboardingStep>("auth");
   const [setupStatus, setSetupStatus] = useState<SetupStatusResponse | null>(null);
   const [settings, setSettings] = useState<SettingsResponse | null>(null);
@@ -33,8 +34,12 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
   }
 
   useEffect(() => {
+    if (!authenticated) {
+      setStep("auth");
+      return;
+    }
     void loadSetupState();
-  }, []);
+  }, [authenticated]);
 
   async function handlePlexAuth() {
     setAuthError(null);

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -50,7 +50,6 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
       const token = await oauth.login();
       await apiPost("/api/auth/plex", { authToken: token });
       await loadSetupState();
-      setStep("plex");
     } catch (caught) {
       setAuthError(caught instanceof Error ? caught.message : String(caught));
     } finally {
@@ -65,8 +64,12 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
     if (step === "plex") {
       return { authDone: true, plexDone: false };
     }
-    return { authDone: true, plexDone: true };
-  }, [step]);
+    return {
+      authDone: true,
+      plexDone: true,
+      collectionsDone: Boolean(setupStatus?.collectionsConfigured)
+    };
+  }, [setupStatus?.collectionsConfigured, step]);
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
@@ -82,7 +85,7 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
           <div className="w-8 h-px bg-outline-variant/40" />
           <StepDot number={2} active={step === "plex"} done={stepState.plexDone} label="Configure Plex" />
           <div className="w-8 h-px bg-outline-variant/40" />
-          <StepDot number={3} active={step === "collections"} done={false} label="Collections" />
+          <StepDot number={3} active={step === "collections"} done={stepState.collectionsDone ?? false} label="Collections" />
         </div>
 
         {step === "auth" && (

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -5,6 +5,9 @@ type PackageJson = {
   version?: string;
 };
 
+const VALID_BUILD_CHANNELS = ["stable", "develop", "custom"] as const;
+type BuildChannel = (typeof VALID_BUILD_CHANNELS)[number];
+
 function readPackageVersion() {
   const packageJsonPath = path.resolve(process.cwd(), "package.json");
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as PackageJson;
@@ -21,7 +24,14 @@ export const PLEX_USER_AGENT = `Hubarr/${APP_VERSION}`;
 
 // BUILD_CHANNEL is baked into the Docker image at CI build time via --build-arg.
 // Values: "stable" (release workflow), "develop" (develop workflow), "custom" (no arg passed — any non-CI build).
-export const BUILD_CHANNEL = (process.env.BUILD_CHANNEL ?? "custom") as "stable" | "develop" | "custom";
+function normalizeBuildChannel(value: string | undefined): BuildChannel {
+  if (value && VALID_BUILD_CHANNELS.includes(value as BuildChannel)) {
+    return value as BuildChannel;
+  }
+  return "custom";
+}
+
+export const BUILD_CHANNEL = normalizeBuildChannel(process.env.BUILD_CHANNEL);
 
 // Full commit SHA baked in at build time. "local" when running outside CI.
 const rawCommitSha = process.env.COMMIT_SHA ?? "local";


### PR DESCRIPTION
## Summary

This PR fixes a live regression where Hubarr could render a blank page after setup because the runtime reported an unexpected build channel value. It normalizes invalid build channel env values on the server, adds a defensive fallback in the client shell, and avoids noisy authenticated setup requests before a fresh install has signed in.

## Changes

- Updated the server build metadata handling in `src/server/version.ts` so any unexpected `BUILD_CHANNEL` value is normalized to `custom` instead of being returned directly to the client.
- Updated the sidebar version footer in `src/client/components/Sidebar.tsx` to fall back to the custom channel label/icon if it ever receives an unknown channel value.
- Updated onboarding flow wiring in `src/client/App.tsx` and `src/client/pages/Onboarding.tsx` so fresh installs stay on the auth step without immediately calling authenticated setup/settings endpoints.
- Rebuilt and recreated the live `hubarr` container with the existing production-style settings to verify the fix against the same runtime configuration that triggered the blank page.

## Test plan

- [x] Run `npm run check`
- [x] Run `npm run build`
- [x] Build a local `hubarr` Docker image from this branch using `BUILD_CHANNEL=local` and `COMMIT_SHA=local`
- [x] Recreate the live `hubarr` container with the existing settings: bridge networking, `/opt/hubarr:/config`, port `9301`, and `unless-stopped`
- [x] Confirm the recreated app reports a normalized build channel instead of crashing on `BUILD_CHANNEL=local`
- [x] Run `npx playwright test tests/playwright/pages.spec.ts tests/playwright/settings.spec.ts --project=chromium` against `https://hubarr.coelho.je`

🤖 Generated with Codex
