### PR TITLE
feat: track all users watchlist data

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -93,7 +93,7 @@ Read-only. Safe to run against a live instance.
 |---|---|
 | All six tabs are visible | Navigates to `/settings`, asserts all six tab buttons (General, Plex, Collections, Logs, Jobs, About) are rendered |
 | Clicking a tab updates the URL | Clicks Plex, Jobs, and About tabs in turn; asserts the URL gains the expected `?tab=` parameter |
-| General tab shows Startup Sync toggle and History Retention field | Navigates to `/settings?tab=general`, waits for load, asserts both setting labels are visible |
+| General tab shows Track All Users, Startup Sync, and History Retention controls | Navigates to `/settings?tab=general`, waits for load, asserts all three setting labels are visible |
 | Jobs tab shows the jobs table | Navigates to `/settings?tab=jobs`, asserts the "Job Name" column header is visible |
 | Jobs tab lists the Maintenance Tasks job | Navigates to `/settings?tab=jobs`, asserts the `Maintenance Tasks` row is present with its daily schedule and `Run Now` button |
 | About tab shows version and support info | Navigates to `/settings?tab=about`, asserts "About Hubarr" and "Version" headings are visible |
@@ -109,6 +109,7 @@ Read-only. Safe to run against a live instance.
 |---|---|
 | Active users section heading is visible | Asserts the "Active (N)" heading renders |
 | Disabled users accordion toggle is visible | Asserts the "Disabled (N)" toggle button renders |
+| Disabled users never show a Sync Watchlist button | Expands the disabled users section and asserts no `Sync Watchlist` button is rendered there |
 | Refresh Users button is present | Asserts the Refresh Users button renders |
 | Edit modal shows collection ordering override section | Clicks the first user's edit button, asserts the "Collection Ordering" section is visible in the modal, and that the dropdown contains the two watchlist date sort options |
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -85,6 +85,21 @@ Read-only. Safe to run against a live instance.
 
 ---
 
+### Onboarding flow
+
+Not covered by automated tests (requires a fresh unconfigured instance). The flow has four steps:
+
+| Step | What it covers |
+|---|---|
+| 1 — Auth | Plex OAuth sign-in |
+| 2 — Configure Plex | Server URL, port, SSL, and library selection |
+| 3 — General | Track All Users and Startup Sync toggles |
+| 4 — Collections | Collection name pattern and sort order |
+
+Step order is enforced server-side by `getCurrentOnboardingStep` in `src/server/db/settings.ts`.
+
+---
+
 ### `tests/playwright/settings.spec.ts` — Settings tabs
 
 Read-only. Safe to run against a live instance.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -45,6 +45,7 @@ The most important data groups are:
 
 - `Startup Sync`
 - `History Retention`
+- `Track All Users`
 
 #### Collections
 
@@ -81,6 +82,16 @@ in a Plex library.
 
 The job that updates Plex collections and hub visibility from cached Hubarr
 state.
+
+#### Tracked user
+
+A user whose watchlist Hubarr should keep in sync. This always includes enabled
+users, and also includes disabled users when `Track All Users` is enabled.
+
+#### Publishing user
+
+An enabled user that participates in collection publishing, dashboard
+visibility, default watchlist views, and isolation rules.
 
 #### Startup Sync
 
@@ -152,7 +163,7 @@ Purpose:
 - perform all collection and hub-row updates
 
 How it works:
-- loads the cached watchlist state for each enabled user
+- loads the cached watchlist state for each publishing user
 - builds the movie and TV collections for that user from matched items
 - ensures collection labels and sort behavior are correct
 - updates Plex hub visibility settings
@@ -184,6 +195,7 @@ For the current task list and extension guidance, see
 
 - Watchlist items are matched against Plex library items
 - RSS and GraphQL syncs both try to match immediately
+- Background tracking may update disabled users too when `Track All Users` is enabled
 - Plex library scans exist to catch items that appear later
 - Availability is represented by whether a watchlist item has a `matchedRatingKey`
 

--- a/docs/watchlist.md
+++ b/docs/watchlist.md
@@ -21,6 +21,13 @@ The GraphQL sync is the source of truth for what is on a watchlist right now.
 The RSS feeds catch new items quickly between full syncs. The activity feed
 cache fills in when items were added, which GraphQL alone cannot answer.
 
+Hubarr distinguishes between:
+
+- `publishing users` — enabled users that participate in collections, dashboard
+  visibility, default watchlist views, and isolation
+- `tracked users` — publishing users plus disabled users when `Track All Users`
+  is enabled
+
 ---
 
 ## GraphQL Full Sync
@@ -33,7 +40,7 @@ optionally on startup if `fullSyncOnStartup` is enabled.
 
 ### What it does
 
-For each enabled user (self and friends), Hubarr queries the Plex Community
+For each tracked user (self and friends), Hubarr queries the Plex Community
 GraphQL API for their full watchlist. The query paginates in batches of 100
 until all items are retrieved:
 
@@ -79,9 +86,8 @@ watchlist for that user.
 
 ### Ad-hoc sync (button press)
 
-When a sync is triggered manually — either the dashboard "Run Sync" button
-(all users) or the per-user sync button — the flow is extended beyond a plain
-GraphQL fetch:
+When a sync is triggered manually, the flow is extended beyond a plain GraphQL
+fetch:
 
 1. **Activity cache refresh** — the activity feed is fetched incrementally
    before the GraphQL pass, so date resolution uses the freshest available data.
@@ -93,8 +99,10 @@ GraphQL fetch:
 4. **Collection publish** — runs immediately after the sync so Plex collections
    are updated without waiting for the next scheduled publish job.
 
-The per-user sync button fetches the activity cache for all users (the feed is
-global) but scopes the RSS date map to that specific user's author entries.
+- The dashboard "Run Sync" button processes all tracked users.
+- The per-user sync button remains enabled-user only, but still fetches the
+  activity cache for all users (the feed is global) and scopes the RSS date map
+  to that specific user's author entries.
 
 ---
 
@@ -114,7 +122,7 @@ Hubarr maintains two RSS feeds:
 | Feed | Covers | `feedType` |
 |---|---|---|
 | Self watchlist | Admin's own additions only | `watchlist` |
-| Friends watchlist | All enabled friends combined | `friendsWatchlist` |
+| Friends watchlist | All tracked friends combined | `friendsWatchlist` |
 
 On startup both caches are primed with the current feed state. On each poll,
 the feed is diffed against the in-memory cache — only new items (those not seen
@@ -135,9 +143,8 @@ Each RSS item includes:
 - `author` — the Plex UUID of the user who added the item
 
 The `author` field is used to attribute friends-feed items to the correct
-enabled user. Items whose `author` does not match any enabled user are skipped
-by the RSS path — if that user is disabled in Hubarr, they will also not appear
-in the GraphQL sync, so their items are intentionally ignored across both paths.
+tracked user. Items whose `author` does not match any tracked user are skipped
+by the RSS path and left for the next full GraphQL sync.
 
 ### Limitation
 
@@ -156,9 +163,9 @@ processed — one does not silently shadow the other.
 ### Collection publish on new items
 
 When the background RSS poll detects new items and processes them, a collection
-publish is triggered immediately afterwards. Plex collections are updated as
-soon as the RSS item is ingested rather than waiting for the next scheduled
-publish job.
+publish is triggered immediately afterwards. Only enabled users publish
+collections, so disabled tracked users may refresh cached watchlist state
+without becoming visible in Plex or the main Hubarr watchlist views.
 
 ---
 

--- a/src/client/components/PlexConfigForm.tsx
+++ b/src/client/components/PlexConfigForm.tsx
@@ -11,11 +11,13 @@ interface PlexConfigResponse {
 
 export default function PlexConfigForm({
   initialConfig,
+  initialTrackAllUsers = false,
   saveUrl,
   onSaved,
   saveLabel = "Save Plex"
 }: {
   initialConfig: PlexSettingsView | null;
+  initialTrackAllUsers?: boolean;
   saveUrl: string;
   onSaved?: (result: PlexConfigResponse) => void | Promise<void>;
   saveLabel?: string;
@@ -29,6 +31,7 @@ export default function PlexConfigForm({
   const [hostname, setHostname] = useState(initialConfig?.hostname ?? "");
   const [port, setPort] = useState(String(initialConfig?.port ?? 32400));
   const [useSsl, setUseSsl] = useState(initialConfig?.useSsl ?? false);
+  const [trackAllUsers, setTrackAllUsers] = useState(initialTrackAllUsers);
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -75,8 +78,13 @@ export default function PlexConfigForm({
               mode: "manual",
               hostname,
               port: Number(port),
-              useSsl
+              useSsl,
+              trackAllUsers
             };
+
+      if (payload.mode === "preset") {
+        payload.trackAllUsers = trackAllUsers;
+      }
 
       const result = await apiPost<PlexConfigResponse>(saveUrl, payload);
       setSuccess(true);
@@ -164,6 +172,13 @@ export default function PlexConfigForm({
         switchToManual();
         setUseSsl(value);
       }} />
+
+      <ToggleField
+        label="Track All Users"
+        hint="Keep background watchlist tracking running for disabled users too. Disabled users still will not publish collections or appear in normal dashboard/watchlist views."
+        checked={trackAllUsers}
+        onChange={setTrackAllUsers}
+      />
 
       <SaveBar
         saving={saving}

--- a/src/client/components/PlexConfigForm.tsx
+++ b/src/client/components/PlexConfigForm.tsx
@@ -11,13 +11,11 @@ interface PlexConfigResponse {
 
 export default function PlexConfigForm({
   initialConfig,
-  initialTrackAllUsers = false,
   saveUrl,
   onSaved,
   saveLabel = "Save Plex"
 }: {
   initialConfig: PlexSettingsView | null;
-  initialTrackAllUsers?: boolean;
   saveUrl: string;
   onSaved?: (result: PlexConfigResponse) => void | Promise<void>;
   saveLabel?: string;
@@ -31,7 +29,6 @@ export default function PlexConfigForm({
   const [hostname, setHostname] = useState(initialConfig?.hostname ?? "");
   const [port, setPort] = useState(String(initialConfig?.port ?? 32400));
   const [useSsl, setUseSsl] = useState(initialConfig?.useSsl ?? false);
-  const [trackAllUsers, setTrackAllUsers] = useState(initialTrackAllUsers);
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -78,13 +75,8 @@ export default function PlexConfigForm({
               mode: "manual",
               hostname,
               port: Number(port),
-              useSsl,
-              trackAllUsers
+              useSsl
             };
-
-      if (payload.mode === "preset") {
-        payload.trackAllUsers = trackAllUsers;
-      }
 
       const result = await apiPost<PlexConfigResponse>(saveUrl, payload);
       setSuccess(true);
@@ -172,13 +164,6 @@ export default function PlexConfigForm({
         switchToManual();
         setUseSsl(value);
       }} />
-
-      <ToggleField
-        label="Track All Users"
-        hint="Keep background watchlist tracking running for disabled users too. Disabled users still will not publish collections or appear in normal dashboard/watchlist views."
-        checked={trackAllUsers}
-        onChange={setTrackAllUsers}
-      />
 
       <SaveBar
         saving={saving}

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -368,7 +368,15 @@ function RunItems({ items }: { items: SyncRunItem[] }) {
       )}
 
       {/* Match failures */}
-      {failures.length > 0 && <MatchFailuresCollapsible items={failures} />}
+      {failures.length > 0 && (
+        <ItemSectionCollapsible
+          title="unmatched items"
+          count={failures.length}
+          tone="warning"
+          items={failures}
+          renderItem={(item) => <MatchFailureRow key={item.id} item={item} />}
+        />
+      )}
 
       {/* Watchlisted at date unresolved */}
       {unresolved.length > 0 && (
@@ -485,18 +493,6 @@ function MatchFailureRow({ item }: { item: SyncRunItem }) {
         </div>
       )}
     </div>
-  );
-}
-
-function MatchFailuresCollapsible({ items }: { items: SyncRunItem[] }) {
-  return (
-    <ItemSectionCollapsible
-      title="unmatched items"
-      count={items.length}
-      tone="warning"
-      items={items}
-      renderItem={(item) => <MatchFailureRow key={item.id} item={item} />}
-    />
   );
 }
 

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { AlertCircle, CheckCircle, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Clock, XCircle } from "lucide-react";
 import { apiGet } from "../lib/api";
@@ -357,32 +357,28 @@ function RunItems({ items }: { items: SyncRunItem[] }) {
       </div>
 
       {/* Errors */}
-      {errors.map((item) => (
-        <RunItemRow key={item.id} item={item} />
-      ))}
+      {errors.length > 0 && (
+        <ItemSectionCollapsible
+          title="errors"
+          count={errors.length}
+          tone="error"
+          items={errors}
+          renderItem={(item) => <RunItemRow key={item.id} item={item} />}
+        />
+      )}
 
       {/* Match failures */}
-      {failures.length > 0 && (
-        <div>
-          <div className="text-xs text-warning font-medium mb-1.5">Unmatched items ({failures.length})</div>
-          <div className="space-y-1">
-            {failures.map((item) => (
-              <MatchFailureRow key={item.id} item={item} />
-            ))}
-          </div>
-        </div>
-      )}
+      {failures.length > 0 && <MatchFailuresCollapsible items={failures} />}
 
       {/* Watchlisted at date unresolved */}
       {unresolved.length > 0 && (
-        <div>
-          <div className="text-xs text-warning font-medium mb-1.5">Watchlisted At Date Unresolved ({unresolved.length})</div>
-          <div className="space-y-1">
-            {unresolved.map((item) => (
-              <DateUnresolvedRow key={item.id} item={item} />
-            ))}
-          </div>
-        </div>
+        <ItemSectionCollapsible
+          title="watchlisted date unresolved"
+          count={unresolved.length}
+          tone="warning"
+          items={unresolved}
+          renderItem={(item) => <DateUnresolvedRow key={item.id} item={item} />}
+        />
       )}
 
       {/* Successful steps (collapsed by default) */}
@@ -492,6 +488,18 @@ function MatchFailureRow({ item }: { item: SyncRunItem }) {
   );
 }
 
+function MatchFailuresCollapsible({ items }: { items: SyncRunItem[] }) {
+  return (
+    <ItemSectionCollapsible
+      title="unmatched items"
+      count={items.length}
+      tone="warning"
+      items={items}
+      renderItem={(item) => <MatchFailureRow key={item.id} item={item} />}
+    />
+  );
+}
+
 interface DateUnresolvedDetails {
   title?: string;
   type?: string;
@@ -530,6 +538,42 @@ function StepsCollapsible({ items }: { items: SyncRunItem[] }) {
               )}
             </div>
           ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ItemSectionCollapsible({
+  title,
+  count,
+  tone,
+  items,
+  renderItem
+}: {
+  title: string;
+  count: number;
+  tone: "warning" | "error";
+  items: SyncRunItem[];
+  renderItem: (item: SyncRunItem) => ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const toneClass = tone === "error"
+    ? "text-error hover:text-error/80"
+    : "text-warning hover:text-warning/80";
+
+  return (
+    <div>
+      <button
+        onClick={() => setOpen((value) => !value)}
+        className={`flex items-center gap-1 text-xs font-medium transition-colors ${toneClass}`}
+      >
+        {open ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+        {open ? "Hide" : "Show"} {title} ({count})
+      </button>
+      {open && (
+        <div className="mt-2 space-y-1">
+          {items.map(renderItem)}
         </div>
       )}
     </div>

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { Check, ChevronRight } from "lucide-react";
-import { apiGet, apiPost } from "../lib/api";
+import { apiGet, apiPatch, apiPost } from "../lib/api";
 import PlexOAuth from "../lib/plexOAuth";
 import PlexConfigForm from "../components/PlexConfigForm";
 import CollectionsConfigForm from "../components/CollectionsConfigForm";
+import { SaveBar, SectionCard, ToggleField } from "../components/FormControls";
 import type { OnboardingStep, SetupStatusResponse, SettingsResponse } from "../../shared/types";
 
 interface OnboardingProps {
@@ -59,14 +60,18 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
 
   const stepState = useMemo(() => {
     if (step === "auth") {
-      return { authDone: false, plexDone: false };
+      return { authDone: false, plexDone: false, generalDone: false };
     }
     if (step === "plex") {
-      return { authDone: true, plexDone: false };
+      return { authDone: true, plexDone: false, generalDone: false };
+    }
+    if (step === "general") {
+      return { authDone: true, plexDone: true, generalDone: false };
     }
     return {
       authDone: true,
       plexDone: true,
+      generalDone: true,
       collectionsDone: Boolean(setupStatus?.collectionsConfigured)
     };
   }, [setupStatus?.collectionsConfigured, step]);
@@ -85,7 +90,9 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
           <div className="w-8 h-px bg-outline-variant/40" />
           <StepDot number={2} active={step === "plex"} done={stepState.plexDone} label="Configure Plex" />
           <div className="w-8 h-px bg-outline-variant/40" />
-          <StepDot number={3} active={step === "collections"} done={stepState.collectionsDone ?? false} label="Collections" />
+          <StepDot number={3} active={step === "general"} done={stepState.generalDone ?? false} label="General" />
+          <div className="w-8 h-px bg-outline-variant/40" />
+          <StepDot number={4} active={step === "collections"} done={stepState.collectionsDone ?? false} label="Collections" />
         </div>
 
         {step === "auth" && (
@@ -117,9 +124,18 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
         {step === "plex" && (
           <PlexConfigForm
             initialConfig={setupStatus?.plex ?? null}
-            initialTrackAllUsers={settings?.general.trackAllUsers ?? false}
             saveUrl="/api/setup/plex/save"
-            saveLabel="Continue to Collections"
+            saveLabel="Continue to General"
+            onSaved={async () => {
+              await loadSetupState();
+              setStep("general");
+            }}
+          />
+        )}
+
+        {step === "general" && settings && (
+          <GeneralOnboardingStep
+            settings={settings}
             onSaved={async () => {
               await loadSetupState();
               setStep("collections");
@@ -139,6 +155,75 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
         )}
       </div>
     </div>
+  );
+}
+
+function GeneralOnboardingStep({
+  settings,
+  onSaved
+}: {
+  settings: SettingsResponse;
+  onSaved: () => Promise<void>;
+}) {
+  const [trackAllUsers, setTrackAllUsers] = useState(settings.general.trackAllUsers);
+  const [fullSyncOnStartup, setFullSyncOnStartup] = useState(settings.general.fullSyncOnStartup);
+  const [saving, setSaving] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setTrackAllUsers(settings.general.trackAllUsers);
+    setFullSyncOnStartup(settings.general.fullSyncOnStartup);
+  }, [settings.general.fullSyncOnStartup, settings.general.trackAllUsers]);
+
+  async function save() {
+    setSaving(true);
+    setSuccess(false);
+    setError(null);
+    try {
+      await apiPatch("/api/settings", {
+        general: {
+          trackAllUsers,
+          fullSyncOnStartup
+        }
+      });
+      setSuccess(true);
+      await onSaved();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <SectionCard
+      title="General Settings"
+      description="Choose how Hubarr should behave after Plex is connected. You can change these again later in Settings."
+      wide
+    >
+      <div className="space-y-4">
+        <ToggleField
+          label="Track All Users"
+          hint="Keep background watchlist tracking running for disabled users too. Turning this off deletes cached watchlist data for disabled users."
+          checked={trackAllUsers}
+          onChange={setTrackAllUsers}
+        />
+        <ToggleField
+          label="Startup Sync"
+          hint="When Hubarr starts, run a Plex full library scan, then a watchlist GraphQL sync, then a collection sync."
+          checked={fullSyncOnStartup}
+          onChange={setFullSyncOnStartup}
+        />
+      </div>
+      <SaveBar
+        saving={saving}
+        success={success}
+        error={error}
+        onSave={() => void save()}
+        label="Continue to Collections"
+      />
+    </SectionCard>
   );
 }
 

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -117,6 +117,7 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
         {step === "plex" && (
           <PlexConfigForm
             initialConfig={setupStatus?.plex ?? null}
+            initialTrackAllUsers={settings?.general.trackAllUsers ?? false}
             saveUrl="/api/setup/plex/save"
             saveLabel="Continue to Collections"
             onSaved={async () => {

--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -142,7 +142,14 @@ function GeneralTab({
     setError(null);
     setSuccess(false);
     try {
-      await apiPatch("/api/settings", { general: { fullSyncOnStartup: form.fullSyncOnStartup, historyRetentionDays: form.historyRetentionDays, trustProxy: form.trustProxy } });
+      await apiPatch("/api/settings", {
+        general: {
+          fullSyncOnStartup: form.fullSyncOnStartup,
+          historyRetentionDays: form.historyRetentionDays,
+          trackAllUsers: form.trackAllUsers,
+          trustProxy: form.trustProxy
+        }
+      });
       setSuccess(true);
       await onSave();
     } catch (caught) {
@@ -218,6 +225,12 @@ function GeneralTab({
           checked={form.trustProxy}
           onChange={(value) => setForm((current) => ({ ...current, trustProxy: value }))}
           restartRequired
+        />
+        <ToggleField
+          label="Track All Users"
+          hint="Keep background watchlist tracking running for disabled users too. Turning this off deletes cached watchlist data for disabled users."
+          checked={form.trackAllUsers}
+          onChange={(value) => setForm((current) => ({ ...current, trackAllUsers: value }))}
         />
         <ToggleField
           label="Startup Sync"

--- a/src/client/pages/Users.tsx
+++ b/src/client/pages/Users.tsx
@@ -179,7 +179,6 @@ export default function Users() {
               onToggleSelected={() => toggleSelected(user.id)}
               onEdit={() => setEditingId(user.id)}
               onSync={() => void syncUser(user.id)}
-              canOpenWatchlist={user.enabled || Boolean(settings?.general.trackAllUsers)}
               onOpenWatchlist={() => navigate(`/watchlists?user=${user.id}`)}
               onShowNoData={() => setWatchlistInfoUser(user)}
             />
@@ -207,7 +206,6 @@ export default function Users() {
                   onToggleSelected={() => toggleSelected(user.id)}
                   onEdit={() => setEditingId(user.id)}
                   onSync={() => void syncUser(user.id)}
-                  canOpenWatchlist={user.enabled || Boolean(settings?.general.trackAllUsers)}
                   onOpenWatchlist={() => navigate(`/watchlists?user=${user.id}`)}
                   onShowNoData={() => setWatchlistInfoUser(user)}
                 />
@@ -289,7 +287,6 @@ function UserCard({
   onToggleSelected,
   onEdit,
   onSync,
-  canOpenWatchlist,
   onOpenWatchlist,
   onShowNoData
 }: {
@@ -299,7 +296,6 @@ function UserCard({
   onToggleSelected: () => void;
   onEdit: () => void;
   onSync: () => void;
-  canOpenWatchlist: boolean;
   onOpenWatchlist: () => void;
   onShowNoData: () => void;
 }) {
@@ -388,6 +384,17 @@ function WatchlistInfoModal({
   trackAllUsersEnabled: boolean;
   onClose: () => void;
 }) {
+  useEffect(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeydown);
+    return () => document.removeEventListener("keydown", handleKeydown);
+  }, [onClose]);
+
   const detail = !user.enabled && !trackAllUsersEnabled
     ? "No watchlist data is available for this user right now. They are currently disabled in Hubarr and Track All Users is turned off."
     : "No watchlist data can be found for this user. This usually means their watchlist privacy is set to private or they currently have no items in their watchlist.";

--- a/src/client/pages/Users.tsx
+++ b/src/client/pages/Users.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { ChevronDown, ChevronRight, Edit2, Play, RefreshCw, X } from "lucide-react";
 import { apiGet, apiPatch, apiPost } from "../lib/api";
 import { getPlexImageSrc } from "../lib/plexImage";
@@ -21,6 +22,7 @@ const USERS_IDLE_REFRESH_MS = 30_000;
 const USERS_DISCOVER_JOB_ID = "users-discover";
 
 export default function Users() {
+  const navigate = useNavigate();
   const [users, setUsers] = useState<UserRecord[]>([]);
   const [managedUsers, setManagedUsers] = useState<ManagedUserRecord[]>([]);
   const [usersDiscoverJob, setUsersDiscoverJob] = useState<JobInfo | null>(null);
@@ -33,6 +35,7 @@ export default function Users() {
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [disabledOpen, setDisabledOpen] = useState(false);
   const [managedOpen, setManagedOpen] = useState(false);
+  const [watchlistInfoUser, setWatchlistInfoUser] = useState<UserRecord | null>(null);
 
   async function load(background = false) {
     setLoading((current) => current || !background);
@@ -176,6 +179,9 @@ export default function Users() {
               onToggleSelected={() => toggleSelected(user.id)}
               onEdit={() => setEditingId(user.id)}
               onSync={() => void syncUser(user.id)}
+              canOpenWatchlist={user.enabled || Boolean(settings?.general.trackAllUsers)}
+              onOpenWatchlist={() => navigate(`/watchlists?user=${user.id}`)}
+              onShowNoData={() => setWatchlistInfoUser(user)}
             />
           ))}
         </div>
@@ -201,6 +207,9 @@ export default function Users() {
                   onToggleSelected={() => toggleSelected(user.id)}
                   onEdit={() => setEditingId(user.id)}
                   onSync={() => void syncUser(user.id)}
+                  canOpenWatchlist={user.enabled || Boolean(settings?.general.trackAllUsers)}
+                  onOpenWatchlist={() => navigate(`/watchlists?user=${user.id}`)}
+                  onShowNoData={() => setWatchlistInfoUser(user)}
                 />
               ))}
             </div>
@@ -241,6 +250,14 @@ export default function Users() {
           }}
         />
       )}
+
+      {watchlistInfoUser && (
+        <WatchlistInfoModal
+          user={watchlistInfoUser}
+          trackAllUsersEnabled={Boolean(settings?.general.trackAllUsers)}
+          onClose={() => setWatchlistInfoUser(null)}
+        />
+      )}
     </div>
   );
 }
@@ -271,7 +288,10 @@ function UserCard({
   syncing,
   onToggleSelected,
   onEdit,
-  onSync
+  onSync,
+  canOpenWatchlist,
+  onOpenWatchlist,
+  onShowNoData
 }: {
   user: UserRecord;
   selected: boolean;
@@ -279,6 +299,9 @@ function UserCard({
   onToggleSelected: () => void;
   onEdit: () => void;
   onSync: () => void;
+  canOpenWatchlist: boolean;
+  onOpenWatchlist: () => void;
+  onShowNoData: () => void;
 }) {
   const displayName = user.displayNameOverride?.trim() ? user.displayName : user.username;
   const showUsernameHint = Boolean(user.displayNameOverride?.trim());
@@ -295,6 +318,14 @@ function UserCard({
         onChange={onToggleSelected}
         className="absolute top-3 left-3 accent-primary w-4 h-4 cursor-pointer"
       />
+
+      <button
+        onClick={onEdit}
+        className="absolute top-3 right-3 p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors border border-outline-variant/20"
+        title="Edit user"
+      >
+        <Edit2 size={14} />
+      </button>
 
       <Avatar avatarUrl={user.avatarUrl} displayName={displayName} size="w-16 h-16" />
 
@@ -317,7 +348,22 @@ function UserCard({
         )}
       </div>
 
-      <div className="flex items-center gap-1.5 mt-auto pt-1 w-full justify-center flex-wrap">
+      <div className="flex items-center gap-1.5 mt-auto pt-2 w-full justify-center flex-wrap">
+        {user.watchlistItemCount > 0 ? (
+          <button
+            onClick={onOpenWatchlist}
+            className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface text-xs font-medium rounded-lg px-2.5 py-1.5 transition-colors border border-outline-variant/20"
+          >
+            {user.watchlistItemCount} Watchlist {user.watchlistItemCount === 1 ? "Item" : "Items"}
+          </button>
+        ) : (
+          <button
+            onClick={onShowNoData}
+            className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface-variant text-xs font-medium rounded-lg px-2.5 py-1.5 transition-colors border border-outline-variant/20"
+          >
+            No Watchlist Data
+          </button>
+        )}
         {user.enabled && (
           <button
             disabled={syncing}
@@ -328,13 +374,57 @@ function UserCard({
             {syncing ? "Syncing…" : "Sync Watchlist"}
           </button>
         )}
-        <button
-          onClick={onEdit}
-          className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors border border-outline-variant/20"
-          title="Edit user"
-        >
-          <Edit2 size={14} />
-        </button>
+      </div>
+    </div>
+  );
+}
+
+function WatchlistInfoModal({
+  user,
+  trackAllUsersEnabled,
+  onClose
+}: {
+  user: UserRecord;
+  trackAllUsersEnabled: boolean;
+  onClose: () => void;
+}) {
+  const detail = !user.enabled && !trackAllUsersEnabled
+    ? "No watchlist data is available for this user right now. They are currently disabled in Hubarr and Track All Users is turned off."
+    : "No watchlist data can be found for this user. This usually means their watchlist privacy is set to private or they currently have no items in their watchlist.";
+
+  return (
+    <div
+      className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface-container rounded-2xl p-6 w-full max-w-md border border-outline-variant/20 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="font-headline font-semibold text-lg text-on-surface">
+            {user.displayName}
+          </h3>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <p className="text-sm text-on-surface-variant leading-6">
+          {detail}
+        </p>
+
+        <div className="mt-6">
+          <button
+            onClick={onClose}
+            className="w-full bg-primary hover:bg-primary-dim text-on-primary text-sm font-semibold rounded-xl py-2.5 transition-colors"
+          >
+            Close
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -185,6 +185,10 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       showLibraryId: appSettings.defaultShowLibraryId || ""
     });
 
+    if (typeof payload.trackAllUsers === "boolean") {
+      services.updateSettings({ trackAllUsers: payload.trackAllUsers });
+    }
+
     services.upsertSelfUser().catch((err) => {
       logger.warn("Self user upsert failed after Plex settings save", {
         error: err instanceof Error ? err.message : String(err)
@@ -556,6 +560,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       general: {
         fullSyncOnStartup: app.fullSyncOnStartup,
         historyRetentionDays: app.historyRetentionDays,
+        trackAllUsers: app.trackAllUsers,
         trustProxy: app.trustProxy
       },
       sync: {
@@ -577,7 +582,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   app.patch("/api/settings", requireAuth, (req, res) => {
     const body = req.body as {
-      general?: { fullSyncOnStartup?: boolean; historyRetentionDays?: number; trustProxy?: boolean };
+      general?: { fullSyncOnStartup?: boolean; historyRetentionDays?: number; trackAllUsers?: boolean; trustProxy?: boolean };
       collections?: {
         collectionNamePattern?: string;
         collectionSortOrder?: string;
@@ -600,6 +605,9 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       }
       if (body.general.historyRetentionDays !== undefined) {
         patch.historyRetentionDays = Math.max(1, Math.floor(body.general.historyRetentionDays));
+      }
+      if (typeof body.general.trackAllUsers === "boolean") {
+        patch.trackAllUsers = body.general.trackAllUsers;
       }
       if (typeof body.general.trustProxy === "boolean") {
         patch.trustProxy = body.general.trustProxy;
@@ -642,7 +650,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       }
     }
 
-    const updated = db.updateAppSettings(patch);
+    const updated = services.updateSettings(patch);
 
     scheduler?.updateJob("full-sync", {
       intervalMs: updated.reconciliationIntervalMinutes * 60 * 1000,

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -185,10 +185,6 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       showLibraryId: appSettings.defaultShowLibraryId || ""
     });
 
-    if (typeof payload.trackAllUsers === "boolean") {
-      services.updateSettings({ trackAllUsers: payload.trackAllUsers });
-    }
-
     services.upsertSelfUser().catch((err) => {
       logger.warn("Self user upsert failed after Plex settings save", {
         error: err instanceof Error ? err.message : String(err)

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -150,6 +150,10 @@ export class HubarrDatabase {
     return usersRepo.listUsers(this.db);
   }
 
+  listDisabledUserIds(): number[] {
+    return usersRepo.listDisabledUserIds(this.db);
+  }
+
   upsertManagedUsers(
     users: Array<{
       plexUserId: string;
@@ -252,6 +256,10 @@ export class HubarrDatabase {
 
   clearActivityCache(): number {
     return watchlistRepo.clearActivityCache(this.db);
+  }
+
+  deleteWatchlistItemsForUsers(userIds: number[]): number {
+    return watchlistRepo.deleteWatchlistItemsForUsers(this.db, userIds);
   }
 
   // -------------------------------------------------------------------------

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -131,7 +131,7 @@ export function getCurrentOnboardingStep(db: Database.Database): OnboardingStep 
 
   const appSettings = getAppSettings(db);
   if (!appSettings.defaultMovieLibraryId || !appSettings.defaultShowLibraryId) {
-    return "collections";
+    return "general";
   }
 
   return "collections";

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -19,6 +19,7 @@ export const defaultAppSettings: AppSettings = {
   activityCacheFetchIntervalMinutes: 60,
   rssPollIntervalSeconds: 300,
   rssEnabled: true,
+  trackAllUsers: false,
   collectionPublishIntervalMinutes: 5,
   plexRecentlyAddedScanIntervalMinutes: 5,
   plexFullLibraryScanIntervalMinutes: 1440,

--- a/src/server/db/users.ts
+++ b/src/server/db/users.ts
@@ -100,9 +100,12 @@ export function listUsers(db: Database.Database): UserRecord[] {
         u.collection_name AS collectionName,
         u.collection_sort_order_override AS collectionSortOrderOverride,
         u.last_synced_at AS lastSyncedAt,
-        u.last_sync_error AS lastSyncError
+        u.last_sync_error AS lastSyncError,
+        COUNT(w.id) AS watchlistItemCount
       FROM users u
+      LEFT JOIN watchlist_cache w ON w.user_id = u.id
       LEFT JOIN image_cache ic ON ic.cache_key = 'avatar:' || u.plex_user_id
+      GROUP BY u.id
       ORDER BY u.is_self DESC, u.enabled DESC, LOWER(u.display_name) ASC
     `)
     .all()
@@ -111,6 +114,7 @@ export function listUsers(db: Database.Database): UserRecord[] {
         enabled: number;
         isSelf: number;
         visibilityOverride: string | null;
+        watchlistItemCount: number;
       };
       return {
         ...r,
@@ -174,14 +178,23 @@ export function updateUser(
     id
   );
 
+  if (!next.enabled && !appSettings.trackAllUsers) {
+    db.prepare("DELETE FROM watchlist_cache WHERE user_id = ?").run(id);
+  }
+
   return getUser(db, id);
 }
 
 export function bulkUpdateUsers(db: Database.Database, ids: number[], enabled: boolean): number[] {
   const stmt = db.prepare("UPDATE users SET enabled = ? WHERE id = ?");
+  const appSettings = getAppSettings(db);
+  const deleteWatchlist = db.prepare("DELETE FROM watchlist_cache WHERE user_id = ?");
   db.transaction(() => {
     for (const id of ids) {
       stmt.run(enabled ? 1 : 0, id);
+      if (!enabled && !appSettings.trackAllUsers) {
+        deleteWatchlist.run(id);
+      }
     }
   })();
   return ids;
@@ -218,6 +231,13 @@ export function refreshDerivedCollectionNames(db: Database.Database): void {
 export function markUserSyncResult(db: Database.Database, userId: number, error: string | null): void {
   db.prepare("UPDATE users SET last_synced_at = ?, last_sync_error = ? WHERE id = ?")
     .run(new Date().toISOString(), error, userId);
+}
+
+export function listDisabledUserIds(db: Database.Database): number[] {
+  return db
+    .prepare("SELECT id FROM users WHERE enabled = 0")
+    .all()
+    .map((row) => (row as { id: number }).id);
 }
 
 export function upsertManagedUsers(

--- a/src/server/db/users.ts
+++ b/src/server/db/users.ts
@@ -160,27 +160,32 @@ export function updateUser(
     next.collectionNameOverride ?? null
   );
 
-  db.prepare(`
+  const updateUserRow = db.prepare(`
     UPDATE users
     SET enabled = ?, movie_library_id = ?, show_library_id = ?,
         visibility_override = ?, display_name_override = ?, collection_name_override = ?,
         collection_name = ?, collection_sort_order_override = ?
     WHERE id = ?
-  `).run(
-    next.enabled ? 1 : 0,
-    next.movieLibraryId ?? null,
-    next.showLibraryId ?? null,
-    next.visibilityOverride !== undefined ? JSON.stringify(next.visibilityOverride) : null,
-    next.displayNameOverride ?? null,
-    next.collectionNameOverride ?? null,
-    collectionName,
-    next.collectionSortOrderOverride ?? null,
-    id
-  );
+  `);
+  const deleteWatchlist = db.prepare("DELETE FROM watchlist_cache WHERE user_id = ?");
 
-  if (!next.enabled && !appSettings.trackAllUsers) {
-    db.prepare("DELETE FROM watchlist_cache WHERE user_id = ?").run(id);
-  }
+  db.transaction(() => {
+    updateUserRow.run(
+      next.enabled ? 1 : 0,
+      next.movieLibraryId ?? null,
+      next.showLibraryId ?? null,
+      next.visibilityOverride !== undefined ? JSON.stringify(next.visibilityOverride) : null,
+      next.displayNameOverride ?? null,
+      next.collectionNameOverride ?? null,
+      collectionName,
+      next.collectionSortOrderOverride ?? null,
+      id
+    );
+
+    if (!next.enabled && !appSettings.trackAllUsers) {
+      deleteWatchlist.run(id);
+    }
+  })();
 
   return getUser(db, id);
 }

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -3,6 +3,7 @@ import type Database from "better-sqlite3";
 import type { WatchlistGroupedItem, WatchlistItem, WatchlistPageResponse, WatchlistSortBy } from "../../shared/types.js";
 import { buildGuidMergePlan, mergeRawPayloadGuids } from "./guid-dedupe.js";
 import { getDiscoverKeyForPlexItemId, upsertMediaItemIdentifiers } from "./identifiers.js";
+import { getAppSettings } from "./settings.js";
 
 export function getWatchlistDiscoverKey(db: Database.Database, plexItemId: string): string | null {
   const explicitDiscoverKey = getDiscoverKeyForPlexItemId(db, plexItemId);
@@ -109,6 +110,22 @@ export function getWatchlistGrouped(
 ): WatchlistPageResponse {
   const { userId, mediaType, availability, sortBy = "added-desc", page, pageSize } = options;
   const offset = (page - 1) * pageSize;
+  const appSettings = getAppSettings(db);
+  const selectedUser = userId
+    ? (db.prepare(`
+        SELECT
+          u.id AS userId,
+          COALESCE(u.display_name_override, u.username) AS displayName,
+          ic.local_web_path AS avatarUrl,
+          u.enabled
+        FROM users u
+        LEFT JOIN image_cache ic ON ic.cache_key = 'avatar:' || u.plex_user_id
+        WHERE u.id = ?
+      `).get(userId) as
+        | { userId: number; displayName: string; avatarUrl: string | null; enabled: number }
+        | undefined)
+    : undefined;
+  const allowSelectedDisabledOnly = Boolean(selectedUser && !selectedUser.enabled && appSettings.trackAllUsers);
 
   type RawRow = {
     plex_item_id: string;
@@ -136,10 +153,10 @@ export function getWatchlistGrouped(
       JOIN users f ON f.id = w.user_id
       LEFT JOIN image_cache ip ON ip.cache_key = 'poster:' || w.plex_item_id
       LEFT JOIN image_cache ia ON ia.cache_key = 'avatar:' || f.plex_user_id
-      WHERE f.enabled = 1
+      WHERE ${allowSelectedDisabledOnly ? "f.id = ?" : "f.enabled = 1"}
       ORDER BY w.added_at DESC
     `)
-    .all() as RawRow[];
+    .all(...(allowSelectedDisabledOnly && userId ? [userId] : [])) as RawRow[];
 
   const enabledUsers = db
     .prepare(`
@@ -278,12 +295,30 @@ export function getWatchlistGrouped(
     },
     facets: {
       allUsersCount,
-      users: enabledUsers.map((user) => ({
-        ...user,
-        count: userCounts.get(user.userId) ?? 0
-      })),
+      users: [
+        ...enabledUsers.map((user) => ({
+          ...user,
+          count: userCounts.get(user.userId) ?? 0
+        })),
+        ...(allowSelectedDisabledOnly && selectedUser
+          ? [{
+              userId: selectedUser.userId,
+              displayName: selectedUser.displayName,
+              avatarUrl: selectedUser.avatarUrl,
+              count: userCounts.get(selectedUser.userId) ?? 0
+            }]
+          : [])
+      ],
       media: mediaCounts
-    }
+    },
+    selectedUser: selectedUser
+      ? {
+          userId: selectedUser.userId,
+          displayName: selectedUser.displayName,
+          avatarUrl: selectedUser.avatarUrl,
+          enabled: Boolean(selectedUser.enabled)
+        }
+      : null
   };
 }
 
@@ -340,5 +375,12 @@ export function getActivityCacheDate(
 export function clearActivityCache(db: Database.Database): number {
   const result = db.prepare("DELETE FROM watchlist_activity_cache").run();
   db.prepare("UPDATE job_run_state SET last_run_at = NULL, updated_at = datetime('now') WHERE job_id = 'activity-cache-fetch'").run();
+  return result.changes;
+}
+
+export function deleteWatchlistItemsForUsers(db: Database.Database, userIds: number[]): number {
+  if (userIds.length === 0) return 0;
+  const placeholders = userIds.map(() => "?").join(", ");
+  const result = db.prepare(`DELETE FROM watchlist_cache WHERE user_id IN (${placeholders})`).run(...userIds);
   return result.changes;
 }

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -110,7 +110,6 @@ export function getWatchlistGrouped(
 ): WatchlistPageResponse {
   const { userId, mediaType, availability, sortBy = "added-desc", page, pageSize } = options;
   const offset = (page - 1) * pageSize;
-  const appSettings = getAppSettings(db);
   const selectedUser = userId
     ? (db.prepare(`
         SELECT
@@ -125,7 +124,11 @@ export function getWatchlistGrouped(
         | { userId: number; displayName: string; avatarUrl: string | null; enabled: number }
         | undefined)
     : undefined;
-  const allowSelectedDisabledOnly = Boolean(selectedUser && !selectedUser.enabled && appSettings.trackAllUsers);
+  const allowSelectedDisabledOnly = Boolean(
+    selectedUser &&
+    !selectedUser.enabled &&
+    getAppSettings(db).trackAllUsers
+  );
 
   type RawRow = {
     plex_item_id: string;

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1185,7 +1185,7 @@ export class HubarrServices {
    */
   async pollRss() {
     const runId = this.db.createSyncRun("rss", "RSS sync started.");
-    const { trackedUsers, publishingUsers } = this.getUserScopes();
+    const { settings, trackedUsers, publishingUsers } = this.getUserScopes();
 
     try {
       const plex = this.getPlexIntegration();
@@ -1228,7 +1228,7 @@ export class HubarrServices {
           const newItems = this.selfRssCache.diff(result.items);
           if (newItems.length > 0) {
             this.logger.info("Self RSS feed detected new items", { count: newItems.length });
-            selfProcessed = await this.processSelfRssNewItems(newItems, runId, plex);
+            selfProcessed = await this.processSelfRssNewItems(newItems, runId, plex, settings);
           }
         }
       }
@@ -1302,7 +1302,8 @@ export class HubarrServices {
   private async processSelfRssNewItems(
     newItems: Array<RssFeedItem & { stableKey: string }>,
     runId: number,
-    plex: PlexIntegration
+    plex: PlexIntegration,
+    settings: AppSettings
   ): Promise<number> {
     const selfUser = this.db.listUsers().find((f) => f.isSelf);
 
@@ -1311,7 +1312,6 @@ export class HubarrServices {
       return 0;
     }
 
-    const settings = this.db.getAppSettings();
     if (!selfUser.enabled && !settings.trackAllUsers) {
       this.logger.debug("Self user is not currently tracked, skipping self RSS items");
       return 0;

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -260,13 +260,15 @@ export class HubarrServices {
     };
   }
 
-  private listTrackedUsers() {
+  private getUserScopes() {
     const settings = this.db.getAppSettings();
-    return this.db.listUsers().filter((user) => user.enabled || settings.trackAllUsers);
-  }
-
-  private listPublishingUsers() {
-    return this.db.listUsers().filter((user) => user.enabled);
+    const users = this.db.listUsers();
+    return {
+      settings,
+      users,
+      trackedUsers: users.filter((user) => user.enabled || settings.trackAllUsers),
+      publishingUsers: users.filter((user) => user.enabled)
+    };
   }
 
   private buildWatchlistIdentityMap(items: WatchlistItem[]) {
@@ -349,7 +351,7 @@ export class HubarrServices {
     since?: Date;
   }) {
     const plex = this.getPlexIntegration();
-    const trackedUsers = this.listTrackedUsers();
+    const { trackedUsers } = this.getUserScopes();
     const libraries = new Map<string, { libraryId: string; mediaType: "movie" | "show"; userIds: number[] }>();
 
     for (const friend of trackedUsers) {
@@ -797,13 +799,14 @@ export class HubarrServices {
   async runFullSync() {
     const syncStart = Date.now();
     const runId = this.db.createSyncRun("full", "Full sync started.");
-    const friends = this.listTrackedUsers();
+    const { trackedUsers, publishingUsers } = this.getUserScopes();
+    const friends = trackedUsers;
     const failures: string[] = [];
 
     this.logger.info("Full sync started", {
       userCount: friends.length,
       trackedUsers: friends.length,
-      publishingUsers: this.listPublishingUsers().length
+      publishingUsers: publishingUsers.length
     });
 
     // Refresh self user account info (including avatar) on every full sync
@@ -947,7 +950,8 @@ export class HubarrServices {
   async runPublishPass() {
     const syncStart = Date.now();
     const runId = this.db.createSyncRun("publish", "Collection sync started.");
-    const friends = this.listPublishingUsers();
+    const { publishingUsers } = this.getUserScopes();
+    const friends = publishingUsers;
     const failures: string[] = [];
     const plex = this.getPlexIntegration();
 
@@ -1181,9 +1185,14 @@ export class HubarrServices {
    */
   async pollRss() {
     const runId = this.db.createSyncRun("rss", "RSS sync started.");
+    const { trackedUsers, publishingUsers } = this.getUserScopes();
 
     try {
       const plex = this.getPlexIntegration();
+      this.logger.info("RSS sync started", {
+        trackedUsers: trackedUsers.length,
+        publishingUsers: publishingUsers.length
+      });
 
       // Retry init for any feed not yet primed
       if (!this.selfRssPrimed || !this.usersRssPrimed) {
@@ -1239,7 +1248,12 @@ export class HubarrServices {
           const newItems = this.usersRssCache.diff(result.items);
           if (newItems.length > 0) {
             this.logger.info("Friends RSS feed detected new items", { count: newItems.length });
-            friendsProcessed = await this.processRssNewItems(newItems, runId, plex);
+            friendsProcessed = await this.processRssNewItems(
+              newItems,
+              runId,
+              plex,
+              trackedUsers.filter((user) => !user.isSelf)
+            );
           }
         }
       }
@@ -1297,7 +1311,8 @@ export class HubarrServices {
       return 0;
     }
 
-    if (!this.listTrackedUsers().some((user) => user.id === selfUser.id)) {
+    const settings = this.db.getAppSettings();
+    if (!selfUser.enabled && !settings.trackAllUsers) {
       this.logger.debug("Self user is not currently tracked, skipping self RSS items");
       return 0;
     }
@@ -1419,9 +1434,9 @@ export class HubarrServices {
   private async processRssNewItems(
     newItems: Array<RssFeedItem & { stableKey: string }>,
     runId: number,
-    plex: PlexIntegration
+    plex: PlexIntegration,
+    trackedUsers: UserRecord[]
   ): Promise<number> {
-    const trackedUsers = this.listTrackedUsers().filter((f) => !f.isSelf);
     let processedCount = 0;
 
     for (const item of newItems) {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -260,6 +260,15 @@ export class HubarrServices {
     };
   }
 
+  private listTrackedUsers() {
+    const settings = this.db.getAppSettings();
+    return this.db.listUsers().filter((user) => user.enabled || settings.trackAllUsers);
+  }
+
+  private listPublishingUsers() {
+    return this.db.listUsers().filter((user) => user.enabled);
+  }
+
   private buildWatchlistIdentityMap(items: WatchlistItem[]) {
     const byItemId = new Map<string, WatchlistItem>();
     const byGuid = new Map<string, WatchlistItem>();
@@ -340,10 +349,10 @@ export class HubarrServices {
     since?: Date;
   }) {
     const plex = this.getPlexIntegration();
-    const enabledUsers = this.db.listUsers().filter((friend) => friend.enabled);
+    const trackedUsers = this.listTrackedUsers();
     const libraries = new Map<string, { libraryId: string; mediaType: "movie" | "show"; userIds: number[] }>();
 
-    for (const friend of enabledUsers) {
+    for (const friend of trackedUsers) {
       const effectiveLibraries = this.getEffectiveLibraryIds(friend);
 
       if (effectiveLibraries.movieLibraryId) {
@@ -394,7 +403,7 @@ export class HubarrServices {
       }
 
       for (const friendId of library.userIds) {
-        const friend = enabledUsers.find((entry) => entry.id === friendId);
+        const friend = trackedUsers.find((entry) => entry.id === friendId);
         if (!friend) {
           continue;
         }
@@ -454,9 +463,6 @@ export class HubarrServices {
   }
 
   async syncUser(friend: UserRecord, runId: number, rssDateMap?: Map<string, string>) {
-    if (!friend.enabled) {
-      throw new Error("Friend must be enabled before syncing.");
-    }
     const { movieLibraryId, showLibraryId } = this.getEffectiveLibraryIds(friend);
     if (!movieLibraryId || !showLibraryId) {
       throw new Error("Friend must have both target libraries selected.");
@@ -466,7 +472,8 @@ export class HubarrServices {
     this.logger.info("Starting watchlist sync", {
       userId: friend.id,
       displayName: friend.displayName,
-      isSelf: friend.isSelf
+      isSelf: friend.isSelf,
+      enabled: friend.enabled
     });
 
     const plex = this.getPlexIntegration();
@@ -790,10 +797,14 @@ export class HubarrServices {
   async runFullSync() {
     const syncStart = Date.now();
     const runId = this.db.createSyncRun("full", "Full sync started.");
-    const friends = this.db.listUsers().filter((friend) => friend.enabled);
+    const friends = this.listTrackedUsers();
     const failures: string[] = [];
 
-    this.logger.info("Full sync started", { userCount: friends.length });
+    this.logger.info("Full sync started", {
+      userCount: friends.length,
+      trackedUsers: friends.length,
+      publishingUsers: this.listPublishingUsers().length
+    });
 
     // Refresh self user account info (including avatar) on every full sync
     await this.upsertSelfUser();
@@ -874,6 +885,13 @@ export class HubarrServices {
     if (!friend) {
       throw new Error("Friend not found.");
     }
+    if (!friend.enabled) {
+      this.logger.warn("Manual sync rejected for disabled user", {
+        userId: friend.id,
+        displayName: friend.displayName
+      });
+      throw new Error("Disabled users can only be tracked by background sync.");
+    }
 
     const label = friend.isSelf ? "self" : friend.displayName;
     const runId = this.db.createSyncRun("user", `Manual sync for ${label}.`);
@@ -929,7 +947,7 @@ export class HubarrServices {
   async runPublishPass() {
     const syncStart = Date.now();
     const runId = this.db.createSyncRun("publish", "Collection sync started.");
-    const friends = this.db.listUsers().filter((friend) => friend.enabled);
+    const friends = this.listPublishingUsers();
     const failures: string[] = [];
     const plex = this.getPlexIntegration();
 
@@ -1279,8 +1297,8 @@ export class HubarrServices {
       return 0;
     }
 
-    if (!selfUser.enabled) {
-      this.logger.debug("Self user is not enabled, skipping self RSS items");
+    if (!this.listTrackedUsers().some((user) => user.id === selfUser.id)) {
+      this.logger.debug("Self user is not currently tracked, skipping self RSS items");
       return 0;
     }
 
@@ -1403,19 +1421,19 @@ export class HubarrServices {
     runId: number,
     plex: PlexIntegration
   ): Promise<number> {
-    const enabledUsers = this.db.listUsers().filter((f) => f.enabled && !f.isSelf);
+    const trackedUsers = this.listTrackedUsers().filter((f) => !f.isSelf);
     let processedCount = 0;
 
     for (const item of newItems) {
       const friend = item.author
-        ? enabledUsers.find((f) => f.plexUserId === item.author)
+        ? trackedUsers.find((f) => f.plexUserId === item.author)
         : null;
 
       if (!friend) {
-        this.logger.warn("RSS item author not matched to any enabled friend — will be caught by full sync", {
+        this.logger.warn("RSS item author not matched to any tracked friend — will be caught by full sync", {
           title: item.title,
           author: item.author || "(none)",
-          knownFriendIds: enabledUsers.map((f) => f.plexUserId)
+          knownFriendIds: trackedUsers.map((f) => f.plexUserId)
         });
         continue;
       }
@@ -1518,6 +1536,7 @@ export class HubarrServices {
 
       this.logger.info("RSS item cached", {
         userId: friend.id,
+        enabled: friend.enabled,
         title: item.title,
         type: item.type,
         matchedRatingKey: matchedRatingKey ?? "(not in library)"
@@ -1565,7 +1584,17 @@ export class HubarrServices {
   }
 
   updateSettings(patch: Partial<AppSettings>) {
-    return this.db.updateAppSettings(patch);
+    const current = this.db.getAppSettings();
+    const next = this.db.updateAppSettings(patch);
+
+    if (current.trackAllUsers && !next.trackAllUsers) {
+      const removed = this.db.deleteWatchlistItemsForUsers(this.db.listDisabledUserIds());
+      this.logger.info("Disabled-user watchlist cache deleted after Track All Users was disabled", {
+        removed
+      });
+    }
+
+    return next;
   }
 
   async resetCollections() {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,7 +7,7 @@ export interface BootstrapStatus {
   hasActiveSession: boolean;
 }
 
-export type OnboardingStep = "auth" | "plex" | "collections";
+export type OnboardingStep = "auth" | "plex" | "general" | "collections";
 
 export interface SessionUser {
   plexId: string;
@@ -389,5 +389,4 @@ export interface PlexConfigPayload {
   hostname?: string;
   port?: number;
   useSsl?: boolean;
-  trackAllUsers?: boolean;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -58,6 +58,7 @@ export interface AppSettings {
   activityCacheFetchIntervalMinutes: number;
   rssPollIntervalSeconds: number;
   rssEnabled: boolean;
+  trackAllUsers: boolean;
   collectionPublishIntervalMinutes: number;
   plexRecentlyAddedScanIntervalMinutes: number;
   plexFullLibraryScanIntervalMinutes: number;
@@ -89,6 +90,7 @@ export interface UserRecord {
   collectionSortOrderOverride: CollectionSortOrder | null;
   lastSyncedAt: string | null;
   lastSyncError: string | null;
+  watchlistItemCount: number;
 }
 
 export interface ManagedUserRecord {
@@ -179,6 +181,12 @@ export interface WatchlistPageResponse {
       show: number;
     };
   };
+  selectedUser: {
+    userId: number;
+    displayName: string;
+    avatarUrl: string | null;
+    enabled: boolean;
+  } | null;
 }
 
 export interface PlexCollectionRecord {
@@ -344,6 +352,7 @@ export interface SettingsResponse {
   general: {
     fullSyncOnStartup: boolean;
     historyRetentionDays: number;
+    trackAllUsers: boolean;
     trustProxy: boolean;
   };
   sync: {
@@ -380,4 +389,5 @@ export interface PlexConfigPayload {
   hostname?: string;
   port?: number;
   useSsl?: boolean;
+  trackAllUsers?: boolean;
 }

--- a/tests/playwright/settings.spec.ts
+++ b/tests/playwright/settings.spec.ts
@@ -31,9 +31,10 @@ test.describe("Settings tabs", () => {
     await expect(page).toHaveURL(/[?&]tab=about/);
   });
 
-  test("General tab shows Startup Sync toggle and History Retention field", async ({ page }) => {
+  test("General tab shows Track All Users, Startup Sync, and History Retention controls", async ({ page }) => {
     await page.goto("/settings?tab=general");
     await expect(page.getByText("Loading settings...")).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Track All Users")).toBeVisible();
     await expect(page.getByText("Startup Sync")).toBeVisible();
     await expect(page.getByText("History Retention")).toBeVisible();
   });

--- a/tests/playwright/users.spec.ts
+++ b/tests/playwright/users.spec.ts
@@ -23,6 +23,18 @@ test.describe("Users page structure", () => {
     await expect(page.getByRole("button", { name: /^Disabled \(/ })).toBeVisible();
   });
 
+  test("Disabled users never show a Sync Watchlist button", async ({ page }) => {
+    const disabledToggle = page.getByRole("button", { name: /^Disabled \(/ });
+    await expect(disabledToggle).toBeVisible();
+    await disabledToggle.click();
+
+    const disabledSection = page.locator("div.mb-6").filter({
+      has: page.getByRole("button", { name: /^Disabled \(/ })
+    }).first();
+
+    await expect(disabledSection.getByRole("button", { name: /sync watchlist/i })).toHaveCount(0);
+  });
+
   test("Refresh Users button is present", async ({ page }) => {
     await expect(page.getByRole("button", { name: /refresh users/i })).toBeVisible();
   });


### PR DESCRIPTION
Closes #56

## Summary

Adds a new `Track All Users` mode so Hubarr can keep background watchlist data fresh for disabled users without treating them as active publishing users. Disabled users stay out of dashboard stats, default watchlist browsing, manual per-user sync, collection publishing, and isolation, but admins can still inspect their cached watchlist data through the Users page and direct watchlist links.

This also tightens up the surrounding UX by surfacing a clear no-data state for users whose watchlists are empty or privately hidden, and by collapsing large history detail sections by default so full-sync runs are easier to review.

## Changes

- updates shared settings/types and server settings handling to add `trackAllUsers`, expose it in onboarding and Settings > General, and purge disabled-user watchlist cache when the setting is turned off
- splits sync behavior into tracked vs publishing users so full sync, RSS ingestion, and availability matching can include disabled users in the background while publish/dashboard/default watchlist flows remain enabled-only
- extends the Users page with watchlist status actions, hidden direct access to disabled-user watchlists, a no-data explanation modal, and a tidier card layout
- updates watchlist querying so disabled tracked users only appear when explicitly targeted, while normal watchlist browsing and filters remain enabled-only
- improves History detail rendering by collapsing large unmatched/error/date-unresolved sections by default
- updates technical docs for the new tracked-vs-publishing behavior and adds read-only Playwright coverage for the new settings/users UI expectations

## Test plan

- [x] `npm run check`
- [x] `npm run build`
- [x] `npm run test:e2e` 
- [x] Rebuild the live `hubarr` Docker image from this branch and recreate the live container with the same `/opt/hubarr:/config`, bridge networking, port mapping, and restart policy
- [x] Manually verify Users and History UI changes on the live instance
- [ ] Note: one unrelated Playwright assertion still needs follow-up in issue #80

🤖 Generated with Codex
