### PR TITLE
fix: add maintenance tasks job for orphaned poster cache cleanup

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -95,6 +95,7 @@ Read-only. Safe to run against a live instance.
 | Clicking a tab updates the URL | Clicks Plex, Jobs, and About tabs in turn; asserts the URL gains the expected `?tab=` parameter |
 | General tab shows Startup Sync toggle and History Retention field | Navigates to `/settings?tab=general`, waits for load, asserts both setting labels are visible |
 | Jobs tab shows the jobs table | Navigates to `/settings?tab=jobs`, asserts the "Job Name" column header is visible |
+| Jobs tab lists the Maintenance Tasks job | Navigates to `/settings?tab=jobs`, asserts the `Maintenance Tasks` row is present with its daily schedule and `Run Now` button |
 | About tab shows version and support info | Navigates to `/settings?tab=about`, asserts "About Hubarr" and "Version" headings are visible |
 | Collections tab shows watchlisted date sort options | Navigates to `/settings?tab=collections`, asserts the ordering `<select>` contains the "Watchlisted Date (New to Old)" and "Watchlisted Date (Old to New)" options |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ long gone.
   GraphQL/RSS/activity-cache behavior, date resolution, and sync flows
 - [image-caching.md](image-caching.md) — poster/avatar caching design, stale
   refresh behavior, storage model, and cache lifecycle details
+- [maintenance.md](maintenance.md) — scheduled housekeeping tasks, current
+  cleanup responsibilities, and how to add new maintenance work safely
 
 ## When To Read Which Doc
 
@@ -27,6 +29,8 @@ long gone.
   `addedAt` handling, or collection publish triggers.
 - Read [image-caching.md](image-caching.md) when changing poster/avatar fetch,
   storage, refresh, or serving behavior.
+- Read [maintenance.md](maintenance.md) when adding background cleanup,
+  consistency checks, pruning, or other housekeeping tasks.
 
 ## Maintenance Rule
 

--- a/docs/image-caching.md
+++ b/docs/image-caching.md
@@ -146,6 +146,16 @@ Scans the cache directory and deletes any `.jpg` file whose web path is not
 present in `image_cache.local_web_path`. Safe to call at any time — only
 removes files with no matching metadata row.
 
+### `runMaintenanceTasks()`
+
+Performs image-cache housekeeping used by the daily `Maintenance Tasks` job:
+
+1. delete orphaned watchlist poster rows from `image_cache`
+2. prune any local files no longer referenced by metadata
+
+This cleanup is intentionally scoped to watchlist-owned poster cache entries.
+Avatar cache rows are left alone.
+
 ---
 
 ## Stale-while-refresh detail

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,89 @@
+# Maintenance Tasks
+
+This document describes Hubarr's maintenance job, what it is responsible for,
+and how to add new maintenance work in the future.
+
+## Overview
+
+Hubarr has a dedicated `Maintenance Tasks` background job for housekeeping work
+that should run automatically but does not need to happen inline with a user
+flow or sync pass.
+
+Current schedule:
+
+- `Maintenance Tasks` — daily at `5:30 AM`
+
+The job is surfaced in `Settings → Jobs`, persists its last-run state like the
+other scheduler-managed jobs, and can also be triggered manually with `Run Now`.
+
+## Current Tasks
+
+At the moment the maintenance job performs image-cache cleanup for watchlist
+posters:
+
+1. Find `image_cache` rows where:
+   - `kind = 'poster'`
+   - `entity_id` no longer matches any current `watchlist_cache.plex_item_id`
+2. Delete those orphaned metadata rows.
+3. Prune any local files in `/config/image-cache/` that are no longer
+   referenced by any remaining `image_cache.local_web_path`.
+
+This keeps watchlist-owned derived poster data aligned with the current
+watchlist state without touching unrelated caches such as avatars or
+`watchlist_activity_cache`.
+
+## How It Fits Together
+
+The maintenance flow is intentionally layered:
+
+- `src/server/services.ts`
+  owns the top-level `runMaintenanceTasks()` workflow and job-level logging
+- `src/server/image-cache.ts`
+  owns image-cache-specific maintenance steps
+- `src/server/db/image-cache.ts`
+  owns the SQL that identifies and deletes orphaned poster rows
+
+That split keeps the scheduler job generic while still letting each subsystem
+own its own cleanup logic.
+
+## Logging Expectations
+
+Maintenance work should be observable in production.
+
+For each task:
+
+- log when the overall maintenance job starts and finishes
+- log meaningful counts for rows/files/items removed
+- use `debug` when nothing needed to be done
+- use `warn` or `error` when cleanup fails or only partially succeeds
+
+The goal is to make housekeeping visible without making the logs noisy when the
+system is already clean.
+
+## Adding New Maintenance Tasks
+
+When adding a new maintenance task in the future:
+
+1. Decide whether the work is true maintenance.
+   Use this job for cleanup, pruning, retention, repair, or consistency checks
+   that can safely happen later. Do not put user-visible sync logic here if it
+   needs to happen immediately to keep core state correct.
+2. Add the subsystem-specific logic near the subsystem that owns the data.
+   For example, image-cache cleanup belongs in `image-cache.ts`, not as raw SQL
+   directly inside the scheduler registration.
+3. Call that logic from `HubarrServices.runMaintenanceTasks()`.
+4. Add intentional logging with counts and outcomes.
+5. Add or update tests that prove the task removes only the intended data.
+6. Update this document if the maintenance job gains a new responsibility.
+
+## Design Rule
+
+`Maintenance Tasks` is a bucket for scheduled housekeeping, not a place to hide
+unstructured miscellaneous logic.
+
+Each task should still have:
+
+- one clear owner
+- explicit scope
+- tests where practical
+- docs when the behavior is long-lived or non-obvious

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -12,6 +12,7 @@ Hubarr uses separate background jobs so each job has one clear responsibility:
 - `Collection Sync`
 - `Refresh Users`
 - `Plex Refresh Token`
+- `Maintenance Tasks`
 
 For a detailed explanation of how the three watchlist-specific jobs work together
 — including date resolution, RSS deduplication, and the activity feed cache —
@@ -61,6 +62,7 @@ The most important data groups are:
 - `Collection Sync` interval
 - `Plex Recently Added Scan` interval
 - `Plex Full Library Scan` interval
+- daily `Maintenance Tasks`
 
 ---
 
@@ -97,6 +99,11 @@ History page.
 
 The persisted last-run timestamp and status used by the Jobs page so run times
 remain truthful across restarts.
+
+#### Maintenance task
+
+Scheduled housekeeping work that keeps derived or cached data tidy without
+changing the main sync flow.
 
 ---
 
@@ -154,6 +161,22 @@ How it works:
 Only this job should perform collection updates. The watchlist sync jobs
 (RSS and GraphQL) trigger a collection sync immediately after processing
 changes — see [docs/watchlist.md](watchlist.md) for details.
+
+---
+
+## Maintenance Tasks
+
+Purpose:
+- run daily housekeeping that is useful for long-term correctness or storage
+  hygiene, but does not need to run inline with a sync
+
+How it works:
+- runs as a separate daily scheduler-managed job
+- delegates task-specific cleanup to the subsystem that owns the data
+- records last-run state so `Settings → Jobs` stays truthful across restarts
+
+For the current task list and extension guidance, see
+[docs/maintenance.md](maintenance.md).
 
 ---
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -849,6 +849,15 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         lastRunStatus: scheduler?.getLastRunStatus("users-discover") ?? null
       },
       {
+        id: "maintenance-tasks",
+        name: "Maintenance Tasks",
+        intervalDescription: "Daily at 5:30 AM",
+        isRunning: scheduler?.isRunning("maintenance-tasks") ?? false,
+        nextRunAt: scheduler?.getNextRunAt("maintenance-tasks") ?? null,
+        lastRunAt: scheduler?.getLastRunAt("maintenance-tasks") ?? null,
+        lastRunStatus: scheduler?.getLastRunStatus("maintenance-tasks") ?? null
+      },
+      {
         id: "rss-sync",
         name: "Watchlist RSS Sync",
         intervalDescription: settings.rssEnabled
@@ -916,6 +925,13 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         res.json({ triggered: true });
       } else if (jobId === "users-discover") {
         const triggered = scheduler?.runNow("users-discover") ?? false;
+        if (!triggered) {
+          res.status(404).json({ error: "Unknown job." });
+          return;
+        }
+        res.json({ triggered: true });
+      } else if (jobId === "maintenance-tasks") {
+        const triggered = scheduler?.runNow("maintenance-tasks") ?? false;
         if (!triggered) {
           res.status(404).json({ error: "Unknown job." });
           return;

--- a/src/server/db/image-cache.ts
+++ b/src/server/db/image-cache.ts
@@ -157,30 +157,17 @@ export function listAllImageCacheWebPaths(db: Database.Database): string[] {
 }
 
 export function deleteOrphanedPosterCacheEntries(db: Database.Database): number {
-  const rows = db.prepare(`
-    SELECT cache_key
-    FROM image_cache ic
-    WHERE ic.kind = 'poster'
+  const result = db.prepare(`
+    DELETE FROM image_cache
+    WHERE kind = 'poster'
       AND NOT EXISTS (
         SELECT 1
         FROM watchlist_cache w
-        WHERE w.plex_item_id = ic.entity_id
+        WHERE w.plex_item_id = entity_id
       )
-  `).all() as Array<{ cache_key: string }>;
+  `).run();
 
-  if (rows.length === 0) {
-    return 0;
-  }
-
-  const del = db.prepare("DELETE FROM image_cache WHERE cache_key = ?");
-
-  db.transaction(() => {
-    for (const row of rows) {
-      del.run(row.cache_key);
-    }
-  })();
-
-  return rows.length;
+  return result.changes;
 }
 
 export function clearImageCacheTable(db: Database.Database): void {

--- a/src/server/db/image-cache.ts
+++ b/src/server/db/image-cache.ts
@@ -156,6 +156,33 @@ export function listAllImageCacheWebPaths(db: Database.Database): string[] {
   return rows.map((r) => r.local_web_path);
 }
 
+export function deleteOrphanedPosterCacheEntries(db: Database.Database): number {
+  const rows = db.prepare(`
+    SELECT cache_key
+    FROM image_cache ic
+    WHERE ic.kind = 'poster'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM watchlist_cache w
+        WHERE w.plex_item_id = ic.entity_id
+      )
+  `).all() as Array<{ cache_key: string }>;
+
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  const del = db.prepare("DELETE FROM image_cache WHERE cache_key = ?");
+
+  db.transaction(() => {
+    for (const row of rows) {
+      del.run(row.cache_key);
+    }
+  })();
+
+  return rows.length;
+}
+
 export function clearImageCacheTable(db: Database.Database): void {
   db.prepare("DELETE FROM image_cache").run();
 }

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -282,6 +282,10 @@ export class HubarrDatabase {
     return imageCacheRepo.listAllImageCacheWebPaths(this.db);
   }
 
+  deleteOrphanedPosterCacheEntries(): number {
+    return imageCacheRepo.deleteOrphanedPosterCacheEntries(this.db);
+  }
+
   clearImageCacheTable(): void {
     imageCacheRepo.clearImageCacheTable(this.db);
   }

--- a/src/server/image-cache.ts
+++ b/src/server/image-cache.ts
@@ -178,6 +178,35 @@ export class ImageCacheService {
   }
 
   /**
+   * Remove watchlist-owned poster metadata rows whose item no longer exists in
+   * watchlist_cache, then delete any now-unreferenced files left on disk.
+   */
+  runMaintenanceTasks(): { orphanedPosterRowsRemoved: number; orphanedFilesRemoved: number } {
+    const orphanedPosterRowsRemoved = this.db.deleteOrphanedPosterCacheEntries();
+
+    if (orphanedPosterRowsRemoved > 0) {
+      this.logger.info("ImageCache: removed orphaned watchlist poster rows", {
+        action: "maintenance",
+        orphanedPosterRowsRemoved
+      });
+    } else {
+      this.logger.debug("ImageCache: no orphaned watchlist poster rows found", {
+        action: "maintenance"
+      });
+    }
+
+    const orphanedFilesRemoved = this.pruneOrphaned();
+
+    this.logger.info("ImageCache: maintenance tasks complete", {
+      action: "maintenance",
+      orphanedPosterRowsRemoved,
+      orphanedFilesRemoved
+    });
+
+    return { orphanedPosterRowsRemoved, orphanedFilesRemoved };
+  }
+
+  /**
    * Delete all files and clear all image_cache metadata rows.
    * Returns the number of files removed.
    */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -77,6 +77,15 @@ scheduler.registerDailyJob({
   }
 });
 
+scheduler.registerDailyJob({
+  id: "maintenance-tasks",
+  hour: 5,
+  minute: 30,
+  task: async () => {
+    services.runMaintenanceTasks();
+  }
+});
+
 // Activity cache — run on startup (full fetch on first run, incremental thereafter)
 services.syncActivityCache().catch((error) => {
   logger.warn("Activity cache sync failed at startup", {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -201,6 +201,21 @@ export class HubarrServices {
     }
   }
 
+  runMaintenanceTasks() {
+    this.logger.info("Maintenance tasks started", {
+      label: "Maintenance Tasks"
+    });
+
+    const result = this.imageCache.runMaintenanceTasks();
+
+    this.logger.info("Maintenance tasks complete", {
+      label: "Maintenance Tasks",
+      ...result
+    });
+
+    return result;
+  }
+
   getManagedUsers() {
     return this.db.listManagedUsers();
   }

--- a/tests/playwright/settings.spec.ts
+++ b/tests/playwright/settings.spec.ts
@@ -45,6 +45,17 @@ test.describe("Settings tabs", () => {
     await expect(page.getByText("Job Name")).toBeVisible();
   });
 
+  test("Jobs tab lists the Maintenance Tasks job", async ({ page }) => {
+    await page.goto("/settings?tab=jobs");
+    await expect(page.getByText("Loading settings...")).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Loading jobs...")).not.toBeVisible({ timeout: 10_000 });
+
+    const row = page.locator("tr", { hasText: "Maintenance Tasks" });
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("Daily at 5:30 AM");
+    await expect(row.getByRole("button", { name: "Run Now", exact: true })).toBeVisible();
+  });
+
   test("About tab shows version and support info", async ({ page }) => {
     await page.goto("/settings?tab=about");
     await expect(page.getByText("Loading settings...")).not.toBeVisible({ timeout: 10_000 });

--- a/tests/server/maintenance.test.ts
+++ b/tests/server/maintenance.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { ImageCacheService } from "../../src/server/image-cache.js";
+import { createTestDatabase } from "./test-db.js";
+
+test("maintenance tasks remove orphaned watchlist poster cache rows and preserve active caches", () => {
+  const { db, cleanup } = createTestDatabase();
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "hubarr-maintenance-test-"));
+
+  try {
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {}
+    };
+    const imageCache = new ImageCacheService(dataDir, db, logger);
+    const cacheDir = path.join(dataDir, "image-cache");
+
+    db.upsertUsers([
+      { plexUserId: "plex-user-1", username: "alice", displayName: "Alice", avatarUrl: null },
+      { plexUserId: "plex-user-2", username: "bob", displayName: "Bob", avatarUrl: null }
+    ]);
+
+    const [alice, bob] = db.listUsers();
+    db.updateUser(alice.id, { enabled: true });
+    db.updateUser(bob.id, { enabled: true });
+
+    db.upsertWatchlistItem(alice.id, {
+      plexItemId: "active-item",
+      title: "Still Watched",
+      type: "movie",
+      year: 2024,
+      releaseDate: "2024-01-01",
+      thumb: "/library/metadata/1/thumb/1",
+      guids: ["plex://movie/active-item"],
+      discoverKey: "/library/metadata/1",
+      source: "graphql",
+      addedAt: "2026-04-13T10:00:00.000Z",
+      matchedRatingKey: null
+    });
+
+    const orphanPosterFilePath = path.join(cacheDir, "orphan-poster.jpg");
+    const activePosterFilePath = path.join(cacheDir, "active-poster.jpg");
+    const avatarFilePath = path.join(cacheDir, "avatar.jpg");
+    fs.writeFileSync(orphanPosterFilePath, "orphan-poster");
+    fs.writeFileSync(activePosterFilePath, "active-poster");
+    fs.writeFileSync(avatarFilePath, "avatar");
+
+    db.upsertImageCacheEntry({
+      cacheKey: "poster:removed-item",
+      kind: "poster",
+      entityId: "removed-item",
+      sourceType: "plex-path",
+      sourceValue: "/library/metadata/2/thumb/2",
+      localFilePath: orphanPosterFilePath,
+      localWebPath: "/images/orphan-poster.jpg",
+      cachedAt: "2026-04-13T10:00:00.000Z",
+      lastRefreshAt: "2026-04-13T10:00:00.000Z",
+      refreshAfter: "2026-04-14T10:00:00.000Z"
+    });
+
+    db.upsertImageCacheEntry({
+      cacheKey: "poster:active-item",
+      kind: "poster",
+      entityId: "active-item",
+      sourceType: "plex-path",
+      sourceValue: "/library/metadata/1/thumb/1",
+      localFilePath: activePosterFilePath,
+      localWebPath: "/images/active-poster.jpg",
+      cachedAt: "2026-04-13T10:00:00.000Z",
+      lastRefreshAt: "2026-04-13T10:00:00.000Z",
+      refreshAfter: "2026-04-14T10:00:00.000Z"
+    });
+
+    db.upsertImageCacheEntry({
+      cacheKey: "avatar:plex-user-1",
+      kind: "avatar",
+      entityId: "plex-user-1",
+      sourceType: "public-url",
+      sourceValue: "https://example.com/avatar.jpg",
+      localFilePath: avatarFilePath,
+      localWebPath: "/images/avatar.jpg",
+      cachedAt: "2026-04-13T10:00:00.000Z",
+      lastRefreshAt: "2026-04-13T10:00:00.000Z",
+      refreshAfter: "2026-04-14T10:00:00.000Z"
+    });
+
+    const result = imageCache.runMaintenanceTasks();
+
+    assert.deepEqual(result, {
+      orphanedPosterRowsRemoved: 1,
+      orphanedFilesRemoved: 1
+    });
+    assert.equal(db.getImageCacheEntry("poster:removed-item"), null);
+    assert.notEqual(db.getImageCacheEntry("poster:active-item"), null);
+    assert.notEqual(db.getImageCacheEntry("avatar:plex-user-1"), null);
+    assert.equal(fs.existsSync(orphanPosterFilePath), false);
+    assert.equal(fs.existsSync(activePosterFilePath), true);
+    assert.equal(fs.existsSync(avatarFilePath), true);
+  } finally {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    cleanup();
+  }
+});


### PR DESCRIPTION
Closes #74

## Summary

This PR adds a dedicated daily `Maintenance Tasks` job so Hubarr can clean up orphaned watchlist-owned poster cache data automatically without tying that cleanup directly to the GraphQL reconciliation path. The new job removes stale poster metadata rows, prunes any now-unreferenced cached image files, and surfaces the maintenance work in `Settings -> Jobs` so it is visible and can be run manually.

## Changes

- Added a maintenance workflow in `src/server/services.ts` and `src/server/image-cache.ts` that deletes orphaned `poster:*` rows from `image_cache`, prunes unreferenced files from `/config/image-cache`, and logs the cleanup counts.
- Added the supporting repository and database plumbing in `src/server/db/image-cache.ts` and `src/server/db/index.ts` to identify poster cache entries whose `entity_id` no longer exists in `watchlist_cache`.
- Registered a new daily `maintenance-tasks` scheduler job in `src/server/index.ts` and exposed it through the existing Jobs API in `src/server/app.ts` so it appears in `Settings > Jobs` and supports `Run Now`.
- Added technical documentation in `docs/maintenance.md` and updated `docs/README.md`, `docs/sync.md`, and `docs/image-caching.md` so the maintenance job and its ownership model are documented for future cleanup tasks.
- Added automated coverage in `tests/server/maintenance.test.ts`, updated the Playwright settings coverage in `tests/playwright/settings.spec.ts`, and documented the new read-only check in `TESTING.md`.

## Test plan

- [x] Run `node --test --import tsx tests/server/maintenance.test.ts tests/server/watchlist-grouping.test.ts`
- [x] Run `npm run check`
- [x] Run `npm run build`
- [x] Run `npx playwright test tests/playwright/settings.spec.ts --grep "Maintenance Tasks job"`
- [x] Build a fresh `hubarr` image from this workspace and recreate the live `hubarr` container with the existing `/opt/hubarr:/config` bind mount, bridge networking, and port `9301` so the deployed instance reflects this branch for manual verification.

🤖 Generated with Codex
