### PR TITLE
fix: trust a single proxy hop

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -56,10 +56,12 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   // Enable trust proxy if configured — required for express-rate-limit to
   // correctly identify clients by their real IP when Hubarr runs behind a
-  // reverse proxy that injects X-Forwarded-For headers.
+  // reverse proxy that injects X-Forwarded-For headers. Trust only a single
+  // proxy hop so forwarded headers are honored without accepting arbitrary
+  // client-supplied proxy chains.
   if (db.getAppSettings().trustProxy) {
-    app.set("trust proxy", true);
-    logger.info("Trust proxy enabled — using X-Forwarded-For for client IP identification");
+    app.set("trust proxy", 1);
+    logger.info("Trust proxy enabled — using one trusted proxy hop for client IP identification");
   }
 
   app.use(helmet({


### PR DESCRIPTION
## Summary

This PR fixes the proxy-trust behavior introduced by the reverse-proxy support work so it is compatible with `express-rate-limit` and safer by default.

With the current code, enabling the general-settings proxy toggle sets Express `trust proxy` to `true`, which means “trust all proxy hops.” That triggers `express-rate-limit`'s permissive trust proxy warning and is broader than Hubarr needs for the common “one reverse proxy in front of the app” deployment.

This change keeps the setting behavior but narrows it to a single trusted proxy hop.

## Changes

**`src/server/app.ts`**
- Changes the proxy-enabled branch from `app.set("trust proxy", true)` to `app.set("trust proxy", 1)`
- Updates the inline comment to explain that Hubarr now trusts exactly one proxy hop rather than arbitrary proxy chains
- Updates the startup log message so it reflects the new behavior

## Test plan

- [x] Run `npm run check`
- [ ] Enable the proxy setting in Hubarr and restart the app
- [ ] Confirm the previous `express-rate-limit` permissive trust proxy warning no longer appears in startup logs
- [ ] Confirm requests forwarded through the expected reverse proxy still resolve the correct client IP behavior

🤖 Generated with Codex
