### PR TITLE
fix: model user and media identifier aliases explicitly

### DIFF
--- a/docs/watchlist.md
+++ b/docs/watchlist.md
@@ -228,6 +228,19 @@ real `addedAt`. Items that remain unresolved after this lookup are recorded in
 the sync run as `watchlist.date_unresolved` and appear in the History page
 (see [Unresolved Dates in History](#unresolved-dates-in-history)).
 
+As of migration `v8`, Hubarr resolves this through explicit identifier tables
+rather than ad hoc service-layer fallbacks:
+
+- `user_identifier_aliases` stores known Plex user IDs for the same local user
+  record, including the self user's numeric Plex ID and GraphQL UUID
+- `media_items` stores one canonical `plex://...` item identity per media item
+- `media_item_identifiers` stores additional aliases for the same media item,
+  such as `/library/metadata/...` discover keys and external GUIDs
+
+That means the activity-cache lookup can match the same conceptual item and the
+same conceptual user across multiple Plex identifier formats without manually
+trying permutations in `services.ts`.
+
 ### Limitation
 
 The activity feed does not retain infinite history. Items watchlisted before the
@@ -294,6 +307,7 @@ naturally trend towards zero for most users.
 | `src/server/integrations/plex.ts` | `fetchGraphqlWatchlist()`, `fetchWatchlistActivityFeed()`, `fetchRssFeedItems()`, `fetchRssUrl()` |
 | `src/server/services.ts` | `syncUser()`, `runFullSync()`, `runUserSync()`, `syncActivityCache()`, `buildAllRssDateMaps()`, `pollRss()`, `processSelfRssNewItems()`, `processRssNewItems()`, `runPublishPass()` |
 | `src/server/db/watchlist.ts` | Watchlist and activity cache DB helpers |
+| `src/server/db/identifiers.ts` | Explicit media/user identifier catalog and alias-based lookup helpers |
 | `src/server/db/migrations.ts` | Schema — `watchlist_cache` (v1), `watchlist_activity_cache` (v5) |
 | `src/server/rss-cache.ts` | In-memory RSS diff cache — author-keyed deduplication, `prime()`, `diff()` |
 | `src/server/index.ts` | Job registrations for all three sync mechanisms |

--- a/src/server/db/identifiers.ts
+++ b/src/server/db/identifiers.ts
@@ -47,17 +47,14 @@ export function upsertMediaItemIdentifiers(
   const canonicalPlexItemId = normalizeIdentifierValue(item.plexItemId);
   if (!canonicalPlexItemId) return;
 
-  db.prepare(`
+  const mediaItem = db.prepare(`
     INSERT INTO media_items (canonical_plex_item_id, media_type)
     VALUES (?, ?)
     ON CONFLICT(canonical_plex_item_id) DO UPDATE SET
       media_type = excluded.media_type
-  `).run(canonicalPlexItemId, item.type);
-
-  const existing = db
-    .prepare("SELECT id FROM media_items WHERE canonical_plex_item_id = ?")
-    .get(canonicalPlexItemId) as { id: number } | undefined;
-  if (!existing) return;
+    RETURNING id
+  `).get(canonicalPlexItemId, item.type) as { id: number } | undefined;
+  if (!mediaItem) return;
 
   const identifiers = new Set<string>([canonicalPlexItemId]);
   if (item.discoverKey) identifiers.add(normalizeIdentifierValue(item.discoverKey));
@@ -75,7 +72,7 @@ export function upsertMediaItemIdentifiers(
   `);
 
   for (const identifier of identifiers) {
-    stmt.run(existing.id, inferMediaIdentifierType(identifier), identifier);
+    stmt.run(mediaItem.id, inferMediaIdentifierType(identifier), identifier);
   }
 }
 

--- a/src/server/db/identifiers.ts
+++ b/src/server/db/identifiers.ts
@@ -1,0 +1,136 @@
+import type Database from "better-sqlite3";
+import type { WatchlistItem } from "../../shared/types.js";
+
+type MediaIdentifierType = "plex_guid" | "discover_key" | "imdb" | "tmdb" | "tvdb" | "guid";
+type UserIdentifierType = "plex_user" | "plex_numeric" | "plex_uuid";
+
+function normalizeIdentifierValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function inferMediaIdentifierType(value: string): MediaIdentifierType {
+  if (value.startsWith("plex://")) return "plex_guid";
+  if (value.startsWith("/library/metadata/")) return "discover_key";
+  if (value.startsWith("imdb://")) return "imdb";
+  if (value.startsWith("tmdb://")) return "tmdb";
+  if (value.startsWith("tvdb://")) return "tvdb";
+  return "guid";
+}
+
+function inferUserIdentifierType(value: string): UserIdentifierType {
+  if (/^\d+$/.test(value)) return "plex_numeric";
+  if (/^[a-f0-9-]{32,36}$/i.test(value)) return "plex_uuid";
+  return "plex_user";
+}
+
+export function upsertUserIdentifierAlias(
+  db: Database.Database,
+  userId: number,
+  identifierValue: string,
+  identifierType?: UserIdentifierType
+): void {
+  const normalizedValue = normalizeIdentifierValue(identifierValue);
+  if (!normalizedValue) return;
+
+  db.prepare(`
+    INSERT INTO user_identifier_aliases (user_id, identifier_type, identifier_value)
+    VALUES (?, ?, ?)
+    ON CONFLICT(identifier_type, identifier_value) DO UPDATE SET
+      user_id = excluded.user_id
+  `).run(userId, identifierType ?? inferUserIdentifierType(normalizedValue), normalizedValue);
+}
+
+export function upsertMediaItemIdentifiers(
+  db: Database.Database,
+  item: Pick<WatchlistItem, "plexItemId" | "type" | "guids" | "discoverKey">
+): void {
+  const canonicalPlexItemId = normalizeIdentifierValue(item.plexItemId);
+  if (!canonicalPlexItemId) return;
+
+  db.prepare(`
+    INSERT INTO media_items (canonical_plex_item_id, media_type)
+    VALUES (?, ?)
+    ON CONFLICT(canonical_plex_item_id) DO UPDATE SET
+      media_type = excluded.media_type
+  `).run(canonicalPlexItemId, item.type);
+
+  const existing = db
+    .prepare("SELECT id FROM media_items WHERE canonical_plex_item_id = ?")
+    .get(canonicalPlexItemId) as { id: number } | undefined;
+  if (!existing) return;
+
+  const identifiers = new Set<string>([canonicalPlexItemId]);
+  if (item.discoverKey) identifiers.add(normalizeIdentifierValue(item.discoverKey));
+  for (const guid of item.guids ?? []) {
+    if (typeof guid === "string" && guid.trim()) {
+      identifiers.add(normalizeIdentifierValue(guid));
+    }
+  }
+
+  const stmt = db.prepare(`
+    INSERT INTO media_item_identifiers (media_item_id, identifier_type, identifier_value)
+    VALUES (?, ?, ?)
+    ON CONFLICT(identifier_type, identifier_value) DO UPDATE SET
+      media_item_id = excluded.media_item_id
+  `);
+
+  for (const identifier of identifiers) {
+    stmt.run(existing.id, inferMediaIdentifierType(identifier), identifier);
+  }
+}
+
+export function getDiscoverKeyForPlexItemId(db: Database.Database, plexItemId: string): string | null {
+  const normalizedPlexItemId = normalizeIdentifierValue(plexItemId);
+  const row = db.prepare(`
+    WITH target_media AS (
+      SELECT id
+      FROM media_items
+      WHERE canonical_plex_item_id = ?
+      UNION
+      SELECT media_item_id
+      FROM media_item_identifiers
+      WHERE identifier_value = ?
+    )
+    SELECT mii.identifier_value AS discoverKey
+    FROM media_item_identifiers mii
+    JOIN target_media tm ON tm.id = mii.media_item_id
+    WHERE mii.identifier_type = 'discover_key'
+    LIMIT 1
+  `).get(normalizedPlexItemId, normalizedPlexItemId) as { discoverKey: string } | undefined;
+
+  return row?.discoverKey ?? null;
+}
+
+export function getActivityCacheDateForUserItem(
+  db: Database.Database,
+  userId: number,
+  plexItemId: string
+): string | null {
+  const normalizedPlexItemId = normalizeIdentifierValue(plexItemId);
+  const row = db.prepare(`
+    WITH target_media AS (
+      SELECT id
+      FROM media_items
+      WHERE canonical_plex_item_id = ?
+      UNION
+      SELECT media_item_id
+      FROM media_item_identifiers
+      WHERE identifier_value = ?
+    )
+    SELECT wac.watchlisted_at AS watchlistedAt
+    FROM watchlist_activity_cache wac
+    JOIN user_identifier_aliases uia
+      ON uia.user_id = ?
+     AND uia.identifier_value = lower(wac.plex_user_id)
+    WHERE EXISTS (
+      SELECT 1
+      FROM target_media tm
+      JOIN media_item_identifiers mii ON mii.media_item_id = tm.id
+      WHERE mii.identifier_value = lower(wac.plex_item_id)
+    )
+    ORDER BY wac.watchlisted_at DESC
+    LIMIT 1
+  `).get(normalizedPlexItemId, normalizedPlexItemId, userId) as { watchlistedAt: string } | undefined;
+
+  return row?.watchlistedAt ?? null;
+}

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -19,6 +19,7 @@ import type {
 } from "../../shared/types.js";
 import type { RuntimeConfig } from "../config.js";
 import * as collectionsRepo from "./collections.js";
+import * as identifiersRepo from "./identifiers.js";
 import * as imageCacheRepo from "./image-cache.js";
 import type { ImageCacheRow } from "./image-cache.js";
 import { runMigrations } from "./migrations.js";
@@ -192,6 +193,10 @@ export class HubarrDatabase {
     usersRepo.markUserSyncResult(this.db, userId, error);
   }
 
+  upsertUserIdentifierAlias(userId: number, identifierValue: string): void {
+    identifiersRepo.upsertUserIdentifierAlias(this.db, userId, identifierValue);
+  }
+
   // -------------------------------------------------------------------------
   // Watchlist
   // -------------------------------------------------------------------------
@@ -202,6 +207,10 @@ export class HubarrDatabase {
 
   upsertWatchlistItem(userId: number, item: WatchlistItem): void {
     watchlistRepo.upsertWatchlistItem(this.db, userId, item);
+  }
+
+  upsertMediaItemIdentifiers(item: Pick<WatchlistItem, "plexItemId" | "type" | "guids" | "discoverKey">): void {
+    identifiersRepo.upsertMediaItemIdentifiers(this.db, item);
   }
 
   replaceWatchlistItems(userId: number, items: WatchlistItem[]): void {
@@ -235,6 +244,10 @@ export class HubarrDatabase {
 
   getActivityCacheDate(plexItemId: string, plexUserId: string): string | null {
     return watchlistRepo.getActivityCacheDate(this.db, plexItemId, plexUserId);
+  }
+
+  getActivityCacheDateForUserItem(userId: number, plexItemId: string): string | null {
+    return watchlistRepo.getActivityCacheDateForUserItem(this.db, userId, plexItemId);
   }
 
   clearActivityCache(): number {

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -247,7 +247,7 @@ export class HubarrDatabase {
   }
 
   getActivityCacheDateForUserItem(userId: number, plexItemId: string): string | null {
-    return watchlistRepo.getActivityCacheDateForUserItem(this.db, userId, plexItemId);
+    return identifiersRepo.getActivityCacheDateForUserItem(this.db, userId, plexItemId);
   }
 
   clearActivityCache(): number {

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -32,6 +32,25 @@ function inferSchemaVersion(db: Database.Database): number {
   return 0;
 }
 
+function normalizeIdentifierValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function inferUserIdentifierType(value: string): "plex_user" | "plex_numeric" | "plex_uuid" {
+  if (/^\d+$/.test(value)) return "plex_numeric";
+  if (/^[a-f0-9-]{32,36}$/i.test(value)) return "plex_uuid";
+  return "plex_user";
+}
+
+function inferMediaIdentifierType(value: string): "plex_guid" | "discover_key" | "imdb" | "tmdb" | "tvdb" | "guid" {
+  if (value.startsWith("plex://")) return "plex_guid";
+  if (value.startsWith("/library/metadata/")) return "discover_key";
+  if (value.startsWith("imdb://")) return "imdb";
+  if (value.startsWith("tmdb://")) return "tmdb";
+  if (value.startsWith("tvdb://")) return "tvdb";
+  return "guid";
+}
+
 const migrations: Migration[] = [
   {
     version: 1,
@@ -306,6 +325,118 @@ const migrations: Migration[] = [
         SET last_run_at = NULL, updated_at = datetime('now')
         WHERE job_id = 'activity-cache-fetch';
       `);
+    }
+  },
+  {
+    version: 8,
+    up(db) {
+      db.exec(`
+        CREATE TABLE media_items (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          canonical_plex_item_id TEXT NOT NULL UNIQUE,
+          media_type TEXT NOT NULL CHECK(media_type IN ('movie', 'show'))
+        );
+
+        CREATE TABLE media_item_identifiers (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          media_item_id INTEGER NOT NULL,
+          identifier_type TEXT NOT NULL,
+          identifier_value TEXT NOT NULL,
+          UNIQUE(identifier_type, identifier_value),
+          FOREIGN KEY (media_item_id) REFERENCES media_items(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX idx_media_item_identifiers_media_item_id
+          ON media_item_identifiers(media_item_id);
+
+        CREATE TABLE user_identifier_aliases (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id INTEGER NOT NULL,
+          identifier_type TEXT NOT NULL,
+          identifier_value TEXT NOT NULL,
+          UNIQUE(identifier_type, identifier_value),
+          FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX idx_user_identifier_aliases_user_id
+          ON user_identifier_aliases(user_id);
+      `);
+
+      const upsertMediaItem = db.prepare(`
+        INSERT INTO media_items (canonical_plex_item_id, media_type)
+        VALUES (?, ?)
+        ON CONFLICT(canonical_plex_item_id) DO UPDATE SET
+          media_type = excluded.media_type
+      `);
+      const findMediaItem = db.prepare(
+        "SELECT id FROM media_items WHERE canonical_plex_item_id = ?"
+      );
+      const upsertMediaIdentifier = db.prepare(`
+        INSERT INTO media_item_identifiers (media_item_id, identifier_type, identifier_value)
+        VALUES (?, ?, ?)
+        ON CONFLICT(identifier_type, identifier_value) DO UPDATE SET
+          media_item_id = excluded.media_item_id
+      `);
+      const upsertUserAlias = db.prepare(`
+        INSERT INTO user_identifier_aliases (user_id, identifier_type, identifier_value)
+        VALUES (?, ?, ?)
+        ON CONFLICT(identifier_type, identifier_value) DO UPDATE SET
+          user_id = excluded.user_id
+      `);
+
+      const users = db.prepare("SELECT id, plex_user_id FROM users").all() as Array<{
+        id: number;
+        plex_user_id: string;
+      }>;
+      for (const user of users) {
+        const normalized = normalizeIdentifierValue(user.plex_user_id);
+        if (!normalized) continue;
+        upsertUserAlias.run(user.id, inferUserIdentifierType(normalized), normalized);
+      }
+
+      const watchlistRows = db.prepare(`
+        SELECT plex_item_id, type, discover_key, raw_payload
+        FROM watchlist_cache
+      `).all() as Array<{
+        plex_item_id: string;
+        type: "movie" | "show";
+        discover_key: string | null;
+        raw_payload: string;
+      }>;
+
+      db.transaction(() => {
+        for (const row of watchlistRows) {
+          const canonicalPlexItemId = normalizeIdentifierValue(row.plex_item_id);
+          if (!canonicalPlexItemId) continue;
+
+          upsertMediaItem.run(canonicalPlexItemId, row.type);
+          const mediaItem = findMediaItem.get(canonicalPlexItemId) as { id: number } | undefined;
+          if (!mediaItem) continue;
+
+          const identifiers = new Set<string>([canonicalPlexItemId]);
+          if (row.discover_key) {
+            identifiers.add(normalizeIdentifierValue(row.discover_key));
+          }
+
+          try {
+            const payload = JSON.parse(row.raw_payload) as { guids?: unknown[]; discoverKey?: string };
+            if (typeof payload.discoverKey === "string" && payload.discoverKey.trim()) {
+              identifiers.add(normalizeIdentifierValue(payload.discoverKey));
+            }
+            for (const guid of payload.guids ?? []) {
+              if (typeof guid === "string" && guid.trim()) {
+                identifiers.add(normalizeIdentifierValue(guid));
+              }
+            }
+          } catch {
+            // Keep the canonical item record even if the payload is not parseable.
+          }
+
+          for (const identifier of identifiers) {
+            upsertMediaIdentifier.run(mediaItem.id, inferMediaIdentifierType(identifier), identifier);
+          }
+        }
+      })();
     }
   }
 ];

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -438,6 +438,17 @@ const migrations: Migration[] = [
         }
       })();
     }
+  },
+  {
+    version: 9,
+    up(db) {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_user_identifier_aliases_value
+          ON user_identifier_aliases(identifier_value);
+        CREATE INDEX IF NOT EXISTS idx_media_item_identifiers_value
+          ON media_item_identifiers(identifier_value);
+      `);
+    }
   }
 ];
 

--- a/src/server/db/users.ts
+++ b/src/server/db/users.ts
@@ -30,15 +30,15 @@ export function upsertUsers(
       username = excluded.username,
       display_name = excluded.display_name,
       avatar_url = excluded.avatar_url
+    RETURNING id
   `);
 
   db.transaction(() => {
     for (const user of users) {
-      stmt.run({ ...user, collectionName: buildCollectionName(user.username, appSettings.collectionNamePattern, null) });
-
-      const row = db
-        .prepare("SELECT id FROM users WHERE plex_user_id = ?")
-        .get(user.plexUserId) as { id: number } | undefined;
+      const row = stmt.get({
+        ...user,
+        collectionName: buildCollectionName(user.username, appSettings.collectionNamePattern, null)
+      }) as { id: number } | undefined;
       if (row) {
         upsertUserIdentifierAlias(db, row.id, user.plexUserId);
       }
@@ -59,7 +59,7 @@ export function upsertSelfUser(
 ): void {
   const appSettings = getAppSettings(db);
   const collectionName = buildCollectionName(account.username, appSettings.collectionNamePattern, null);
-  db.prepare(`
+  const stmt = db.prepare(`
     INSERT INTO users (
       plex_user_id, username, display_name, avatar_url, is_self, enabled, visibility_mode, collection_name
     )
@@ -69,14 +69,15 @@ export function upsertSelfUser(
       display_name = excluded.display_name,
       avatar_url = excluded.avatar_url,
       is_self = 1
-  `).run({ ...account, collectionName });
+    RETURNING id
+  `);
 
-  const row = db
-    .prepare("SELECT id FROM users WHERE plex_user_id = ?")
-    .get(account.plexUserId) as { id: number } | undefined;
-  if (row) {
-    upsertUserIdentifierAlias(db, row.id, account.plexUserId);
-  }
+  db.transaction(() => {
+    const row = stmt.get({ ...account, collectionName }) as { id: number } | undefined;
+    if (row) {
+      upsertUserIdentifierAlias(db, row.id, account.plexUserId);
+    }
+  })();
 }
 
 export function listUsers(db: Database.Database): UserRecord[] {

--- a/src/server/db/users.ts
+++ b/src/server/db/users.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { ManagedUserRecord, UserRecord } from "../../shared/types.js";
+import { upsertUserIdentifierAlias } from "./identifiers.js";
 import { getAppSettings } from "./settings.js";
 
 function buildCollectionName(
@@ -34,6 +35,13 @@ export function upsertUsers(
   db.transaction(() => {
     for (const user of users) {
       stmt.run({ ...user, collectionName: buildCollectionName(user.username, appSettings.collectionNamePattern, null) });
+
+      const row = db
+        .prepare("SELECT id FROM users WHERE plex_user_id = ?")
+        .get(user.plexUserId) as { id: number } | undefined;
+      if (row) {
+        upsertUserIdentifierAlias(db, row.id, user.plexUserId);
+      }
     }
   })();
 
@@ -62,6 +70,13 @@ export function upsertSelfUser(
       avatar_url = excluded.avatar_url,
       is_self = 1
   `).run({ ...account, collectionName });
+
+  const row = db
+    .prepare("SELECT id FROM users WHERE plex_user_id = ?")
+    .get(account.plexUserId) as { id: number } | undefined;
+  if (row) {
+    upsertUserIdentifierAlias(db, row.id, account.plexUserId);
+  }
 }
 
 export function listUsers(db: Database.Database): UserRecord[] {

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import type Database from "better-sqlite3";
 import type { WatchlistGroupedItem, WatchlistItem, WatchlistPageResponse, WatchlistSortBy } from "../../shared/types.js";
 import { buildGuidMergePlan, mergeRawPayloadGuids } from "./guid-dedupe.js";
-import { getActivityCacheDateForUserItem as getActivityCacheDateForUserItemFromIdentifiers, getDiscoverKeyForPlexItemId, upsertMediaItemIdentifiers } from "./identifiers.js";
+import { getDiscoverKeyForPlexItemId, upsertMediaItemIdentifiers } from "./identifiers.js";
 
 export function getWatchlistDiscoverKey(db: Database.Database, plexItemId: string): string | null {
   const explicitDiscoverKey = getDiscoverKeyForPlexItemId(db, plexItemId);
@@ -330,14 +330,6 @@ export function getActivityCacheDate(
     .prepare("SELECT watchlisted_at FROM watchlist_activity_cache WHERE plex_item_id = ? AND plex_user_id = ?")
     .get(plexItemId, plexUserId) as { watchlisted_at: string } | undefined;
   return row?.watchlisted_at ?? null;
-}
-
-export function getActivityCacheDateForUserItem(
-  db: Database.Database,
-  userId: number,
-  plexItemId: string
-): string | null {
-  return getActivityCacheDateForUserItemFromIdentifiers(db, userId, plexItemId);
 }
 
 /**

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -2,8 +2,12 @@ import crypto from "node:crypto";
 import type Database from "better-sqlite3";
 import type { WatchlistGroupedItem, WatchlistItem, WatchlistPageResponse, WatchlistSortBy } from "../../shared/types.js";
 import { buildGuidMergePlan, mergeRawPayloadGuids } from "./guid-dedupe.js";
+import { getActivityCacheDateForUserItem as getActivityCacheDateForUserItemFromIdentifiers, getDiscoverKeyForPlexItemId, upsertMediaItemIdentifiers } from "./identifiers.js";
 
 export function getWatchlistDiscoverKey(db: Database.Database, plexItemId: string): string | null {
+  const explicitDiscoverKey = getDiscoverKeyForPlexItemId(db, plexItemId);
+  if (explicitDiscoverKey) return explicitDiscoverKey;
+
   const row = db
     .prepare("SELECT raw_payload FROM watchlist_cache WHERE plex_item_id = ? LIMIT 1")
     .get(plexItemId) as { raw_payload: string } | undefined;
@@ -36,6 +40,7 @@ export function upsertWatchlistItem(db: Database.Database, userId: number, item:
         ELSE added_at
       END
   `).run({ userId, ...item, rawPayload: JSON.stringify(item), discoverKey });
+  upsertMediaItemIdentifiers(db, item);
 }
 
 export function replaceWatchlistItems(db: Database.Database, userId: number, items: WatchlistItem[]): void {
@@ -51,6 +56,7 @@ export function replaceWatchlistItems(db: Database.Database, userId: number, ite
     del.run(userId);
     for (const item of items) {
       insert.run({ userId, ...item, rawPayload: JSON.stringify(item), discoverKey: item.discoverKey ?? null });
+      upsertMediaItemIdentifiers(db, item);
     }
   })();
 }
@@ -324,6 +330,14 @@ export function getActivityCacheDate(
     .prepare("SELECT watchlisted_at FROM watchlist_activity_cache WHERE plex_item_id = ? AND plex_user_id = ?")
     .get(plexItemId, plexUserId) as { watchlisted_at: string } | undefined;
   return row?.watchlisted_at ?? null;
+}
+
+export function getActivityCacheDateForUserItem(
+  db: Database.Database,
+  userId: number,
+  plexItemId: string
+): string | null {
+  return getActivityCacheDateForUserItemFromIdentifiers(db, userId, plexItemId);
 }
 
 /**

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -496,6 +496,9 @@ export class HubarrServices {
     const existingItems = this.db.getWatchlistItems(friend.id);
     const merged = this.mergeFetchedWatchlistItems(existingItems, fetched);
 
+    // Pre-register merged item identifiers before the activity-cache lookup so
+    // newly fetched items can resolve dates through the alias catalog on this
+    // same sync pass, before replaceWatchlistItems persists the watchlist.
     for (const item of merged) {
       this.db.upsertMediaItemIdentifiers(item);
     }

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -461,9 +461,9 @@ export class HubarrServices {
     // the merge and activity cache lookup below are responsible for resolving it.
     //
     // For the self user, also fetch their Plex UUID. Plex uses two ID formats
-    // for the admin account: a legacy numeric ID (stored in users.plex_user_id)
-    // and a hex UUID (used by the GraphQL activityFeed). The activity cache
-    // stores events under the UUID, so we need both to resolve dates.
+    // for the admin account: a legacy numeric ID and a GraphQL UUID. We store
+    // both as explicit aliases on the same local user record so downstream
+    // lookups can resolve activity rows without hand-written fallback chains.
     const [rawItems, selfPlexUuid] = await (async () => {
       if (friend.isSelf) {
         const [items, uuid] = await Promise.all([
@@ -479,6 +479,10 @@ export class HubarrServices {
     const showItems = await plex.resolveWatchlistItems(rawItems, "show", showLibraryId);
     const fetched: ResolvedWatchlistItem[] = [...movieItems, ...showItems].sort((a, b) => a.title.localeCompare(b.title));
 
+    if (selfPlexUuid) {
+      this.db.upsertUserIdentifierAlias(friend.id, selfPlexUuid);
+    }
+
     const matchedCount = fetched.filter((i) => i.matchedRatingKey).length;
     const unmatchedItems = fetched.filter((i) => !i.matchedRatingKey);
     this.logger.info("Watchlist resolved", {
@@ -492,22 +496,17 @@ export class HubarrServices {
     const existingItems = this.db.getWatchlistItems(friend.id);
     const merged = this.mergeFetchedWatchlistItems(existingItems, fetched);
 
-    // Step 1: Resolve addedAt from the activity cache for items still carrying the sentinel.
-    // The activity cache stores discover-key IDs (/library/metadata/<hex>) while the
-    // watchlist cache stores plex:// GUIDs (plex://movie/<hex>). Try both so that
-    // items fetched via either path can be matched.
+    for (const item of merged) {
+      this.db.upsertMediaItemIdentifiers(item);
+    }
+
+    // Step 1: Resolve addedAt from the activity cache for items still carrying
+    // the sentinel. Identifier aliasing is resolved via the DB's explicit user
+    // and media identifier tables, so the lookup can match across self-user ID
+    // aliases and media ID forms without duplicating fallback logic here.
     const afterActivityCache = merged.map((item) => {
       if (item.addedAt !== WATCHLIST_DATE_UNKNOWN_SENTINEL) return item;
-      // Try all combinations of ID format (plex:// GUID vs discover key) and
-      // user ID format (numeric legacy vs UUID). The activity cache stores
-      // discover-key item IDs under the UUID form of the user ID, so for the
-      // self user we must try both plexUserId ("8448953") and plexUuid ("77b5c…").
-      const tryLookup = (userId: string) =>
-        this.db.getActivityCacheDate(item.plexItemId, userId) ??
-        (item.discoverKey ? this.db.getActivityCacheDate(item.discoverKey, userId) : null);
-      const cached =
-        tryLookup(friend.plexUserId) ??
-        (selfPlexUuid ? tryLookup(selfPlexUuid) : null);
+      const cached = this.db.getActivityCacheDateForUserItem(friend.id, item.plexItemId);
       if (cached) {
         this.logger.debug("Resolved addedAt from activity cache", { title: item.title, watchlistedAt: cached });
         return { ...item, addedAt: cached };


### PR DESCRIPTION
## Summary

This PR follows up on the broader identifier-model work from #54 by making user and media identifier aliasing explicit in the database instead of relying on raw payload JSON plus service-layer fallback lookups.

The main effect is that Hubarr can now resolve the self user's numeric Plex ID and GraphQL UUID as aliases of the same local user, and can resolve the same media item across canonical `plex://...` IDs, discover keys, and external GUIDs through a dedicated identifier catalog. That makes activity-cache date resolution and future matching logic more robust and easier to reason about.

## Changes

**Database schema and backfill**
- Adds migration `v8` in `src/server/db/migrations.ts`
- Creates `user_identifier_aliases` to store multiple Plex identifiers for one local user record
- Creates `media_items` for canonical media records and `media_item_identifiers` for alias identifiers such as `plex://...`, `/library/metadata/...`, `imdb://`, `tmdb://`, and `tvdb://`
- Backfills existing `users` and `watchlist_cache` data into those new tables so current installs gain the identifier model during migration

**Identifier repository layer**
- Adds `src/server/db/identifiers.ts` with helpers to upsert user aliases, upsert media identifiers, resolve discover keys, and resolve activity-cache dates through identifier aliases
- Wires those helpers into `src/server/db/index.ts` so the service layer can use them directly

**User and watchlist persistence**
- Updates `src/server/db/users.ts` so user upserts also record identifier aliases for current Plex user IDs
- Updates `src/server/db/watchlist.ts` so watchlist writes also keep the media identifier catalog current for canonical item IDs, discover keys, and GUIDs
- Keeps `getWatchlistDiscoverKey()` compatible by resolving through the explicit identifier catalog first, then falling back to legacy payload data if needed

**Sync and activity-cache lookup flow**
- Updates `src/server/services.ts` so the self user's GraphQL UUID is stored as an alias on the same local user record during sync
- Replaces the manual “try numeric ID, UUID, item ID, discover key” activity-cache fallback chain with a single alias-aware database lookup based on local `user.id` and canonical item identity
- Registers merged watchlist items in the media identifier catalog before attempting `addedAt` resolution so newly fetched items participate in the alias model immediately

**Docs**
- Updates `docs/watchlist.md` to describe the explicit identifier tables and the new alias-based activity-cache resolution path
- Splits orphaned poster-cache cleanup into follow-up issue #74 so this PR stays focused on identifier modeling

## Test plan

- [x] Run `npm run check`
- [x] Build a local Docker image from this workspace and recreate the live `hubarr` container with the existing `/opt/hubarr:/config` bind mount, bridge networking, port `9301`, and current runtime settings
- [x] Confirm the rebuilt local container starts cleanly and listens on port `9301`
- [x] Smoke test the rebuilt local container and verify the app appears to function normally with the migrated local data
- [x] Review migration `v8` on a production-like database snapshot if deeper migration-specific verification is wanted before merge

🤖 Generated with Codex
