### PR TITLE
feat: improve history job detail display

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -164,5 +164,8 @@ jobs on the server.
 
 | Test | What it checks |
 |---|---|
+| Running history rows show `Just now` and live elapsed text | Opens `/history` with a stubbed running sync and verifies the row shows capitalized relative time plus a live `Running for ...` duration |
 | History list keeps polling while the tab is hidden when a run is active | Opens `/history` with a stubbed running sync, switches to another tab, and verifies the hidden History page still polls `/api/history` |
 | Expanded history details keep polling while the tab is hidden when a run is active | Expands a stubbed running History row, switches to another tab, and verifies the hidden page keeps polling `/api/history/:runId` for updated details |
+| Expanded errors stay collapsed by default and grouped steps render readable labels | Opens a stubbed failed History run, verifies the errors section stays collapsed initially, and checks that repeated low-level steps render as grouped human-readable labels |
+| RSS runs show feed checks and descriptive item labels | Opens a stubbed RSS History run and verifies feed-check steps and found-item labels render instead of a generic empty-details state |

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -220,7 +220,10 @@ History stores higher-level sync runs such as:
 - `publish`
 
 It also stores per-run detail rows for actions such as watchlist fetches, match
-failures, unresolved `addedAt` dates, and collection updates.
+failures, unresolved `addedAt` dates, collection updates, and RSS feed checks.
+The History page groups those raw rows into more readable operational steps so
+the UI reflects what a job actually did rather than dumping every low-level
+event verbatim.
 
 ### Jobs
 

--- a/src/client/lib/utils.ts
+++ b/src/client/lib/utils.ts
@@ -40,7 +40,7 @@ export function formatRelativeTime(isoString: string): string {
   const diffHours = Math.floor(diffMins / 60);
   const diffDays = Math.floor(diffHours / 24);
 
-  if (diffSecs < 60) return "just now";
+  if (diffSecs < 60) return "Just now";
 
   if (diffMs > 0) {
     if (diffMins < 60) return `in ${diffMins}m`;

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -22,6 +22,11 @@ function stripKindPrefix(summary: string): string {
   return summary.replace(/^(RSS sync|Full sync|Manual sync|Collection publish|Collection sync)[:\s]*/i, "").trim();
 }
 
+function capitalizeSentence(text: string): string {
+  if (!text) return text;
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
 const ACTION_LABELS: Record<string, string> = {
   "watchlist.fetch": "Watchlist fetch",
   "watchlist.rss": "RSS item",
@@ -29,8 +34,11 @@ const ACTION_LABELS: Record<string, string> = {
   "watchlist.match.failed": "Match failed",
   "watchlist.date_unresolved": "Date unresolved",
   "collection.publish": "Collection publish",
+  "collection.publish.followup": "Collection publish triggered",
   "isolation.filters": "Isolation filters",
-  "sync.user": "User sync"
+  "sync.user": "User sync",
+  "rss.feed.check.self": "Self RSS feed check",
+  "rss.feed.check.friends": "Friends RSS feed check"
 };
 
 const VALID_KINDS: KindFilter[] = ["all", "full", "rss", "user", "publish"];
@@ -130,7 +138,7 @@ export default function History() {
                   : "bg-surface-container text-on-surface-variant hover:text-on-surface"
               }`}
             >
-              {s === "all" ? "All status" : s}
+              {s === "all" ? "All status" : titleCaseStatus(s)}
             </button>
           ))}
         </div>
@@ -200,6 +208,275 @@ export default function History() {
   );
 }
 
+interface HistoryStep {
+  id: string;
+  status: "success" | "error";
+  label: string;
+  meta?: string;
+}
+
+interface WatchlistFetchDetails {
+  userId?: number;
+  displayName?: string;
+  isSelf?: boolean;
+  itemCount?: number;
+  matched?: number;
+  unmatched?: number;
+}
+
+interface CollectionPublishDetails {
+  userId?: number;
+  displayName?: string;
+  mediaType?: string;
+  collectionName?: string;
+  collectionRatingKey?: string;
+  matchedItems?: number;
+  message?: string;
+}
+
+interface FeedCheckDetails {
+  feed?: "self" | "friends";
+  checked?: boolean;
+  found?: number;
+  authError?: boolean;
+  message?: string;
+}
+
+interface RssItemDetails {
+  userId?: number;
+  displayName?: string;
+  title?: string;
+  type?: string;
+  matchedRatingKey?: string | null;
+}
+
+interface SyncUserErrorDetails {
+  userId?: number;
+  displayName?: string;
+  message?: string;
+}
+
+function titleCaseStatus(status: SyncRun["status"]): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function formatRunDuration(run: SyncRun): string | null {
+  const endTime = run.completedAt ? new Date(run.completedAt).getTime() : Date.now();
+  const durationMs = Math.max(0, endTime - new Date(run.startedAt).getTime());
+  const durationSeconds = Math.floor(durationMs / 1000);
+
+  if (run.status === "running") {
+    if (durationSeconds < 60) return `Running for ${durationSeconds}s`;
+    if (durationSeconds < 3600) return `Running for ${Math.floor(durationSeconds / 60)}m`;
+    return `Running for ${Math.floor(durationSeconds / 3600)}h`;
+  }
+
+  if (durationMs < 1000) return `${durationMs}ms`;
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function formatMediaTypeLabel(mediaType?: string): string {
+  if (mediaType === "movie") return "Movies";
+  if (mediaType === "show") return "Shows";
+  return "Items";
+}
+
+function formatStepLabel(item: SyncRunItem): string {
+  if (item.action === "sync.user" && item.status === "error") {
+    const details = item.details as SyncUserErrorDetails | null;
+    return details?.displayName
+      ? `User sync failed for ${details.displayName}`
+      : "User sync failed";
+  }
+
+  if (item.action === "rss.feed.check.self" || item.action === "rss.feed.check.friends") {
+    const details = item.details as FeedCheckDetails | null;
+    const subject = details?.feed === "friends" ? "Friends RSS feed" : "Self RSS feed";
+    if (item.status === "error") {
+      return details?.authError ? `${subject} check failed: authentication error` : `${subject} check failed`;
+    }
+    if (details?.checked === false) return `${subject} not checked`;
+    return `${subject} checked`;
+  }
+
+  if (item.action === "collection.publish.followup") {
+    const details = item.details as { message?: string } | null;
+    return details?.message ?? "Triggered collection publish after full sync";
+  }
+
+  return ACTION_LABELS[item.action] ?? item.action;
+}
+
+function formatStepMeta(item: SyncRunItem): string | undefined {
+  if (item.action === "sync.user" && item.status === "error") {
+    const details = item.details as SyncUserErrorDetails | null;
+    return details?.message;
+  }
+
+  if (item.action === "collection.publish") {
+    const details = item.details as CollectionPublishDetails | null;
+    return details?.message;
+  }
+
+  if (item.action === "rss.feed.check.self" || item.action === "rss.feed.check.friends") {
+    const details = item.details as FeedCheckDetails | null;
+    if (item.status === "error") return details?.message;
+    if (details?.checked === false) return "Feed was not initialized for this run.";
+    return `${details?.found ?? 0} new item${details?.found === 1 ? "" : "s"} found`;
+  }
+
+  if (item.details && typeof item.details === "object") {
+    const details = item.details as Record<string, unknown>;
+    if (typeof details["message"] === "string") return details["message"];
+  }
+
+  return undefined;
+}
+
+function groupSuccessfulSteps(run: SyncRun, items: SyncRunItem[]): HistoryStep[] {
+  const steps: HistoryStep[] = [];
+
+  const watchlistFetches = items.filter((item) => item.action === "watchlist.fetch" && item.status === "success");
+  if (watchlistFetches.length > 0) {
+    for (const item of watchlistFetches) {
+      const details = item.details as WatchlistFetchDetails | null;
+      const name = details?.displayName ?? "Unknown user";
+      const count = details?.itemCount ?? 0;
+      const matched = details?.matched ?? 0;
+      const unmatched = details?.unmatched ?? 0;
+      steps.push({
+        id: `${item.id}-watchlist-fetch`,
+        status: "success",
+        label: `Watchlist fetch for ${name}`,
+        meta: `${count} items (${matched} matched, ${unmatched} unmatched)`
+      });
+    }
+  }
+
+  if (run.kind === "publish") {
+    const publishItems = items.filter((item) => item.action === "collection.publish" && item.status === "success");
+    const grouped = new Map<string, HistoryStep>();
+    for (const item of publishItems) {
+      const details = item.details as CollectionPublishDetails | null;
+      const name = details?.displayName ?? "Unknown user";
+      const mediaType = formatMediaTypeLabel(details?.mediaType);
+      const key = `${name}-${mediaType}`;
+      grouped.set(key, {
+        id: `${item.id}-${key}`,
+        status: "success",
+        label: `Published ${mediaType} collection for ${name}`,
+        meta: typeof details?.matchedItems === "number" ? `${details.matchedItems} matched items` : undefined
+      });
+    }
+    steps.push(...grouped.values());
+  } else if (run.kind === "rss") {
+    const feedChecks = items.filter(
+      (item) =>
+        item.status === "success" &&
+        (item.action === "rss.feed.check.self" || item.action === "rss.feed.check.friends")
+    );
+    for (const item of feedChecks) {
+      steps.push({
+        id: `${item.id}-feed-check`,
+        status: "success",
+        label: formatStepLabel(item),
+        meta: formatStepMeta(item)
+      });
+    }
+
+    const rssItems = items.filter(
+      (item) => item.status === "success" && (item.action === "watchlist.rss" || item.action === "watchlist.rss.self")
+    );
+    for (const item of rssItems) {
+      const details = item.details as RssItemDetails | null;
+      const name = details?.displayName ?? (item.action === "watchlist.rss.self" ? "Self" : "Unknown user");
+      const title = details?.title ?? "Unknown item";
+      const type = details?.type ? ` (${details.type})` : "";
+      steps.push({
+        id: `${item.id}-rss-item`,
+        status: "success",
+        label: `Found RSS item for ${name}: ${title}${type}`,
+        meta: details?.matchedRatingKey ? "Matched in Plex library" : "Not matched in Plex library"
+      });
+    }
+  } else {
+    const genericSuccesses = items.filter(
+      (item) =>
+        item.status === "success" &&
+        item.action !== "watchlist.fetch" &&
+        item.action !== "watchlist.rss" &&
+        item.action !== "watchlist.rss.self"
+    );
+    for (const item of genericSuccesses) {
+      steps.push({
+        id: `${item.id}-generic-success`,
+        status: "success",
+        label: formatStepLabel(item),
+        meta: formatStepMeta(item)
+      });
+    }
+  }
+
+  const extraGenericSuccesses = items.filter((item) => {
+    if (item.status !== "success") return false;
+    if (run.kind === "publish") return item.action !== "collection.publish";
+    if (run.kind === "rss") {
+      return item.action !== "rss.feed.check.self" &&
+        item.action !== "rss.feed.check.friends" &&
+        item.action !== "watchlist.rss" &&
+        item.action !== "watchlist.rss.self";
+    }
+    return item.action === "collection.publish.followup" || item.action === "isolation.filters";
+  });
+
+  for (const item of extraGenericSuccesses) {
+    if (steps.some((step) => step.id.startsWith(`${item.id}-`))) continue;
+    steps.push({
+      id: `${item.id}-extra-success`,
+      status: "success",
+      label: formatStepLabel(item),
+      meta: formatStepMeta(item)
+    });
+  }
+
+  return steps;
+}
+
+function collectErrorSteps(run: SyncRun, items: SyncRunItem[]): HistoryStep[] {
+  const steps: HistoryStep[] = [];
+
+  if (run.error) {
+    steps.push({
+      id: `${run.id}-run-error`,
+      status: "error",
+      label: "Run error",
+      meta: run.error
+    });
+  }
+
+  const errorItems = items.filter(
+    (item) =>
+      item.status === "error" &&
+      item.action !== "watchlist.match.failed" &&
+      item.action !== "watchlist.date_unresolved"
+  );
+
+  for (const item of errorItems) {
+    const meta = formatStepMeta(item);
+    if (item.action === "collection.publish" && run.error && meta && run.error === meta) {
+      continue;
+    }
+    steps.push({
+      id: `${item.id}-error`,
+      status: "error",
+      label: formatStepLabel(item),
+      meta
+    });
+  }
+
+  return steps;
+}
+
 function RunRow({ run }: { run: SyncRun }) {
   const [expanded, setExpanded] = useState(false);
   const [detail, setDetail] = useState<SyncRunDetail | null>(null);
@@ -266,17 +543,7 @@ function RunRow({ run }: { run: SyncRun }) {
   };
 
   const config = statusConfig[liveRun.status];
-
-  const durationMs =
-    liveRun.completedAt
-      ? new Date(liveRun.completedAt).getTime() - new Date(liveRun.startedAt).getTime()
-      : null;
-
-  const durationText = durationMs !== null
-    ? durationMs < 1000
-      ? `${durationMs}ms`
-      : `${(durationMs / 1000).toFixed(1)}s`
-    : null;
+  const durationText = formatRunDuration(liveRun);
 
   return (
     <div className="bg-surface-container rounded-xl border border-outline-variant/20 overflow-hidden">
@@ -291,10 +558,12 @@ function RunRow({ run }: { run: SyncRun }) {
               {KIND_LABELS[run.kind] ?? run.kind} Sync
             </span>
             <span className={`text-xs px-1.5 py-0.5 rounded-full border font-medium ${config.badge}`}>
-              {liveRun.status}
+              {titleCaseStatus(liveRun.status)}
             </span>
           </div>
-          <div className="text-on-surface-variant text-xs mt-0.5 truncate">{stripKindPrefix(liveRun.summary)}</div>
+          <div className="text-on-surface-variant text-xs mt-0.5 truncate">
+            {capitalizeSentence(stripKindPrefix(liveRun.summary))}
+          </div>
         </div>
         <div className="flex-shrink-0 text-right mr-2">
           <div className="text-on-surface-variant text-xs">{formatRelativeTime(liveRun.startedAt)}</div>
@@ -319,12 +588,6 @@ function RunRow({ run }: { run: SyncRun }) {
                 <div className="text-on-surface mt-0.5">{formatDateTime(liveRun.completedAt)}</div>
               </div>
             )}
-            {liveRun.error && (
-              <div className="col-span-2">
-                <span className="text-error">Error</span>
-                <div className="text-error/80 mt-0.5 font-mono break-all">{liveRun.error}</div>
-              </div>
-            )}
           </div>
 
           {/* Run items */}
@@ -342,7 +605,7 @@ function RunRow({ run }: { run: SyncRun }) {
                 </button>
               </div>
             ) : detail ? (
-              <RunItems items={detail.items} />
+              <RunItems run={liveRun} items={detail.items} />
             ) : null}
           </div>
         </div>
@@ -351,19 +614,18 @@ function RunRow({ run }: { run: SyncRun }) {
   );
 }
 
-function RunItems({ items }: { items: SyncRunItem[] }) {
+function RunItems({ run, items }: { run: SyncRun; items: SyncRunItem[] }) {
   if (items.length === 0) {
+    if (run.kind === "rss" && run.status !== "error") {
+      return <div className="text-xs text-on-surface-variant py-2">RSS feed checks completed with no new items.</div>;
+    }
     return <div className="text-xs text-on-surface-variant py-2">No step details recorded.</div>;
   }
 
   const failures = items.filter((i) => i.action === "watchlist.match.failed");
   const unresolved = items.filter((i) => i.action === "watchlist.date_unresolved");
-  const errors = items.filter(
-    (i) => i.status === "error" && i.action !== "watchlist.match.failed" && i.action !== "watchlist.date_unresolved"
-  );
-  const other = items.filter(
-    (i) => i.status === "success" && i.action !== "watchlist.match.failed" && i.action !== "watchlist.date_unresolved"
-  );
+  const errors = collectErrorSteps(run, items);
+  const other = groupSuccessfulSteps(run, items);
 
   return (
     <div className="space-y-3">
@@ -394,18 +656,18 @@ function RunItems({ items }: { items: SyncRunItem[] }) {
       {/* Errors */}
       {errors.length > 0 && (
         <ItemSectionCollapsible
-          title="errors"
+          title="Errors"
           count={errors.length}
           tone="error"
           items={errors}
-          renderItem={(item) => <RunItemRow key={item.id} item={item} />}
+          renderItem={(item) => <HistoryStepRow key={item.id} item={item} />}
         />
       )}
 
       {/* Match failures */}
       {failures.length > 0 && (
         <ItemSectionCollapsible
-          title="unmatched items"
+          title="Unmatched items"
           count={failures.length}
           tone="warning"
           items={failures}
@@ -416,7 +678,7 @@ function RunItems({ items }: { items: SyncRunItem[] }) {
       {/* Watchlisted at date unresolved */}
       {unresolved.length > 0 && (
         <ItemSectionCollapsible
-          title="watchlisted date unresolved"
+          title="Watchlisted date unresolved"
           count={unresolved.length}
           tone="warning"
           items={unresolved}
@@ -430,16 +692,16 @@ function RunItems({ items }: { items: SyncRunItem[] }) {
   );
 }
 
-function RunItemRow({ item }: { item: SyncRunItem }) {
+function HistoryStepRow({ item }: { item: HistoryStep }) {
   return (
     <div className="bg-error/5 border border-error/20 rounded-lg px-3 py-2 text-xs">
       <div className="flex items-center gap-2">
-        <span className="text-error font-medium">{ACTION_LABELS[item.action] ?? item.action}</span>
+        <span className="text-error font-medium">{item.label}</span>
       </div>
-      {item.details !== undefined && item.details !== null && (
-        <pre className="mt-1 text-error/70 font-mono whitespace-pre-wrap break-all max-h-24 overflow-auto">
-          {JSON.stringify(item.details, null, 2)}
-        </pre>
+      {item.meta && (
+        <div className="mt-1 text-error/80 whitespace-pre-wrap break-words">
+          {item.meta}
+        </div>
       )}
     </div>
   );
@@ -546,7 +808,7 @@ function DateUnresolvedRow({ item }: { item: SyncRunItem }) {
   );
 }
 
-function StepsCollapsible({ items }: { items: SyncRunItem[] }) {
+function StepsCollapsible({ items }: { items: HistoryStep[] }) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -563,9 +825,9 @@ function StepsCollapsible({ items }: { items: SyncRunItem[] }) {
           {items.map((item) => (
             <div key={item.id} className="flex items-center gap-2 text-xs px-2 py-1 rounded-lg bg-surface-container/50">
               <CheckCircle size={12} className="text-success flex-shrink-0" />
-              <span className="text-on-surface-variant">{ACTION_LABELS[item.action] ?? item.action}</span>
-              {item.details !== null && typeof item.details === "object" && "itemCount" in (item.details as object) && (
-                <span className="text-on-surface-variant/60 ml-auto">{String((item.details as Record<string, unknown>)["itemCount"])} items</span>
+              <span className="text-on-surface-variant">{item.label}</span>
+              {item.meta && (
+                <span className="text-on-surface-variant/60 ml-auto text-right">{item.meta}</span>
               )}
             </div>
           ))}
@@ -575,7 +837,7 @@ function StepsCollapsible({ items }: { items: SyncRunItem[] }) {
   );
 }
 
-function ItemSectionCollapsible({
+function ItemSectionCollapsible<T>({
   title,
   count,
   tone,
@@ -585,8 +847,8 @@ function ItemSectionCollapsible({
   title: string;
   count: number;
   tone: "warning" | "error";
-  items: SyncRunItem[];
-  renderItem: (item: SyncRunItem) => ReactNode;
+  items: T[];
+  renderItem: (item: T) => ReactNode;
 }) {
   const [open, setOpen] = useState(false);
   const toneClass = tone === "error"

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -257,12 +257,13 @@ interface SyncUserErrorDetails {
 }
 
 function titleCaseStatus(status: SyncRun["status"]): string {
-  return status.charAt(0).toUpperCase() + status.slice(1);
+  return capitalizeSentence(status);
 }
 
-function formatRunDuration(run: SyncRun): string | null {
+function formatRunDuration(run: SyncRun, now = Date.now()): string | null {
   const endTime = run.completedAt ? new Date(run.completedAt).getTime() : Date.now();
-  const durationMs = Math.max(0, endTime - new Date(run.startedAt).getTime());
+  const effectiveEndTime = run.completedAt ? endTime : now;
+  const durationMs = Math.max(0, effectiveEndTime - new Date(run.startedAt).getTime());
   const durationSeconds = Math.floor(durationMs / 1000);
 
   if (run.status === "running") {
@@ -361,14 +362,30 @@ function groupSuccessfulSteps(run: SyncRun, items: SyncRunItem[]): HistoryStep[]
       const name = details?.displayName ?? "Unknown user";
       const mediaType = formatMediaTypeLabel(details?.mediaType);
       const key = `${name}-${mediaType}`;
+      const collectionName = details?.collectionName;
+      const collectionLabel = collectionName
+        ? `Published ${mediaType} collection "${collectionName}" for ${name}`
+        : `Published ${mediaType} collection for ${name}`;
       grouped.set(key, {
         id: `${item.id}-${key}`,
         status: "success",
-        label: `Published ${mediaType} collection for ${name}`,
+        label: collectionLabel,
         meta: typeof details?.matchedItems === "number" ? `${details.matchedItems} matched items` : undefined
       });
     }
     steps.push(...grouped.values());
+
+    const genericSuccesses = items.filter(
+      (item) => item.status === "success" && item.action !== "collection.publish"
+    );
+    for (const item of genericSuccesses) {
+      steps.push({
+        id: `${item.id}-generic-success`,
+        status: "success",
+        label: formatStepLabel(item),
+        meta: formatStepMeta(item)
+      });
+    }
   } else if (run.kind === "rss") {
     const feedChecks = items.filter(
       (item) =>
@@ -399,6 +416,23 @@ function groupSuccessfulSteps(run: SyncRun, items: SyncRunItem[]): HistoryStep[]
         meta: details?.matchedRatingKey ? "Matched in Plex library" : "Not matched in Plex library"
       });
     }
+
+    const genericSuccesses = items.filter(
+      (item) =>
+        item.status === "success" &&
+        item.action !== "rss.feed.check.self" &&
+        item.action !== "rss.feed.check.friends" &&
+        item.action !== "watchlist.rss" &&
+        item.action !== "watchlist.rss.self"
+    );
+    for (const item of genericSuccesses) {
+      steps.push({
+        id: `${item.id}-generic-success`,
+        status: "success",
+        label: formatStepLabel(item),
+        meta: formatStepMeta(item)
+      });
+    }
   } else {
     const genericSuccesses = items.filter(
       (item) =>
@@ -417,29 +451,33 @@ function groupSuccessfulSteps(run: SyncRun, items: SyncRunItem[]): HistoryStep[]
     }
   }
 
-  const extraGenericSuccesses = items.filter((item) => {
-    if (item.status !== "success") return false;
-    if (run.kind === "publish") return item.action !== "collection.publish";
-    if (run.kind === "rss") {
-      return item.action !== "rss.feed.check.self" &&
-        item.action !== "rss.feed.check.friends" &&
-        item.action !== "watchlist.rss" &&
-        item.action !== "watchlist.rss.self";
-    }
-    return item.action === "collection.publish.followup" || item.action === "isolation.filters";
-  });
+  return steps;
+}
 
-  for (const item of extraGenericSuccesses) {
-    if (steps.some((step) => step.id.startsWith(`${item.id}-`))) continue;
-    steps.push({
-      id: `${item.id}-extra-success`,
-      status: "success",
-      label: formatStepLabel(item),
-      meta: formatStepMeta(item)
-    });
+function normalizeErrorText(text: string): string {
+  return text.trim().replace(/[.\s]+$/g, "").toLowerCase();
+}
+
+function shouldSuppressItemError(run: SyncRun, item: SyncRunItem, meta?: string): boolean {
+  if (!run.error || !meta) return false;
+
+  const normalizedRunSegments = run.error
+    .split("|")
+    .map((segment) => normalizeErrorText(segment))
+    .filter(Boolean);
+
+  const normalizedMeta = normalizeErrorText(meta);
+  if (normalizedRunSegments.includes(normalizedMeta)) return true;
+
+  if (item.action === "collection.publish" || item.action === "sync.user") {
+    const details = item.details as CollectionPublishDetails | SyncUserErrorDetails | null;
+    const displayName = details?.displayName?.trim();
+    if (!displayName) return false;
+    const structuredMessage = normalizeErrorText(`${displayName}: ${meta}`);
+    return normalizedRunSegments.includes(structuredMessage);
   }
 
-  return steps;
+  return false;
 }
 
 function collectErrorSteps(run: SyncRun, items: SyncRunItem[]): HistoryStep[] {
@@ -463,7 +501,7 @@ function collectErrorSteps(run: SyncRun, items: SyncRunItem[]): HistoryStep[] {
 
   for (const item of errorItems) {
     const meta = formatStepMeta(item);
-    if (item.action === "collection.publish" && run.error && meta && run.error === meta) {
+    if (shouldSuppressItemError(run, item, meta)) {
       continue;
     }
     steps.push({
@@ -482,6 +520,7 @@ function RunRow({ run }: { run: SyncRun }) {
   const [detail, setDetail] = useState<SyncRunDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
 
   const loadDetail = useCallback(async (background = false) => {
     setDetailLoading((current) => current || !background);
@@ -523,6 +562,19 @@ function RunRow({ run }: { run: SyncRun }) {
 
   const liveRun = detail ?? run;
 
+  useEffect(() => {
+    if (liveRun.status !== "running") return;
+
+    setNow(Date.now());
+    const timer = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [liveRun.status, liveRun.startedAt]);
+
   const statusConfig = {
     success: {
       icon: <CheckCircle size={18} className="text-success" />,
@@ -543,7 +595,7 @@ function RunRow({ run }: { run: SyncRun }) {
   };
 
   const config = statusConfig[liveRun.status];
-  const durationText = formatRunDuration(liveRun);
+  const durationText = formatRunDuration(liveRun, now);
 
   return (
     <div className="bg-surface-container rounded-xl border border-outline-variant/20 overflow-hidden">

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -261,8 +261,7 @@ function titleCaseStatus(status: SyncRun["status"]): string {
 }
 
 function formatRunDuration(run: SyncRun, now = Date.now()): string | null {
-  const endTime = run.completedAt ? new Date(run.completedAt).getTime() : Date.now();
-  const effectiveEndTime = run.completedAt ? endTime : now;
+  const effectiveEndTime = run.completedAt ? new Date(run.completedAt).getTime() : now;
   const durationMs = Math.max(0, effectiveEndTime - new Date(run.startedAt).getTime());
   const durationSeconds = Math.floor(durationMs / 1000);
 

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -615,6 +615,7 @@ export class HubarrServices {
       "success",
       {
         userId: friend.id,
+        displayName: friend.displayName,
         isSelf: friend.isSelf,
         itemCount: mergedWithDates.length,
         matched: matchedCount,
@@ -801,7 +802,9 @@ export class HubarrServices {
           "success",
           {
             userId: friend.id,
+            displayName: friend.displayName,
             mediaType,
+            collectionName,
             collectionRatingKey,
             matchedItems: matchedRatingKeys.length
           },
@@ -866,7 +869,11 @@ export class HubarrServices {
           message
         });
         this.db.markUserSyncResult(friend.id, message);
-        this.db.addSyncRunItem(runId, "sync.user", "error", { userId: friend.id, message }, friend.id);
+        this.db.addSyncRunItem(runId, "sync.user", "error", {
+          userId: friend.id,
+          displayName: friend.displayName,
+          message
+        }, friend.id);
         failures.push(`${friend.displayName}: ${message}`);
       }
     }
@@ -890,9 +897,19 @@ export class HubarrServices {
 
     // Publish collections immediately so the updated watchlist is live in Plex
     // without waiting for the next scheduled collection-publish job.
-    await this.runPublishPass().catch((err) => {
+    await this.runPublishPass().then(() => {
+      this.db.addSyncRunItem(runId, "collection.publish.followup", "success", {
+        sourceRunKind: "full",
+        message: "Triggered collection publish after full sync."
+      });
+    }).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
       this.logger.warn("Collection publish after full sync failed", {
-        message: err instanceof Error ? err.message : String(err)
+        message
+      });
+      this.db.addSyncRunItem(runId, "collection.publish.followup", "error", {
+        sourceRunKind: "full",
+        message
       });
     });
 
@@ -986,7 +1003,11 @@ export class HubarrServices {
           message
         });
         this.db.markUserSyncResult(friend.id, message);
-        this.db.addSyncRunItem(runId, "collection.publish", "error", { userId: friend.id, message }, friend.id);
+        this.db.addSyncRunItem(runId, "collection.publish", "error", {
+          userId: friend.id,
+          displayName: friend.displayName,
+          message
+        }, friend.id);
         failures.push(`${friend.displayName}: ${message}`);
       }
     }
@@ -1234,6 +1255,13 @@ export class HubarrServices {
       if (this.selfRssPrimed && this.selfRssUrl) {
         const result = await plex.fetchRssFeedItems(this.selfRssUrl);
         if (!result.ok) {
+          this.db.addSyncRunItem(runId, "rss.feed.check.self", "error", {
+            feed: "self",
+            checked: true,
+            found: 0,
+            authError: result.authError,
+            message: result.message
+          });
           if (result.authError) {
             this.logger.warn("Self RSS auth error — check Plex Pass subscription and token RSS access", {
               message: result.message
@@ -1243,17 +1271,35 @@ export class HubarrServices {
           }
         } else {
           const newItems = this.selfRssCache.diff(result.items);
+          this.db.addSyncRunItem(runId, "rss.feed.check.self", "success", {
+            feed: "self",
+            checked: true,
+            found: newItems.length
+          });
           if (newItems.length > 0) {
             this.logger.info("Self RSS feed detected new items", { count: newItems.length });
             selfProcessed = await this.processSelfRssNewItems(newItems, runId, plex, settings);
           }
         }
+      } else {
+        this.db.addSyncRunItem(runId, "rss.feed.check.self", "success", {
+          feed: "self",
+          checked: false,
+          found: 0
+        });
       }
 
       // Poll friends feed
       if (this.usersRssPrimed && this.usersRssUrl) {
         const result = await plex.fetchRssFeedItems(this.usersRssUrl);
         if (!result.ok) {
+          this.db.addSyncRunItem(runId, "rss.feed.check.friends", "error", {
+            feed: "friends",
+            checked: true,
+            found: 0,
+            authError: result.authError,
+            message: result.message
+          });
           if (result.authError) {
             this.logger.warn("Friends RSS auth error — check Plex Pass subscription and token RSS access", {
               message: result.message
@@ -1263,6 +1309,11 @@ export class HubarrServices {
           }
         } else {
           const newItems = this.usersRssCache.diff(result.items);
+          this.db.addSyncRunItem(runId, "rss.feed.check.friends", "success", {
+            feed: "friends",
+            checked: true,
+            found: newItems.length
+          });
           if (newItems.length > 0) {
             this.logger.info("Friends RSS feed detected new items", { count: newItems.length });
             friendsProcessed = await this.processRssNewItems(
@@ -1273,6 +1324,12 @@ export class HubarrServices {
             );
           }
         }
+      } else {
+        this.db.addSyncRunItem(runId, "rss.feed.check.friends", "success", {
+          feed: "friends",
+          checked: false,
+          found: 0
+        });
       }
 
       const total = selfProcessed + friendsProcessed;
@@ -1435,6 +1492,7 @@ export class HubarrServices {
       });
 
       this.db.addSyncRunItem(runId, "watchlist.rss.self", "success", {
+        displayName: selfUser.displayName,
         title: item.title,
         type: item.type,
         matchedRatingKey
@@ -1576,6 +1634,7 @@ export class HubarrServices {
 
       this.db.addSyncRunItem(runId, "watchlist.rss", "success", {
         userId: friend.id,
+        displayName: friend.displayName,
         title: item.title,
         type: item.type,
         matchedRatingKey

--- a/tests/playwright/history-background-refresh.spec.ts
+++ b/tests/playwright/history-background-refresh.spec.ts
@@ -23,6 +23,49 @@ type SyncRunDetail = SyncRun & {
 };
 
 test.describe("History background refresh", () => {
+  test("Running history rows show Just now and live elapsed text", async ({ browser }) => {
+    const context = await browser.newContext({ storageState: "tests/playwright/.auth/storageState.json" });
+    const historyPage = await context.newPage();
+
+    const startedAt = new Date(Date.now() - 42_000).toISOString();
+    const runningRun: SyncRun = {
+      id: 9000,
+      kind: "full",
+      status: "running",
+      startedAt,
+      completedAt: null,
+      summary: "Full sync: syncing watchlist for Alice (1/2).",
+      error: null
+    };
+
+    await historyPage.route("**/api/history?*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          results: [runningRun],
+          pageInfo: {
+            page: 1,
+            pageSize: 10,
+            pages: 1,
+            total: 1
+          }
+        })
+      });
+    });
+
+    await historyPage.goto("/history");
+    await expect(historyPage.getByRole("heading", { name: "History" })).toBeVisible();
+    await expect(historyPage.getByText("Loading history...")).not.toBeVisible({ timeout: 10_000 });
+
+    const runRow = historyPage.locator("div.space-y-2 > div").first();
+    await expect(runRow).toContainText("Running");
+    await expect(runRow).toContainText("Just now");
+    await expect(runRow).toContainText(/Running for \d+s/);
+
+    await context.close();
+  });
+
   test("History list keeps polling while the tab is hidden when a run is active", async ({ browser }) => {
     const context = await browser.newContext({ storageState: "tests/playwright/.auth/storageState.json" });
     const historyPage = await context.newPage();
@@ -59,7 +102,7 @@ test.describe("History background refresh", () => {
     await historyPage.goto("/history");
     await expect(historyPage.getByRole("heading", { name: "History" })).toBeVisible();
     await expect(historyPage.getByText("Loading history...")).not.toBeVisible({ timeout: 10_000 });
-    await expect(historyPage.locator("div.space-y-2 > div").first()).toContainText("running");
+    await expect(historyPage.locator("div.space-y-2 > div").first()).toContainText("Running");
 
     const initialRequestCount = historyRequestCount;
     expect(initialRequestCount).toBeGreaterThanOrEqual(1);
@@ -120,6 +163,7 @@ test.describe("History background refresh", () => {
             status: "success",
             details: {
               userId: 42,
+              displayName: "Bob",
               mediaType: "movie",
               matchedItems: 12
             },
@@ -152,6 +196,230 @@ test.describe("History background refresh", () => {
     await otherPage.bringToFront();
 
     await expect.poll(() => detailRequestCount, { timeout: 10_000 }).toBeGreaterThan(initialDetailRequestCount);
+
+    await context.close();
+  });
+
+  test("Expanded errors stay collapsed by default and grouped steps render readable labels", async ({ browser }) => {
+    const context = await browser.newContext({ storageState: "tests/playwright/.auth/storageState.json" });
+    const historyPage = await context.newPage();
+
+    const completedRun: SyncRun = {
+      id: 9003,
+      kind: "full",
+      status: "error",
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+      completedAt: new Date(Date.now() - 20_000).toISOString(),
+      summary: "Full sync finished: 1/2 users succeeded.",
+      error: "Alice: Plex request failed"
+    };
+
+    await historyPage.route("**/api/history?*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          results: [completedRun],
+          pageInfo: {
+            page: 1,
+            pageSize: 10,
+            pages: 1,
+            total: 1
+          }
+        })
+      });
+    });
+
+    await historyPage.route("**/api/history/9003", async (route) => {
+      const detail: SyncRunDetail = {
+        ...completedRun,
+        items: [
+          {
+            id: 1,
+            runId: 9003,
+            userId: 10,
+            action: "watchlist.fetch",
+            status: "success",
+            details: {
+              userId: 10,
+              displayName: "Alice",
+              itemCount: 12,
+              matched: 11,
+              unmatched: 1
+            },
+            createdAt: "2026-04-14T10:05:00.000Z"
+          },
+          {
+            id: 2,
+            runId: 9003,
+            userId: 11,
+            action: "watchlist.fetch",
+            status: "success",
+            details: {
+              userId: 11,
+              displayName: "Bob",
+              itemCount: 5,
+              matched: 5,
+              unmatched: 0
+            },
+            createdAt: "2026-04-14T10:05:02.000Z"
+          },
+          {
+            id: 3,
+            runId: 9003,
+            userId: 10,
+            action: "sync.user",
+            status: "error",
+            details: {
+              userId: 10,
+              displayName: "Alice",
+              message: "Plex request failed"
+            },
+            createdAt: "2026-04-14T10:05:04.000Z"
+          },
+          {
+            id: 4,
+            runId: 9003,
+            userId: null,
+            action: "collection.publish.followup",
+            status: "success",
+            details: {
+              message: "Triggered collection publish after full sync."
+            },
+            createdAt: "2026-04-14T10:05:05.000Z"
+          }
+        ]
+      };
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(detail)
+      });
+    });
+
+    await historyPage.goto("/history");
+    await expect(historyPage.getByRole("heading", { name: "History" })).toBeVisible();
+    await expect(historyPage.getByText("Loading history...")).not.toBeVisible({ timeout: 10_000 });
+
+    const runRow = historyPage.locator("div.space-y-2 > div").first();
+    await runRow.getByRole("button").click();
+    await expect(historyPage.getByText("Loading details...")).not.toBeVisible({ timeout: 10_000 });
+
+    await expect(historyPage.getByRole("button", { name: /Show Errors \(2\)/ })).toBeVisible();
+    await expect(historyPage.getByText("Run error", { exact: true })).toHaveCount(0);
+
+    await historyPage.getByRole("button", { name: /Show 3 completed steps/ }).click();
+    await expect(historyPage.getByText("Watchlist fetch for Alice", { exact: true })).toBeVisible();
+    await expect(historyPage.getByText("12 items (11 matched, 1 unmatched)", { exact: true })).toBeVisible();
+    await expect(historyPage.getByText("Watchlist fetch for Bob", { exact: true })).toBeVisible();
+    await expect(historyPage.getByText("5 items (5 matched, 0 unmatched)", { exact: true })).toBeVisible();
+    await expect(historyPage.locator("div", { hasText: "Triggered collection publish after full sync." }).first()).toBeVisible();
+
+    await historyPage.getByRole("button", { name: /Show Errors \(2\)/ }).click();
+    await expect(historyPage.getByText("Run error", { exact: true })).toBeVisible();
+    await expect(historyPage.getByText("User sync failed for Alice", { exact: true })).toBeVisible();
+
+    await context.close();
+  });
+
+  test("RSS runs show feed checks and descriptive item labels", async ({ browser }) => {
+    const context = await browser.newContext({ storageState: "tests/playwright/.auth/storageState.json" });
+    const historyPage = await context.newPage();
+
+    const rssRun: SyncRun = {
+      id: 9004,
+      kind: "rss",
+      status: "success",
+      startedAt: new Date(Date.now() - 30_000).toISOString(),
+      completedAt: new Date(Date.now() - 25_000).toISOString(),
+      summary: "RSS sync: 1 new item(s) processed (self: 0, friends: 1).",
+      error: null
+    };
+
+    await historyPage.route("**/api/history?*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          results: [rssRun],
+          pageInfo: {
+            page: 1,
+            pageSize: 10,
+            pages: 1,
+            total: 1
+          }
+        })
+      });
+    });
+
+    await historyPage.route("**/api/history/9004", async (route) => {
+      const detail: SyncRunDetail = {
+        ...rssRun,
+        items: [
+          {
+            id: 1,
+            runId: 9004,
+            userId: null,
+            action: "rss.feed.check.self",
+            status: "success",
+            details: {
+              feed: "self",
+              checked: true,
+              found: 0
+            },
+            createdAt: "2026-04-14T10:05:00.000Z"
+          },
+          {
+            id: 2,
+            runId: 9004,
+            userId: null,
+            action: "rss.feed.check.friends",
+            status: "success",
+            details: {
+              feed: "friends",
+              checked: true,
+              found: 1
+            },
+            createdAt: "2026-04-14T10:05:02.000Z"
+          },
+          {
+            id: 3,
+            runId: 9004,
+            userId: 22,
+            action: "watchlist.rss",
+            status: "success",
+            details: {
+              userId: 22,
+              displayName: "Alice",
+              title: "The Matrix",
+              type: "movie",
+              matchedRatingKey: "1234"
+            },
+            createdAt: "2026-04-14T10:05:04.000Z"
+          }
+        ]
+      };
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(detail)
+      });
+    });
+
+    await historyPage.goto("/history");
+    await expect(historyPage.getByRole("heading", { name: "History" })).toBeVisible();
+    await expect(historyPage.getByText("Loading history...")).not.toBeVisible({ timeout: 10_000 });
+
+    const runRow = historyPage.locator("div.space-y-2 > div").first();
+    await runRow.getByRole("button").click();
+    await expect(historyPage.getByText("Loading details...")).not.toBeVisible({ timeout: 10_000 });
+
+    await historyPage.getByRole("button", { name: /Show 3 completed steps/ }).click();
+    await expect(historyPage.getByText("Self RSS feed checked", { exact: true })).toBeVisible();
+    await expect(historyPage.getByText("Friends RSS feed checked", { exact: true })).toBeVisible();
+    await expect(historyPage.getByText("Found RSS item for Alice: The Matrix (movie)", { exact: true })).toBeVisible();
 
     await context.close();
   });

--- a/tests/playwright/history.spec.ts
+++ b/tests/playwright/history.spec.ts
@@ -25,9 +25,9 @@ test.describe("History filters", () => {
   test("Status filter buttons are all visible", async ({ page }) => {
     // exact: true prevents matching history run-row buttons whose names include these words
     await expect(page.getByRole("button", { name: "All status", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "success", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "error", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "running", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^success$/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^error$/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^running$/i })).toBeVisible();
   });
 
   test("Page size select is visible", async ({ page }) => {
@@ -40,7 +40,7 @@ test.describe("History filters", () => {
   });
 
   test("Success status filter updates URL", async ({ page }) => {
-    await page.getByRole("button", { name: "success", exact: true }).click();
+    await page.getByRole("button", { name: /^success$/i }).click();
     await expect(page).toHaveURL(/[?&]status=success/);
   });
 });

--- a/tests/playwright/live-refresh.spec.ts
+++ b/tests/playwright/live-refresh.spec.ts
@@ -68,8 +68,8 @@ test.describe("Live refresh", () => {
     const completedRun = await waitForRunCompletion(request, "publish", runningRun.startedAt);
     await expect(firstRunRow).not.toHaveText(firstRowTextBefore, { timeout: 30_000 });
     await expect(firstRunRow).toContainText("Collection Sync", { timeout: 30_000 });
-    await expect(firstRunRow).toContainText(completedRun.status, { timeout: 30_000 });
-    await expect(firstRunRow).toContainText(stripHistorySummary(completedRun.summary), { timeout: 30_000 });
+    await expect(firstRunRow).toContainText(capitalizeStatus(completedRun.status), { timeout: 30_000 });
+    await expect(firstRunRow).toContainText(capitalizeSummary(stripHistorySummary(completedRun.summary)), { timeout: 30_000 });
   });
 
   test("Jobs shows a scheduler-managed job running and then returning to Run Now after polling catches completion", async ({ page, request }) => {
@@ -189,4 +189,12 @@ function compactDashboardSummary(run: SyncRun): string {
 
 function stripHistorySummary(summary: string): string {
   return summary.replace(/^(RSS sync|Full sync|Manual sync|Collection publish|Collection sync)[:\s]*/i, "").trim();
+}
+
+function capitalizeStatus(status: SyncRun["status"]): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function capitalizeSummary(summary: string): string {
+  return summary.charAt(0).toUpperCase() + summary.slice(1);
 }


### PR DESCRIPTION
Closes #87

## Summary

This PR upgrades the History page so job runs are easier to scan and the detail view reflects the real work each run performed instead of mostly dumping low-level raw events. It improves subtitle/status wording, adds clearer live-running timing, collapses errors by default, and makes GraphQL, RSS, and collection history rows more descriptive and actionable.

## Changes

- Updated the History page UI in  to normalize raw run items into grouped display steps, capitalize displayed summaries/statuses, show live  timing, collapse error sections by default, and render per-user watchlist fetch rows instead of one combined GraphQL fetch summary.
- Enriched history payloads in  so full sync, collection publish, and RSS runs record the extra context the UI now needs, including user display names, feed-check detail, collection publish follow-up events, and clearer per-step metadata.
- Adjusted shared presentation helpers in , updated sync/testing docs in  and , and refreshed Playwright coverage in the History-related specs so the tests assert the new wording and grouped-step behavior.

## Test plan

- [x] Run 
> hubarr@1.0.2 check
> tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.server.json
- [x] Run 
> hubarr@1.0.2 build
> npm run build:client && npm run build:server


> hubarr@1.0.2 build:client
> vite build

vite v8.0.8 building client environment for production...
[2Ktransforming...✓ 1748 modules transformed.
rendering chunks...
computing gzip size...
dist/client/index.html                   0.66 kB │ gzip:   0.38 kB
dist/client/assets/index-BPikDTI0.css   39.60 kB │ gzip:   7.39 kB
dist/client/assets/index-C1fGOHHD.js   354.61 kB │ gzip: 101.57 kB

✓ built in 269ms

> hubarr@1.0.2 build:server
> tsc -p tsconfig.server.json
- [x] Run the History-focused Playwright specs after updating assertions for the new UI
- [x] Run a full Playwright pass against the rebuilt live Hubarr instance
- [x] Perform a manual UI sanity pass on the History page using the rebuilt live container

🤖 Generated with Codex