### PR TITLE
fix: fix Plex OAuth popup not closing on mobile through reverse proxy

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -20,12 +20,6 @@ interface AppState {
 
 export default function App() {
   const location = useLocation();
-  const navigate = useNavigate();
-  const [state, setState] = useState<AppState>({
-    bootstrap: null,
-    user: null,
-    loading: true
-  });
 
   // Keep the Plex popup on a lightweight same-origin page so mobile browsers
   // treat the auth window as a user-opened tab before it navigates to plex.tv.
@@ -36,6 +30,17 @@ export default function App() {
   if (location.pathname === "/login/plex/done") {
     return <PlexPopupDone />;
   }
+
+  return <MainApp />;
+}
+
+function MainApp() {
+  const navigate = useNavigate();
+  const [state, setState] = useState<AppState>({
+    bootstrap: null,
+    user: null,
+    loading: true
+  });
 
   async function loadState() {
     try {
@@ -180,7 +185,7 @@ function PlexPopupDone() {
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
-      <RefreshCw size={28} className="animate-spin text-primary" aria-label="Loading" />
+      <p className="text-on-surface-variant text-sm">Authentication complete. You can close this tab.</p>
     </div>
   );
 }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { RefreshCw } from "lucide-react";
 import { apiGet, apiPost } from "./lib/api";
 import Layout from "./components/Layout";
 import Login from "./pages/Login";
@@ -18,12 +19,23 @@ interface AppState {
 }
 
 export default function App() {
+  const location = useLocation();
   const navigate = useNavigate();
   const [state, setState] = useState<AppState>({
     bootstrap: null,
     user: null,
     loading: true
   });
+
+  // Keep the Plex popup on a lightweight same-origin page so mobile browsers
+  // treat the auth window as a user-opened tab before it navigates to plex.tv.
+  if (location.pathname === "/login/plex/loading") {
+    return <PlexPopupLoading />;
+  }
+
+  if (location.pathname === "/login/plex/done") {
+    return <PlexPopupDone />;
+  }
 
   async function loadState() {
     try {
@@ -142,5 +154,33 @@ export default function App() {
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Route>
     </Routes>
+  );
+}
+
+function PlexPopupLoading() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <RefreshCw size={28} className="animate-spin text-primary" aria-label="Loading" />
+    </div>
+  );
+}
+
+function PlexPopupDone() {
+  useEffect(() => {
+    window.close();
+
+    const retryId = window.setTimeout(() => {
+      window.close();
+    }, 250);
+
+    return () => {
+      window.clearTimeout(retryId);
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <RefreshCw size={28} className="animate-spin text-primary" aria-label="Loading" />
+    </div>
   );
 }

--- a/src/client/lib/plexOAuth.ts
+++ b/src/client/lib/plexOAuth.ts
@@ -82,13 +82,10 @@ class PlexOAuth {
       "context[device][platform]": this.headers["X-Plex-Platform"],
       "context[device][layout]": "desktop",
       code: this.pin.code,
-      // After auth, plex.tv redirects the popup to this URL. The page calls
-      // window.close() on itself, which is the only reliable way to close a
-      // popup on mobile browsers — calling popup.close() from the opener is
-      // blocked on some mobile browsers once the popup has navigated cross-origin.
-      // Using window.location.origin means this works correctly behind a reverse
-      // proxy without any extra configuration.
-      forwardUrl: `${window.location.origin}/plex-auth-done`
+      // No forwardUrl — after auth the popup stays on plex.tv. The opener
+      // closes it via popup.close() once polling detects the token. This is
+      // more reliable than redirecting back and calling window.close() in the
+      // popup itself, which mobile browsers block after cross-origin navigation.
     };
 
     if (this.popup) {
@@ -100,9 +97,9 @@ class PlexOAuth {
 
   private async pollForToken(): Promise<string> {
     return new Promise((resolve, reject) => {
-      // On mobile, the popup may close (via window.close() in the forwardUrl page, or
-      // manually) a moment before the Plex API returns the token. Allow a few extra
-      // polls after detecting closure so we don't reject a successful auth too early.
+      // The user may close the popup manually before the token arrives. Allow a
+      // few extra polls after detecting closure before giving up, in case the
+      // Plex API response is slightly delayed.
       let gracePollsLeft = 5;
 
       const poll = async () => {

--- a/src/client/lib/plexOAuth.ts
+++ b/src/client/lib/plexOAuth.ts
@@ -105,9 +105,7 @@ class PlexOAuth {
       forwardUrl: `${window.location.origin}/login/plex/done`
     };
 
-    if (this.popup) {
-      this.popup.location.href = `https://app.plex.tv/auth/#!?${encodeParams(params)}`;
-    }
+    this.popup.location.href = `https://app.plex.tv/auth/#!?${encodeParams(params)}`;
 
     return this.pollForToken();
   }
@@ -129,6 +127,9 @@ class PlexOAuth {
           const response = await fetch(`https://plex.tv/api/v2/pins/${this.pin.id}`, {
             headers: this.headers
           });
+          if (!response.ok) {
+            throw new Error(`Failed to poll Plex PIN: ${response.status}`);
+          }
           const data = (await response.json()) as { authToken?: string | null };
 
           if (data.authToken) {
@@ -136,7 +137,8 @@ class PlexOAuth {
             this.popup = undefined;
             resolve(data.authToken);
           } else if (this.popup?.closed) {
-            if (gracePollsLeft-- > 0) {
+            if (gracePollsLeft > 0) {
+              gracePollsLeft -= 1;
               setTimeout(poll, 1000);
             } else {
               reject(new Error("Plex login popup was closed before authorization completed."));

--- a/src/client/lib/plexOAuth.ts
+++ b/src/client/lib/plexOAuth.ts
@@ -81,7 +81,14 @@ class PlexOAuth {
       "context[device][version]": this.headers["X-Plex-Version"],
       "context[device][platform]": this.headers["X-Plex-Platform"],
       "context[device][layout]": "desktop",
-      code: this.pin.code
+      code: this.pin.code,
+      // After auth, plex.tv redirects the popup to this URL. The page calls
+      // window.close() on itself, which is the only reliable way to close a
+      // popup on mobile browsers — calling popup.close() from the opener is
+      // blocked on some mobile browsers once the popup has navigated cross-origin.
+      // Using window.location.origin means this works correctly behind a reverse
+      // proxy without any extra configuration.
+      forwardUrl: `${window.location.origin}/plex-auth-done`
     };
 
     if (this.popup) {
@@ -93,6 +100,11 @@ class PlexOAuth {
 
   private async pollForToken(): Promise<string> {
     return new Promise((resolve, reject) => {
+      // On mobile, the popup may close (via window.close() in the forwardUrl page, or
+      // manually) a moment before the Plex API returns the token. Allow a few extra
+      // polls after detecting closure so we don't reject a successful auth too early.
+      let gracePollsLeft = 5;
+
       const poll = async () => {
         try {
           if (!this.pin || !this.headers) {
@@ -110,7 +122,11 @@ class PlexOAuth {
             this.popup = undefined;
             resolve(data.authToken);
           } else if (this.popup?.closed) {
-            reject(new Error("Plex login popup was closed before authorization completed."));
+            if (gracePollsLeft-- > 0) {
+              setTimeout(poll, 1000);
+            } else {
+              reject(new Error("Plex login popup was closed before authorization completed."));
+            }
           } else {
             setTimeout(poll, 1000);
           }

--- a/src/client/lib/plexOAuth.ts
+++ b/src/client/lib/plexOAuth.ts
@@ -23,6 +23,12 @@ function encodeParams(data: Record<string, string>): string {
     .join("&");
 }
 
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 class PlexOAuth {
   private headers?: PlexHeaders;
   private pin?: PlexPin;
@@ -57,19 +63,30 @@ class PlexOAuth {
   public preparePopup(): void {
     const w = 600;
     const h = 700;
-    const left = window.screenLeft + window.innerWidth / 2 - w / 2;
-    const top = window.screenTop + window.innerHeight / 2 - h / 2;
+    const leftSource = window.screenLeft ?? window.screenX;
+    const topSource = window.screenTop ?? window.screenY;
+    const left = leftSource + window.innerWidth / 2 - w / 2;
+    const top = topSource + window.innerHeight / 2 - h / 2;
     const newWindow = window.open(
-      "about:blank",
+      "/login/plex/loading",
       "Plex Auth",
       `scrollbars=yes,width=${w},height=${h},top=${top},left=${left}`
     );
     if (newWindow) {
+      newWindow.focus();
       this.popup = newWindow;
     }
   }
 
   public async login(): Promise<string> {
+    if (!this.popup || this.popup.closed) {
+      throw new Error("Plex login popup could not be opened. Check your browser popup settings and try again.");
+    }
+
+    // Give mobile browsers a moment to commit the user-opened same-origin tab
+    // before redirecting it to the cross-origin Plex auth page.
+    await wait(1500);
+
     this.initHeaders();
     await this.getPin();
 
@@ -82,10 +99,10 @@ class PlexOAuth {
       "context[device][platform]": this.headers["X-Plex-Platform"],
       "context[device][layout]": "desktop",
       code: this.pin.code,
-      // No forwardUrl — after auth the popup stays on plex.tv. The opener
-      // closes it via popup.close() once polling detects the token. This is
-      // more reliable than redirecting back and calling window.close() in the
-      // popup itself, which mobile browsers block after cross-origin navigation.
+      // Redirect back to a Hubarr-owned page so the popup can close itself
+      // after Plex auth instead of relying on the opener to close a
+      // cross-origin Plex tab, which mobile browsers often block.
+      forwardUrl: `${window.location.origin}/login/plex/done`
     };
 
     if (this.popup) {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1044,6 +1044,23 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   });
 
   // ---------------------------------------------------------------------------
+  // Plex OAuth popup self-close endpoint
+  // ---------------------------------------------------------------------------
+
+  // After Plex auth completes, plex.tv redirects the popup to this URL
+  // (set as forwardUrl in the OAuth params). The page calls window.close() on
+  // itself, which is the only reliable way to dismiss the popup on mobile —
+  // calling popup.close() from the opener is blocked by some mobile browsers
+  // once the window has navigated to a cross-origin page.
+  app.get("/plex-auth-done", (_req, res) => {
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.send(
+      "<!DOCTYPE html><html><head><title>Plex Auth</title></head>" +
+        "<body><script>window.close();</script></body></html>"
+    );
+  });
+
+  // ---------------------------------------------------------------------------
   // Static file serving
   // ---------------------------------------------------------------------------
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1044,23 +1044,6 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   });
 
   // ---------------------------------------------------------------------------
-  // Plex OAuth popup self-close endpoint
-  // ---------------------------------------------------------------------------
-
-  // After Plex auth completes, plex.tv redirects the popup to this URL
-  // (set as forwardUrl in the OAuth params). The page calls window.close() on
-  // itself, which is the only reliable way to dismiss the popup on mobile —
-  // calling popup.close() from the opener is blocked by some mobile browsers
-  // once the window has navigated to a cross-origin page.
-  app.get("/plex-auth-done", (_req, res) => {
-    res.setHeader("Content-Type", "text/html; charset=utf-8");
-    res.send(
-      "<!DOCTYPE html><html><head><title>Plex Auth</title></head>" +
-        "<body><script>window.close();</script></body></html>"
-    );
-  });
-
-  // ---------------------------------------------------------------------------
   // Static file serving
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

This PR fixes the Plex OAuth flow on mobile by making Hubarr handle the popup more like Seerr does, while also keeping the extra polling grace period that protects against Plex token timing races.

Instead of opening `about:blank` and immediately relying on the opener to close a cross-origin Plex tab, Hubarr now opens a same-origin loading page first, waits briefly so mobile browsers treat it as a user-opened popup/tab, redirects to Plex for authentication, and then sends Plex back to a Hubarr-owned completion page that closes itself. The result is that both desktop and mobile complete sign-in cleanly, including the mobile case where the Plex tab previously stayed open after successful login.

## Changes

- `src/client/lib/plexOAuth.ts`
  - Opens the Plex auth popup to `/login/plex/loading` instead of `about:blank`, focuses it, and keeps the short `1500ms` delay before redirecting to Plex so mobile browsers preserve the popup/tab correctly.
  - Adds a clearer error when the popup cannot be opened at all.
  - Passes `forwardUrl: ${window.location.origin}/login/plex/done` to Plex so the auth window returns to a Hubarr-owned page that can close itself reliably.
  - Keeps the extra post-close polling grace period so Hubarr does not reject logins if Plex returns the auth token a moment after the popup closes.

- `src/client/App.tsx`
  - Adds a lightweight public `/login/plex/loading` route that shows a spinner-only loading state while the popup is being handed off to Plex.
  - Adds a lightweight public `/login/plex/done` route that attempts to close the popup from inside the Hubarr-owned page after Plex redirects back.

## Test plan

- [x] Desktop / direct access: click Plex login, authenticate, confirm the popup closes and Hubarr finishes sign-in.
- [x] Desktop / proxied access: confirm the same flow works without regression.
- [x] Mobile / direct access: click Plex login, confirm the spinner page appears briefly, authenticate, and confirm the Plex tab closes and Hubarr ends up signed in.
- [x] Mobile / proxied access: confirm the same flow works when accessing Hubarr via the proxied hostname.
- [x] Confirm the previous mobile failure mode is gone: after successful Plex auth, the Plex window/tab no longer stays open and Hubarr no longer reports that the popup was closed too early.

Closes #83

🤖 Generated with Codex
