### PR TITLE
fix: update dashboard live-refresh sync label assertion

### DIFF
--- a/tests/playwright/live-refresh.spec.ts
+++ b/tests/playwright/live-refresh.spec.ts
@@ -47,7 +47,7 @@ test.describe("Live refresh", () => {
     const runningRun = await waitForNewRun(request, "publish", latestBefore?.startedAt ?? null, "running");
     const completedRun = await waitForRunCompletion(request, "publish", runningRun.startedAt);
     await expect(recentSyncsPanel).not.toHaveText(panelTextBefore, { timeout: 30_000 });
-    await expect(recentSyncsPanel).toContainText("Publish", { timeout: 30_000 });
+    await expect(recentSyncsPanel).toContainText("Collection", { timeout: 30_000 });
     await expect(recentSyncsPanel).toContainText("success", { timeout: 30_000 });
     await expect(recentSyncsPanel).toContainText(compactDashboardSummary(completedRun), { timeout: 30_000 });
   });


### PR DESCRIPTION
## Summary

This PR fixes issue #80 by updating the live-refresh Playwright dashboard assertion to match the current sync label shown in the Recent Syncs panel. The dashboard refresh behavior was already correct; only the stale legacy wording in the test was causing the failure.

## Changes

- Updated `tests/playwright/live-refresh.spec.ts` so the dashboard recent-sync assertion expects `Collection` instead of the old `Publish` label.
- Kept the rest of the test flow intact so it still verifies the panel refreshes after a background collection sync starts and completes.

## Test plan

- [x] Run `npm run check`
- [x] Run `npm run build`
- [x] Run `npx playwright test tests/playwright/live-refresh.spec.ts --grep "Dashboard recent syncs updates after a background collection sync starts and finishes"`

Closes #80

🤖 Generated with Codex