### PR TITLE
feat: add onboarding wizard with users step, preload, and bypass prevention

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -75,7 +75,7 @@ function MainApp() {
       return;
     }
 
-    if (!nextState.bootstrap.setupComplete) {
+    if (!nextState.bootstrap.onboardingComplete) {
       navigate("/onboarding");
     } else {
       navigate("/dashboard");
@@ -134,8 +134,8 @@ function MainApp() {
     );
   }
 
-  // Logged in but setup not complete — show onboarding
-  if (bootstrap && !bootstrap.setupComplete) {
+  // Logged in but onboarding not complete — show onboarding
+  if (bootstrap && !bootstrap.onboardingComplete) {
     return (
       <Routes>
         <Route

--- a/src/client/components/CollectionsConfigForm.tsx
+++ b/src/client/components/CollectionsConfigForm.tsx
@@ -15,11 +15,13 @@ export default function CollectionsConfigForm({
   initialValue,
   librariesUrl,
   onSaved,
+  onBack,
   saveLabel = "Save Collections"
 }: {
   initialValue: CollectionsFormValue;
   librariesUrl: string;
   onSaved?: (value: CollectionsFormValue) => void | Promise<void>;
+  onBack?: () => void;
   saveLabel?: string;
 }) {
   const [form, setForm] = useState<CollectionsFormValue>(initialValue);
@@ -82,7 +84,7 @@ export default function CollectionsConfigForm({
     <div className="space-y-6">
       <SectionCard
         title="Collections"
-        description="Choose the default libraries, visibility, and naming pattern Hubarr will use when creating collections."
+        description="Choose the default collection settings for your Hubarr instance."
         wide
       >
         <Field
@@ -191,6 +193,7 @@ export default function CollectionsConfigForm({
           success={success}
           error={error}
           onSave={() => void save()}
+          onBack={onBack}
           label={saveLabel}
         />
       </SectionCard>

--- a/src/client/components/FormControls.tsx
+++ b/src/client/components/FormControls.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 export function SectionCard({
   title,
@@ -141,23 +142,49 @@ export function SaveBar({
   success,
   error,
   onSave,
+  onBack,
   label = "Save"
 }: {
   saving: boolean;
   success: boolean;
   error: string | null;
   onSave: () => void;
+  onBack?: () => void;
   label?: string;
 }) {
+  const saveButton = (
+    <button
+      disabled={saving}
+      onClick={onSave}
+      className="flex items-center gap-2 bg-primary hover:bg-primary-dim disabled:opacity-50 text-on-primary text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
+    >
+      {saving ? "Saving..." : label}
+      {!saving && <ChevronRight size={15} />}
+    </button>
+  );
+
+  if (onBack) {
+    return (
+      <div className="flex items-center justify-between pt-2">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+        >
+          <ChevronLeft size={15} />
+          Back
+        </button>
+        <div className="flex items-center gap-3">
+          {success && <span className="text-success text-sm">Saved</span>}
+          {error && <span className="text-error text-sm">{error}</span>}
+          {saveButton}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center gap-3 pt-2">
-      <button
-        disabled={saving}
-        onClick={onSave}
-        className="bg-primary hover:bg-primary-dim disabled:opacity-50 text-on-primary text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
-      >
-        {saving ? "Saving..." : label}
-      </button>
+      {saveButton}
       {success && <span className="text-success text-sm">Saved</span>}
       {error && <span className="text-error text-sm">{error}</span>}
     </div>

--- a/src/client/components/PlexConfigForm.tsx
+++ b/src/client/components/PlexConfigForm.tsx
@@ -13,11 +13,13 @@ export default function PlexConfigForm({
   initialConfig,
   saveUrl,
   onSaved,
+  onBack,
   saveLabel = "Save Plex"
 }: {
   initialConfig: PlexSettingsView | null;
   saveUrl: string;
   onSaved?: (result: PlexConfigResponse) => void | Promise<void>;
+  onBack?: () => void;
   saveLabel?: string;
 }) {
   const [availableServers, setAvailableServers] = useState<PlexConnectionOption[]>([]);
@@ -91,7 +93,7 @@ export default function PlexConfigForm({
   return (
     <SectionCard
       title="Plex Settings"
-      description="Connect Hubarr to your Plex server. Once linked, Hubarr will build and maintain watchlist Collections and publish them as Hub rows."
+      description="Connect Hubarr to your Plex server to start building and publishing watchlist collections."
       wide
     >
       <Field label="Server" hint="Press the button to load available servers">
@@ -170,6 +172,7 @@ export default function PlexConfigForm({
         success={success}
         error={error}
         onSave={() => void save()}
+        onBack={onBack}
         label={saveLabel}
       />
 

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Check, ChevronRight, Loader2, X } from "lucide-react";
+import { Check, ChevronLeft, ChevronRight, Loader2, X } from "lucide-react";
 import { apiGet, apiPatch, apiPost } from "../lib/api";
+import { getPlexImageSrc } from "../lib/plexImage";
 import PlexOAuth from "../lib/plexOAuth";
 import PlexConfigForm from "../components/PlexConfigForm";
 import CollectionsConfigForm from "../components/CollectionsConfigForm";
@@ -10,7 +11,8 @@ import type {
   PreloadPhase,
   PreloadProgressEvent,
   SetupStatusResponse,
-  SettingsResponse
+  SettingsResponse,
+  UserRecord
 } from "../../shared/types";
 
 interface OnboardingProps {
@@ -35,7 +37,6 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
       setSettings(currentSettings);
       setStep(status.currentStep);
     } catch {
-      // Fresh install before auth — stay on auth step
       setStep("auth");
     }
   }
@@ -64,27 +65,14 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
     }
   }
 
+  // Step order: auth(1) → general(2) → plex(3) → collections(4) → users(5) → preload(hidden)
   const stepState = useMemo(() => {
-    if (step === "auth") {
-      return { authDone: false, plexDone: false, generalDone: false, collectionsDone: false, preloadDone: false };
-    }
-    if (step === "plex") {
-      return { authDone: true, plexDone: false, generalDone: false, collectionsDone: false, preloadDone: false };
-    }
-    if (step === "general") {
-      return { authDone: true, plexDone: true, generalDone: false, collectionsDone: false, preloadDone: false };
-    }
-    if (step === "collections") {
-      return {
-        authDone: true,
-        plexDone: true,
-        generalDone: true,
-        collectionsDone: Boolean(setupStatus?.collectionsConfigured),
-        preloadDone: false
-      };
-    }
-    // preload
-    return { authDone: true, plexDone: true, generalDone: true, collectionsDone: true, preloadDone: false };
+    const authDone = step !== "auth";
+    const generalDone = authDone && step !== "general";
+    const plexDone = generalDone && step !== "plex";
+    const collectionsDone = plexDone && (step !== "collections" || Boolean(setupStatus?.collectionsConfigured));
+    const usersDone = collectionsDone && step !== "users";
+    return { authDone, generalDone, plexDone, collectionsDone, usersDone };
   }, [setupStatus?.collectionsConfigured, step]);
 
   return (
@@ -99,13 +87,13 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
         <div className="flex items-center justify-center gap-3 mb-6">
           <StepDot number={1} active={step === "auth"} done={stepState.authDone} label="Sign in" />
           <div className="w-6 h-px bg-outline-variant/40" />
-          <StepDot number={2} active={step === "plex"} done={stepState.plexDone} label="Configure Plex" />
+          <StepDot number={2} active={step === "general"} done={stepState.generalDone} label="General" />
           <div className="w-6 h-px bg-outline-variant/40" />
-          <StepDot number={3} active={step === "general"} done={stepState.generalDone ?? false} label="General" />
+          <StepDot number={3} active={step === "plex"} done={stepState.plexDone} label="Plex" />
           <div className="w-6 h-px bg-outline-variant/40" />
-          <StepDot number={4} active={step === "collections"} done={stepState.collectionsDone ?? false} label="Collections" />
+          <StepDot number={4} active={step === "collections"} done={stepState.collectionsDone} label="Collections" />
           <div className="w-6 h-px bg-outline-variant/40" />
-          <StepDot number={5} active={step === "preload"} done={stepState.preloadDone} label="Preloading" />
+          <StepDot number={5} active={step === "users"} done={stepState.usersDone} label="Users" />
         </div>
 
         {step === "auth" && (
@@ -134,21 +122,22 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
           </div>
         )}
 
-        {step === "plex" && (
-          <PlexConfigForm
-            initialConfig={setupStatus?.plex ?? null}
-            saveUrl="/api/setup/plex/save"
-            saveLabel="Continue to General"
+        {step === "general" && settings && (
+          <GeneralOnboardingStep
+            settings={settings}
             onSaved={async () => {
               await loadSetupState();
-              setStep("general");
+              setStep("plex");
             }}
           />
         )}
 
-        {step === "general" && settings && (
-          <GeneralOnboardingStep
-            settings={settings}
+        {step === "plex" && (
+          <PlexConfigForm
+            initialConfig={setupStatus?.plex ?? null}
+            saveUrl="/api/setup/plex/save"
+            saveLabel="Continue to Collections"
+            onBack={() => setStep("general")}
             onSaved={async () => {
               await loadSetupState();
               setStep("collections");
@@ -160,7 +149,17 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
           <CollectionsConfigForm
             initialValue={settings.collections}
             librariesUrl="/api/setup/plex/libraries"
-            saveLabel="Finish Setup"
+            saveLabel="Continue to Users"
+            onBack={() => setStep("plex")}
+            onSaved={async () => {
+              setStep("users");
+            }}
+          />
+        )}
+
+        {step === "users" && (
+          <UsersOnboardingStep
+            onBack={() => setStep("collections")}
             onSaved={async () => {
               setStep("preload");
             }}
@@ -172,6 +171,246 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
         )}
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Users step
+// ---------------------------------------------------------------------------
+
+// How many times to re-fetch users to pick up avatars that are still being
+// cached in the background after the Plex step completes.
+const AVATAR_POLL_MAX = 6;
+
+function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved: () => Promise<void> }) {
+  const [users, setUsers] = useState<UserRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [avatarPollCount, setAvatarPollCount] = useState(0);
+  const initialSelectionDone = useRef(false);
+
+  // Initial load
+  useEffect(() => {
+    apiGet<UserRecord[]>("/api/users")
+      .then((list) => {
+        setUsers(list);
+        if (!initialSelectionDone.current) {
+          // Pre-select the admin and any users already enabled
+          setSelectedIds(new Set(list.filter((u) => u.isSelf || u.enabled).map((u) => u.id)));
+          initialSelectionDone.current = true;
+        }
+      })
+      .catch(() => {
+        /* empty state shown, user can proceed */
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Keep re-fetching avatars that are still being cached in the background.
+  // Stops once all users have avatars or after AVATAR_POLL_MAX attempts.
+  useEffect(() => {
+    if (users.length === 0 || avatarPollCount >= AVATAR_POLL_MAX) return;
+    const hasMissing = users.some((u) => u.avatarUrl === null);
+    if (!hasMissing) return;
+
+    const timer = setTimeout(async () => {
+      try {
+        const list = await apiGet<UserRecord[]>("/api/users");
+        setUsers(list);
+      } catch {
+        /* ignore — we'll try again next cycle */
+      }
+      setAvatarPollCount((c) => c + 1);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [users, avatarPollCount]);
+
+  function toggle(id: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function toggleAll() {
+    if (selectedIds.size === users.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(users.map((u) => u.id)));
+    }
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      // All users default to disabled — only a single call is needed to enable
+      // the selected ones. Unselected users are already disabled.
+      if (selectedIds.size > 0) {
+        await apiPost("/api/users/bulk", {
+          ids: [...selectedIds],
+          enabled: true
+        });
+      }
+      await onSaved();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+      setSaving(false);
+    }
+  }
+
+  const allSelected = users.length > 0 && selectedIds.size === users.length;
+  const noneSelected = selectedIds.size === 0;
+
+  return (
+    <div className="bg-surface-container rounded-2xl p-6 border border-outline-variant/20 max-w-2xl mx-auto">
+      <h2 className="font-headline font-semibold text-lg text-on-surface mb-1">
+        Choose Your Users
+      </h2>
+      <p className="text-on-surface-variant text-sm mb-6">
+        Select which Plex users to create watchlist collections for.<br />
+        Collections will be synced to Plex as part of setup.
+      </p>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-10 gap-2 text-on-surface-variant text-sm">
+          <Loader2 size={18} className="animate-spin" />
+          Loading users...
+        </div>
+      ) : users.length === 0 ? (
+        <div className="text-center py-10 text-on-surface-variant text-sm">
+          No users found yet. You can add them from the Users page after setup.
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-wrap gap-3 mb-5 justify-center">
+            {users.map((user) => (
+              <UserSelectCard
+                key={user.id}
+                user={user}
+                selected={selectedIds.has(user.id)}
+                onToggle={() => toggle(user.id)}
+              />
+            ))}
+          </div>
+
+          <div className="flex items-center justify-between pt-4 border-t border-outline-variant/20">
+            <button
+              onClick={toggleAll}
+              className="text-sm text-primary hover:text-primary-dim transition-colors"
+            >
+              {allSelected ? "Deselect all" : "Select all"}
+            </button>
+            <span className="text-xs text-on-surface-variant">
+              {selectedIds.size} of {users.length} selected
+            </span>
+          </div>
+        </>
+      )}
+
+      {error && (
+        <div className="mt-4 bg-error/10 border border-error/30 rounded-lg px-4 py-3 text-error text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="mt-5 flex items-center justify-between">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+        >
+          <ChevronLeft size={15} />
+          Back
+        </button>
+        <button
+          disabled={saving}
+          onClick={() => void save()}
+          className="flex items-center gap-2 bg-primary hover:bg-primary-dim disabled:opacity-50 disabled:cursor-not-allowed text-on-primary font-semibold rounded-xl px-5 py-2.5 text-sm transition-colors"
+        >
+          {saving ? (
+            <>
+              <Loader2 size={15} className="animate-spin" />
+              Saving...
+            </>
+          ) : noneSelected ? (
+            "Skip"
+          ) : (
+            <>
+              Continue
+              <ChevronRight size={15} />
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function UserSelectCard({
+  user,
+  selected,
+  onToggle
+}: {
+  user: UserRecord;
+  selected: boolean;
+  onToggle: () => void;
+}) {
+  const avatarSrc = getPlexImageSrc(user.avatarUrl);
+
+  return (
+    <button
+      onClick={onToggle}
+      className={`flex flex-col items-center gap-2 p-3 rounded-xl w-24 transition-all ${
+        selected
+          ? "bg-primary/10 ring-1 ring-primary/40"
+          : "hover:bg-surface-container-high ring-1 ring-transparent"
+      }`}
+    >
+      <div className="relative w-14 h-14 shrink-0">
+        <div
+          className={`w-full h-full rounded-full overflow-hidden transition-opacity ${
+            selected ? "opacity-100" : "opacity-50"
+          }`}
+        >
+          {avatarSrc ? (
+            <img src={avatarSrc} alt={user.displayName} className="w-full h-full object-cover" />
+          ) : (
+            <div className="w-full h-full bg-primary/20 flex items-center justify-center">
+              <span className="text-primary font-semibold text-xl">
+                {user.displayName[0]?.toUpperCase() ?? "?"}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {selected && (
+          <div className="absolute -bottom-0.5 -right-0.5 w-5 h-5 rounded-full bg-primary flex items-center justify-center">
+            <Check size={11} className="text-on-primary" />
+          </div>
+        )}
+      </div>
+
+      <div className="w-full text-center">
+        <p
+          className={`text-xs font-medium leading-tight truncate ${
+            selected ? "text-on-surface" : "text-on-surface-variant"
+          }`}
+        >
+          {user.displayName}
+        </p>
+        {user.isSelf && (
+          <p className="text-[10px] text-primary leading-tight mt-0.5">You</p>
+        )}
+      </div>
+    </button>
   );
 }
 
@@ -190,20 +429,21 @@ const INITIAL_PHASES: Record<PreloadPhase, PhaseState> = {
   "discover-users": { status: "idle", message: "" },
   "activity-cache": { status: "idle", message: "" },
   "graphql-sync": { status: "idle", message: "" },
+  "publish-collections": { status: "idle", message: "" },
   "complete": { status: "idle", message: "" }
 };
 
 const PHASE_LABELS: Record<Exclude<PreloadPhase, "complete">, string> = {
   "discover-users": "Fetch Plex users & avatars",
   "activity-cache": "Sync activity feed",
-  "graphql-sync": "Sync watchlists"
+  "graphql-sync": "Sync watchlists",
+  "publish-collections": "Publish collections"
 };
 
 function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
   const [phases, setPhases] = useState<Record<PreloadPhase, PhaseState>>(INITIAL_PHASES);
   const [done, setDone] = useState(false);
   const [fatalError, setFatalError] = useState<string | null>(null);
-  // Prevent double-entering the app if the EventSource fires multiple complete events
   const enteringRef = useRef(false);
 
   useEffect(() => {
@@ -220,11 +460,16 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
       if (event.phase === "complete") {
         es.close();
         setDone(true);
-        // Enter the app automatically after a short pause so the user can see
-        // the completed state before navigating away.
         if (!enteringRef.current) {
           enteringRef.current = true;
-          window.setTimeout(() => void onComplete(), 1500);
+          window.setTimeout(async () => {
+            try {
+              await apiPost("/api/setup/complete", {});
+            } catch {
+              // non-fatal — app will still work, onboarding won't repeat
+            }
+            await onComplete();
+          }, 1500);
         }
         return;
       }
@@ -248,7 +493,6 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
     return () => {
       es.close();
     };
-    // onComplete is stable (passed from App level), so the empty dep array is intentional
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -258,11 +502,12 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
         Getting Hubarr Ready
       </h2>
       <p className="text-on-surface-variant text-sm mb-6">
-        Loading your data in the background — this only happens once.
+        Running your first full sync to get everything ready.<br />
+        This only happens once — future syncs will be much faster.
       </p>
 
       <div className="space-y-3">
-        {(["discover-users", "activity-cache", "graphql-sync"] as const).map((phase) => (
+        {(["discover-users", "activity-cache", "graphql-sync", "publish-collections"] as const).map((phase) => (
           <PreloadPhaseRow
             key={phase}
             label={PHASE_LABELS[phase]}
@@ -297,14 +542,9 @@ function PreloadPhaseRow({ label, state }: { label: string; state: PhaseState })
 
   return (
     <div className="flex items-start gap-3">
-      {/* Status icon */}
       <div className="mt-0.5 w-5 h-5 flex items-center justify-center shrink-0">
-        {isIdle && (
-          <div className="w-4 h-4 rounded-full border-2 border-outline-variant/40" />
-        )}
-        {isRunning && (
-          <Loader2 size={16} className="animate-spin text-primary" />
-        )}
+        {isIdle && <div className="w-4 h-4 rounded-full border-2 border-outline-variant/40" />}
+        {isRunning && <Loader2 size={16} className="animate-spin text-primary" />}
         {isDone && (
           <div className="w-4 h-4 rounded-full bg-success flex items-center justify-center">
             <Check size={10} className="text-white" />
@@ -317,7 +557,6 @@ function PreloadPhaseRow({ label, state }: { label: string; state: PhaseState })
         )}
       </div>
 
-      {/* Label and message */}
       <div className="flex-1 min-w-0">
         <p className={`text-sm font-medium leading-tight ${isIdle ? "text-on-surface-variant" : "text-on-surface"}`}>
           {label}
@@ -325,15 +564,11 @@ function PreloadPhaseRow({ label, state }: { label: string; state: PhaseState })
         {state.message && (
           <p className={`text-xs mt-0.5 ${isError ? "text-error" : "text-on-surface-variant"}`}>
             {state.message}
-            {/* Inline progress counter for the graphql-sync phase */}
             {isRunning && state.total !== undefined && state.total > 0 && state.progress !== undefined && (
-              <span className="ml-1 text-on-surface-variant/60">
-                ({state.progress}/{state.total})
-              </span>
+              <span className="ml-1 text-on-surface-variant/60">({state.progress}/{state.total})</span>
             )}
           </p>
         )}
-        {/* Progress bar for graphql-sync */}
         {isRunning && state.total !== undefined && state.total > 0 && (
           <div className="mt-1.5 h-1 rounded-full bg-surface-container-high overflow-hidden">
             <div
@@ -375,10 +610,7 @@ function GeneralOnboardingStep({
     setError(null);
     try {
       await apiPatch("/api/settings", {
-        general: {
-          trackAllUsers,
-          fullSyncOnStartup
-        }
+        general: { trackAllUsers, fullSyncOnStartup }
       });
       setSuccess(true);
       await onSaved();
@@ -392,19 +624,19 @@ function GeneralOnboardingStep({
   return (
     <SectionCard
       title="General Settings"
-      description="Choose how Hubarr should behave after Plex is connected. You can change these again later in Settings."
+      description="Configure the global settings for your Hubarr instance. You can change these again later in Settings."
       wide
     >
       <div className="space-y-4">
         <ToggleField
           label="Track All Users"
-          hint="Keep background watchlist tracking running for disabled users too. Turning this off deletes cached watchlist data for disabled users."
+          hint="This allows you to view watchlist data for all your Plex users regardless of their enabled status. This will not publish collections."
           checked={trackAllUsers}
           onChange={setTrackAllUsers}
         />
         <ToggleField
           label="Startup Sync"
-          hint="When Hubarr starts, run a Plex full library scan, then a watchlist GraphQL sync, then a collection sync."
+          hint="When Hubarr starts, run a full scan of your libraries and watchlists, then publish collections."
           checked={fullSyncOnStartup}
           onChange={setFullSyncOnStartup}
         />
@@ -414,7 +646,7 @@ function GeneralOnboardingStep({
         success={success}
         error={error}
         onSave={() => void save()}
-        label="Continue to Collections"
+        label="Continue to Plex"
       />
     </SectionCard>
   );

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useMemo, useState } from "react";
-import { Check, ChevronRight } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronRight, Loader2, X } from "lucide-react";
 import { apiGet, apiPatch, apiPost } from "../lib/api";
 import PlexOAuth from "../lib/plexOAuth";
 import PlexConfigForm from "../components/PlexConfigForm";
 import CollectionsConfigForm from "../components/CollectionsConfigForm";
 import { SaveBar, SectionCard, ToggleField } from "../components/FormControls";
-import type { OnboardingStep, SetupStatusResponse, SettingsResponse } from "../../shared/types";
+import type {
+  OnboardingStep,
+  PreloadPhase,
+  PreloadProgressEvent,
+  SetupStatusResponse,
+  SettingsResponse
+} from "../../shared/types";
 
 interface OnboardingProps {
   authenticated?: boolean;
@@ -60,20 +66,25 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
 
   const stepState = useMemo(() => {
     if (step === "auth") {
-      return { authDone: false, plexDone: false, generalDone: false };
+      return { authDone: false, plexDone: false, generalDone: false, collectionsDone: false, preloadDone: false };
     }
     if (step === "plex") {
-      return { authDone: true, plexDone: false, generalDone: false };
+      return { authDone: true, plexDone: false, generalDone: false, collectionsDone: false, preloadDone: false };
     }
     if (step === "general") {
-      return { authDone: true, plexDone: true, generalDone: false };
+      return { authDone: true, plexDone: true, generalDone: false, collectionsDone: false, preloadDone: false };
     }
-    return {
-      authDone: true,
-      plexDone: true,
-      generalDone: true,
-      collectionsDone: Boolean(setupStatus?.collectionsConfigured)
-    };
+    if (step === "collections") {
+      return {
+        authDone: true,
+        plexDone: true,
+        generalDone: true,
+        collectionsDone: Boolean(setupStatus?.collectionsConfigured),
+        preloadDone: false
+      };
+    }
+    // preload
+    return { authDone: true, plexDone: true, generalDone: true, collectionsDone: true, preloadDone: false };
   }, [setupStatus?.collectionsConfigured, step]);
 
   return (
@@ -86,13 +97,15 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
         </div>
 
         <div className="flex items-center justify-center gap-3 mb-6">
-          <StepDot number={1} active={step === "auth"} done={stepState.authDone} label="Sign in with Plex" />
-          <div className="w-8 h-px bg-outline-variant/40" />
+          <StepDot number={1} active={step === "auth"} done={stepState.authDone} label="Sign in" />
+          <div className="w-6 h-px bg-outline-variant/40" />
           <StepDot number={2} active={step === "plex"} done={stepState.plexDone} label="Configure Plex" />
-          <div className="w-8 h-px bg-outline-variant/40" />
+          <div className="w-6 h-px bg-outline-variant/40" />
           <StepDot number={3} active={step === "general"} done={stepState.generalDone ?? false} label="General" />
-          <div className="w-8 h-px bg-outline-variant/40" />
+          <div className="w-6 h-px bg-outline-variant/40" />
           <StepDot number={4} active={step === "collections"} done={stepState.collectionsDone ?? false} label="Collections" />
+          <div className="w-6 h-px bg-outline-variant/40" />
+          <StepDot number={5} active={step === "preload"} done={stepState.preloadDone} label="Preloading" />
         </div>
 
         {step === "auth" && (
@@ -149,14 +162,194 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
             librariesUrl="/api/setup/plex/libraries"
             saveLabel="Finish Setup"
             onSaved={async () => {
-              await onComplete();
+              setStep("preload");
             }}
           />
+        )}
+
+        {step === "preload" && (
+          <PreloadStep onComplete={onComplete} />
         )}
       </div>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Preload step
+// ---------------------------------------------------------------------------
+
+interface PhaseState {
+  status: "idle" | "running" | "done" | "error";
+  message: string;
+  progress?: number;
+  total?: number;
+}
+
+const INITIAL_PHASES: Record<PreloadPhase, PhaseState> = {
+  "discover-users": { status: "idle", message: "" },
+  "activity-cache": { status: "idle", message: "" },
+  "graphql-sync": { status: "idle", message: "" },
+  "complete": { status: "idle", message: "" }
+};
+
+const PHASE_LABELS: Record<Exclude<PreloadPhase, "complete">, string> = {
+  "discover-users": "Fetch Plex users & avatars",
+  "activity-cache": "Sync activity feed",
+  "graphql-sync": "Sync watchlists"
+};
+
+function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
+  const [phases, setPhases] = useState<Record<PreloadPhase, PhaseState>>(INITIAL_PHASES);
+  const [done, setDone] = useState(false);
+  const [fatalError, setFatalError] = useState<string | null>(null);
+  // Prevent double-entering the app if the EventSource fires multiple complete events
+  const enteringRef = useRef(false);
+
+  useEffect(() => {
+    const es = new EventSource("/api/setup/preload");
+
+    es.onmessage = (e: MessageEvent<string>) => {
+      let event: PreloadProgressEvent;
+      try {
+        event = JSON.parse(e.data) as PreloadProgressEvent;
+      } catch {
+        return;
+      }
+
+      if (event.phase === "complete") {
+        es.close();
+        setDone(true);
+        // Enter the app automatically after a short pause so the user can see
+        // the completed state before navigating away.
+        if (!enteringRef.current) {
+          enteringRef.current = true;
+          window.setTimeout(() => void onComplete(), 1500);
+        }
+        return;
+      }
+
+      setPhases((prev) => ({
+        ...prev,
+        [event.phase]: {
+          status: event.status,
+          message: event.message,
+          progress: event.progress,
+          total: event.total
+        }
+      }));
+    };
+
+    es.onerror = () => {
+      es.close();
+      setFatalError("Connection to server lost. Please refresh and try again.");
+    };
+
+    return () => {
+      es.close();
+    };
+    // onComplete is stable (passed from App level), so the empty dep array is intentional
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="bg-surface-container rounded-2xl p-6 border border-outline-variant/20 max-w-xl mx-auto">
+      <h2 className="font-headline font-semibold text-lg text-on-surface mb-1">
+        Getting Hubarr Ready
+      </h2>
+      <p className="text-on-surface-variant text-sm mb-6">
+        Loading your data in the background — this only happens once.
+      </p>
+
+      <div className="space-y-3">
+        {(["discover-users", "activity-cache", "graphql-sync"] as const).map((phase) => (
+          <PreloadPhaseRow
+            key={phase}
+            label={PHASE_LABELS[phase]}
+            state={phases[phase]}
+          />
+        ))}
+      </div>
+
+      {done && (
+        <div className="mt-6 pt-5 border-t border-outline-variant/20 flex flex-col items-center gap-3">
+          <div className="flex items-center gap-2 text-success text-sm font-medium">
+            <Check size={16} />
+            Hubarr is ready — entering now…
+          </div>
+        </div>
+      )}
+
+      {fatalError && (
+        <div className="mt-4 bg-error/10 border border-error/30 rounded-lg px-4 py-3 text-error text-sm">
+          {fatalError}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PreloadPhaseRow({ label, state }: { label: string; state: PhaseState }) {
+  const isIdle = state.status === "idle";
+  const isRunning = state.status === "running";
+  const isDone = state.status === "done";
+  const isError = state.status === "error";
+
+  return (
+    <div className="flex items-start gap-3">
+      {/* Status icon */}
+      <div className="mt-0.5 w-5 h-5 flex items-center justify-center shrink-0">
+        {isIdle && (
+          <div className="w-4 h-4 rounded-full border-2 border-outline-variant/40" />
+        )}
+        {isRunning && (
+          <Loader2 size={16} className="animate-spin text-primary" />
+        )}
+        {isDone && (
+          <div className="w-4 h-4 rounded-full bg-success flex items-center justify-center">
+            <Check size={10} className="text-white" />
+          </div>
+        )}
+        {isError && (
+          <div className="w-4 h-4 rounded-full bg-error/20 flex items-center justify-center">
+            <X size={10} className="text-error" />
+          </div>
+        )}
+      </div>
+
+      {/* Label and message */}
+      <div className="flex-1 min-w-0">
+        <p className={`text-sm font-medium leading-tight ${isIdle ? "text-on-surface-variant" : "text-on-surface"}`}>
+          {label}
+        </p>
+        {state.message && (
+          <p className={`text-xs mt-0.5 ${isError ? "text-error" : "text-on-surface-variant"}`}>
+            {state.message}
+            {/* Inline progress counter for the graphql-sync phase */}
+            {isRunning && state.total !== undefined && state.total > 0 && state.progress !== undefined && (
+              <span className="ml-1 text-on-surface-variant/60">
+                ({state.progress}/{state.total})
+              </span>
+            )}
+          </p>
+        )}
+        {/* Progress bar for graphql-sync */}
+        {isRunning && state.total !== undefined && state.total > 0 && (
+          <div className="mt-1.5 h-1 rounded-full bg-surface-container-high overflow-hidden">
+            <div
+              className="h-full bg-primary rounded-full transition-all duration-300"
+              style={{ width: `${Math.round(((state.progress ?? 0) / state.total) * 100)}%` }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// General step
+// ---------------------------------------------------------------------------
 
 function GeneralOnboardingStep({
   settings,
@@ -226,6 +419,10 @@ function GeneralOnboardingStep({
     </SectionCard>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Step indicator dot
+// ---------------------------------------------------------------------------
 
 function StepDot({
   number,

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -152,6 +152,7 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
             saveLabel="Continue to Users"
             onBack={() => setStep("plex")}
             onSaved={async () => {
+              await loadSetupState();
               setStep("users");
             }}
           />
@@ -332,6 +333,7 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
                 key={user.id}
                 user={user}
                 selected={selectedIds.has(user.id)}
+                disabled={saving}
                 onToggle={() => toggle(user.id)}
               />
             ))}
@@ -339,8 +341,9 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
 
           <div className="flex items-center justify-between pt-4 border-t border-outline-variant/20">
             <button
+              disabled={saving}
               onClick={toggleAll}
-              className="text-sm text-primary hover:text-primary-dim transition-colors"
+              className="text-sm text-primary hover:text-primary-dim disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {allSelected ? "Deselect all" : "Select all"}
             </button>
@@ -359,8 +362,9 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
 
       <div className="mt-5 flex items-center justify-between">
         <button
+          disabled={saving}
           onClick={onBack}
-          className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+          className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright disabled:opacity-50 disabled:cursor-not-allowed text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
         >
           <ChevronLeft size={15} />
           Back
@@ -392,18 +396,25 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
 function UserSelectCard({
   user,
   selected,
+  disabled = false,
   onToggle
 }: {
   user: UserRecord;
   selected: boolean;
+  disabled?: boolean;
   onToggle: () => void;
 }) {
   const avatarSrc = getPlexImageSrc(user.avatarUrl);
 
   return (
     <button
-      onClick={onToggle}
-      className={`flex flex-col items-center gap-2 p-3 rounded-xl w-24 transition-all ${
+      disabled={disabled}
+      onClick={() => {
+        if (!disabled) {
+          onToggle();
+        }
+      }}
+      className={`flex flex-col items-center gap-2 p-3 rounded-xl w-24 transition-all disabled:opacity-60 disabled:cursor-not-allowed ${
         selected
           ? "bg-primary/10 ring-1 ring-primary/40"
           : "hover:bg-surface-container-high ring-1 ring-transparent"
@@ -463,21 +474,18 @@ interface PhaseState {
 type VisiblePreloadPhase = Exclude<PreloadPhase, "complete">;
 
 const VISIBLE_PRELOAD_PHASES: VisiblePreloadPhase[] = [
-  "discover-users",
   "activity-cache",
   "graphql-sync",
   "publish-collections"
 ];
 
 const INITIAL_PHASES: Record<VisiblePreloadPhase, PhaseState> = {
-  "discover-users": { status: "idle", message: "" },
   "activity-cache": { status: "idle", message: "" },
   "graphql-sync": { status: "idle", message: "" },
   "publish-collections": { status: "idle", message: "" }
 };
 
 const PHASE_LABELS: Record<VisiblePreloadPhase, string> = {
-  "discover-users": "Fetch Plex users & avatars",
   "activity-cache": "Sync activity feed",
   "graphql-sync": "Sync watchlists",
   "publish-collections": "Publish collections"
@@ -634,7 +642,10 @@ function PreloadPhaseRow({ label, state }: { label: string; state: PhaseState })
   const isRunning = state.status === "running";
   const isDone = state.status === "done";
   const isError = state.status === "error";
-  const showProgress = isRunning && state.total !== undefined && state.total > 0;
+  const showProgress = isRunning && state.progress !== undefined && state.total !== undefined && state.total > 0;
+  const progressValue: number = showProgress ? (state.progress ?? 0) : 0;
+  const progressTotal: number = showProgress ? (state.total ?? 0) : 0;
+  const progressPercent = showProgress ? Math.round((progressValue / progressTotal) * 100) : 0;
 
   return (
     <div className="flex items-start gap-3">
@@ -660,16 +671,14 @@ function PreloadPhaseRow({ label, state }: { label: string; state: PhaseState })
         {state.message && (
           <p className={`text-xs mt-0.5 ${isError ? "text-error" : "text-on-surface-variant"}`}>
             {state.message}
-            {showProgress && state.progress !== undefined && (
-              <span className="ml-1 text-on-surface-variant/60">({state.progress}/{state.total})</span>
-            )}
+            {showProgress && <span className="ml-1 text-on-surface-variant/60">({progressValue}/{progressTotal})</span>}
           </p>
         )}
         {showProgress && (
           <div className="mt-1.5 h-1 rounded-full bg-surface-container-high overflow-hidden">
             <div
               className="h-full bg-primary rounded-full transition-all duration-300"
-              style={{ width: `${Math.round(((state.progress ?? 0) / state.total) * 100)}%` }}
+              style={{ width: `${progressPercent}%` }}
             />
           </div>
         )}
@@ -764,7 +773,7 @@ function StepDot({
   label: string;
 }) {
   return (
-    <div className="flex flex-col items-center gap-1">
+    <div className="w-16 sm:w-20 flex flex-col items-center gap-1">
       <div
         className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold transition-colors ${
           done
@@ -776,7 +785,7 @@ function StepDot({
       >
         {done ? <Check size={14} /> : number}
       </div>
-      <span className={`text-xs ${active ? "text-on-surface" : "text-on-surface-variant"}`}>
+      <span className={`text-xs text-center ${active ? "text-on-surface" : "text-on-surface-variant"}`}>
         {label}
       </span>
     </div>

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -182,6 +182,10 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
 // cached in the background after the Plex step completes.
 const AVATAR_POLL_MAX = 6;
 
+/**
+ * Lets the admin choose which Plex users should have watchlist collections
+ * enabled before the one-time preload runs.
+ */
 function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved: () => Promise<void> }) {
   const [users, setUsers] = useState<UserRecord[]>([]);
   const [loading, setLoading] = useState(true);
@@ -190,17 +194,38 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
   const [error, setError] = useState<string | null>(null);
   const [avatarPollCount, setAvatarPollCount] = useState(0);
   const initialSelectionDone = useRef(false);
+  const knownUserIds = useRef<Set<number>>(new Set());
+
+  // Merge newly fetched users into local state without undoing manual
+  // selection changes for users the admin has already seen on the page.
+  function applyFetchedUsers(list: UserRecord[]) {
+    const nextKnownIds = new Set(list.map((user) => user.id));
+    const autoSelectedIds = list.filter((user) => user.isSelf || user.enabled).map((user) => user.id);
+
+    setUsers(list);
+    setSelectedIds((prev) => {
+      if (!initialSelectionDone.current) {
+        initialSelectionDone.current = true;
+        knownUserIds.current = nextKnownIds;
+        return new Set(autoSelectedIds);
+      }
+
+      const next = new Set(prev);
+      for (const id of autoSelectedIds) {
+        if (!knownUserIds.current.has(id)) {
+          next.add(id);
+        }
+      }
+      knownUserIds.current = nextKnownIds;
+      return next;
+    });
+  }
 
   // Initial load
   useEffect(() => {
     apiGet<UserRecord[]>("/api/users")
       .then((list) => {
-        setUsers(list);
-        if (!initialSelectionDone.current) {
-          // Pre-select the admin and any users already enabled
-          setSelectedIds(new Set(list.filter((u) => u.isSelf || u.enabled).map((u) => u.id)));
-          initialSelectionDone.current = true;
-        }
+        applyFetchedUsers(list);
       })
       .catch(() => {
         /* empty state shown, user can proceed */
@@ -218,7 +243,7 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
     const timer = setTimeout(async () => {
       try {
         const list = await apiGet<UserRecord[]>("/api/users");
-        setUsers(list);
+        applyFetchedUsers(list);
       } catch {
         /* ignore — we'll try again next cycle */
       }
@@ -458,15 +483,38 @@ const PHASE_LABELS: Record<VisiblePreloadPhase, string> = {
   "publish-collections": "Publish collections"
 };
 
+/**
+ * Streams the one-time preload progress, then marks onboarding complete before
+ * handing control back to the main app shell.
+ */
 function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
   const [phases, setPhases] = useState<Record<VisiblePreloadPhase, PhaseState>>(INITIAL_PHASES);
   const [done, setDone] = useState(false);
   const [fatalError, setFatalError] = useState<string | null>(null);
   const [retryToken, setRetryToken] = useState(0);
+  const [retryCompletionOnly, setRetryCompletionOnly] = useState(false);
   const enteringRef = useRef(false);
   const onCompleteRef = useRef(onComplete);
 
   onCompleteRef.current = onComplete;
+
+  async function finishOnboarding() {
+    setFatalError(null);
+    try {
+      await apiPost("/api/setup/complete", {});
+      setRetryCompletionOnly(false);
+      await onCompleteRef.current();
+    } catch (caught) {
+      setDone(false);
+      setRetryCompletionOnly(true);
+      enteringRef.current = false;
+      setFatalError(
+        caught instanceof Error
+          ? caught.message
+          : "Could not finish setup. Retry to enter Hubarr."
+      );
+    }
+  }
 
   useEffect(() => {
     let closed = false;
@@ -487,15 +535,11 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
         }
         setDone(true);
         setFatalError(null);
+        setRetryCompletionOnly(false);
         if (!enteringRef.current) {
           enteringRef.current = true;
           window.setTimeout(async () => {
-            try {
-              await apiPost("/api/setup/complete", {});
-            } catch {
-              // non-fatal — app will still work, onboarding won't repeat
-            }
-            await onCompleteRef.current();
+            await finishOnboarding();
           }, 1500);
         }
         return;
@@ -527,9 +571,16 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
   }, [retryToken]);
 
   function retry() {
+    if (retryCompletionOnly) {
+      enteringRef.current = true;
+      void finishOnboarding();
+      return;
+    }
+
     enteringRef.current = false;
     setDone(false);
     setFatalError(null);
+    setRetryCompletionOnly(false);
     setPhases(INITIAL_PHASES);
     setRetryToken((current) => current + 1);
   }

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -252,14 +252,24 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
     setSaving(true);
     setError(null);
     try {
-      // All users default to disabled — only a single call is needed to enable
-      // the selected ones. Unselected users are already disabled.
-      if (selectedIds.size > 0) {
+      const selectedUserIds = users.filter((user) => selectedIds.has(user.id)).map((user) => user.id);
+      const deselectedUserIds = users.filter((user) => !selectedIds.has(user.id)).map((user) => user.id);
+
+      if (selectedUserIds.length > 0) {
         await apiPost("/api/users/bulk", {
-          ids: [...selectedIds],
+          ids: selectedUserIds,
           enabled: true
         });
       }
+
+      if (deselectedUserIds.length > 0) {
+        await apiPost("/api/users/bulk", {
+          ids: deselectedUserIds,
+          enabled: false
+        });
+      }
+
+      await apiPost("/api/setup/users/complete", {});
       await onSaved();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
@@ -425,15 +435,23 @@ interface PhaseState {
   total?: number;
 }
 
-const INITIAL_PHASES: Record<PreloadPhase, PhaseState> = {
+type VisiblePreloadPhase = Exclude<PreloadPhase, "complete">;
+
+const VISIBLE_PRELOAD_PHASES: VisiblePreloadPhase[] = [
+  "discover-users",
+  "activity-cache",
+  "graphql-sync",
+  "publish-collections"
+];
+
+const INITIAL_PHASES: Record<VisiblePreloadPhase, PhaseState> = {
   "discover-users": { status: "idle", message: "" },
   "activity-cache": { status: "idle", message: "" },
   "graphql-sync": { status: "idle", message: "" },
-  "publish-collections": { status: "idle", message: "" },
-  "complete": { status: "idle", message: "" }
+  "publish-collections": { status: "idle", message: "" }
 };
 
-const PHASE_LABELS: Record<Exclude<PreloadPhase, "complete">, string> = {
+const PHASE_LABELS: Record<VisiblePreloadPhase, string> = {
   "discover-users": "Fetch Plex users & avatars",
   "activity-cache": "Sync activity feed",
   "graphql-sync": "Sync watchlists",
@@ -441,12 +459,17 @@ const PHASE_LABELS: Record<Exclude<PreloadPhase, "complete">, string> = {
 };
 
 function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
-  const [phases, setPhases] = useState<Record<PreloadPhase, PhaseState>>(INITIAL_PHASES);
+  const [phases, setPhases] = useState<Record<VisiblePreloadPhase, PhaseState>>(INITIAL_PHASES);
   const [done, setDone] = useState(false);
   const [fatalError, setFatalError] = useState<string | null>(null);
+  const [retryToken, setRetryToken] = useState(0);
   const enteringRef = useRef(false);
+  const onCompleteRef = useRef(onComplete);
+
+  onCompleteRef.current = onComplete;
 
   useEffect(() => {
+    let closed = false;
     const es = new EventSource("/api/setup/preload");
 
     es.onmessage = (e: MessageEvent<string>) => {
@@ -459,7 +482,11 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
 
       if (event.phase === "complete") {
         es.close();
+        if (closed) {
+          return;
+        }
         setDone(true);
+        setFatalError(null);
         if (!enteringRef.current) {
           enteringRef.current = true;
           window.setTimeout(async () => {
@@ -468,7 +495,7 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
             } catch {
               // non-fatal — app will still work, onboarding won't repeat
             }
-            await onComplete();
+            await onCompleteRef.current();
           }, 1500);
         }
         return;
@@ -487,14 +514,25 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
 
     es.onerror = () => {
       es.close();
-      setFatalError("Connection to server lost. Please refresh and try again.");
+      if (closed) {
+        return;
+      }
+      setFatalError("Connection to server lost. Retry to continue the preload.");
     };
 
     return () => {
+      closed = true;
       es.close();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [retryToken]);
+
+  function retry() {
+    enteringRef.current = false;
+    setDone(false);
+    setFatalError(null);
+    setPhases(INITIAL_PHASES);
+    setRetryToken((current) => current + 1);
+  }
 
   return (
     <div className="bg-surface-container rounded-2xl p-6 border border-outline-variant/20 max-w-xl mx-auto">
@@ -507,7 +545,7 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
       </p>
 
       <div className="space-y-3">
-        {(["discover-users", "activity-cache", "graphql-sync", "publish-collections"] as const).map((phase) => (
+        {VISIBLE_PRELOAD_PHASES.map((phase) => (
           <PreloadPhaseRow
             key={phase}
             label={PHASE_LABELS[phase]}
@@ -527,7 +565,13 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
 
       {fatalError && (
         <div className="mt-4 bg-error/10 border border-error/30 rounded-lg px-4 py-3 text-error text-sm">
-          {fatalError}
+          <p>{fatalError}</p>
+          <button
+            onClick={retry}
+            className="mt-3 inline-flex items-center gap-2 bg-error text-white font-semibold rounded-lg px-3 py-2 text-sm transition-colors hover:opacity-90"
+          >
+            Retry preload
+          </button>
         </div>
       )}
     </div>

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -634,6 +634,7 @@ function PreloadPhaseRow({ label, state }: { label: string; state: PhaseState })
   const isRunning = state.status === "running";
   const isDone = state.status === "done";
   const isError = state.status === "error";
+  const showProgress = isRunning && state.total !== undefined && state.total > 0;
 
   return (
     <div className="flex items-start gap-3">
@@ -659,12 +660,12 @@ function PreloadPhaseRow({ label, state }: { label: string; state: PhaseState })
         {state.message && (
           <p className={`text-xs mt-0.5 ${isError ? "text-error" : "text-on-surface-variant"}`}>
             {state.message}
-            {isRunning && state.total !== undefined && state.total > 0 && state.progress !== undefined && (
+            {showProgress && state.progress !== undefined && (
               <span className="ml-1 text-on-surface-variant/60">({state.progress}/{state.total})</span>
             )}
           </p>
         )}
-        {isRunning && state.total !== undefined && state.total > 0 && (
+        {showProgress && (
           <div className="mt-1.5 h-1 rounded-full bg-surface-container-high overflow-hidden">
             <div
               className="h-full bg-primary rounded-full transition-all duration-300"

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -541,6 +541,10 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
         if (closed) {
           return;
         }
+        if (event.status === "error") {
+          setFatalError(event.message || "Preload failed unexpectedly. Retry to continue.");
+          return;
+        }
         setDone(true);
         setFatalError(null);
         setRetryCompletionOnly(false);

--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -228,13 +228,13 @@ function GeneralTab({
         />
         <ToggleField
           label="Track All Users"
-          hint="Keep background watchlist tracking running for disabled users too. Turning this off deletes cached watchlist data for disabled users."
+          hint="This allows you to view watchlist data for all your Plex users regardless of their enabled status. This will not publish collections."
           checked={form.trackAllUsers}
           onChange={(value) => setForm((current) => ({ ...current, trackAllUsers: value }))}
         />
         <ToggleField
           label="Startup Sync"
-          hint="When Hubarr starts, run a Plex full library scan, then a watchlist GraphQL sync, then a collection sync."
+          hint="When Hubarr starts, run a full scan of your libraries and watchlists, then publish collections."
           checked={form.fullSyncOnStartup}
           onChange={(value) => setForm((current) => ({ ...current, fullSyncOnStartup: value }))}
         />

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -393,12 +393,18 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     }
   });
 
+  app.post("/api/setup/users/complete", requireAuth, (_req, res) => {
+    db.updateAppSettings({ usersStepComplete: true });
+    res.json({ ok: true });
+  });
+
   /**
-   * Step 5 (final onboarding step): streams preload progress via Server-Sent
-   * Events.  The client connects once collections are saved and listens until
-   * a "complete" phase event signals that all three phases have finished.
+   * Final onboarding step: streams preload progress via Server-Sent Events.
+   * The client connects once the users step is confirmed and listens until a
+   * "complete" phase event signals that all four preload phases have finished.
    *
-   * Phases emitted: discover-users → activity-cache → graphql-sync → complete
+   * Phases emitted:
+   * discover-users → activity-cache → graphql-sync → publish-collections → complete
    */
   app.get("/api/setup/preload", requireAuth, async (_req, res) => {
     res.setHeader("Content-Type", "text/event-stream");
@@ -423,7 +429,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   /** Mark onboarding as fully complete so the main app becomes accessible. */
   app.post("/api/setup/complete", requireAuth, (_req, res) => {
-    db.updateAppSettings({ onboardingComplete: true });
+    db.updateAppSettings({ usersStepComplete: true, onboardingComplete: true });
     res.json({ ok: true });
   });
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -439,6 +439,10 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   /** Mark onboarding as fully complete so the main app becomes accessible. */
   app.post("/api/setup/complete", requireAuth, (_req, res) => {
+    if (!services.isPreloadComplete()) {
+      res.status(400).json({ error: "Preload has not completed successfully." });
+      return;
+    }
     db.updateAppSettings({ usersStepComplete: true, onboardingComplete: true });
     services.clearOnboardingPreloadSession();
     res.json({ ok: true });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -402,10 +402,11 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   /**
    * Final onboarding step: streams preload progress via Server-Sent Events.
    * The client connects once the users step is confirmed and listens until a
-   * "complete" phase event signals that all four preload phases have finished.
+   * "complete" phase event signals that all remaining preload phases have
+   * finished. Reconnecting during preload resumes the same in-flight session.
    *
    * Phases emitted:
-   * discover-users → activity-cache → graphql-sync → publish-collections → complete
+   * activity-cache → graphql-sync → publish-collections → complete
    */
   app.get("/api/setup/preload", requireAuth, async (_req, res) => {
     res.setHeader("Content-Type", "text/event-stream");
@@ -431,6 +432,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   /** Mark onboarding as fully complete so the main app becomes accessible. */
   app.post("/api/setup/complete", requireAuth, (_req, res) => {
     db.updateAppSettings({ usersStepComplete: true, onboardingComplete: true });
+    services.clearOnboardingPreloadSession();
     res.json({ ok: true });
   });
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -393,6 +393,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     }
   });
 
+  /** Persist completion of the user-selection step before preload begins. */
   app.post("/api/setup/users/complete", requireAuth, (_req, res) => {
     db.updateAppSettings({ usersStepComplete: true });
     res.json({ ok: true });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -393,6 +393,34 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     }
   });
 
+  /**
+   * Step 5 (final onboarding step): streams preload progress via Server-Sent
+   * Events.  The client connects once collections are saved and listens until
+   * a "complete" phase event signals that all three phases have finished.
+   *
+   * Phases emitted: discover-users → activity-cache → graphql-sync → complete
+   */
+  app.get("/api/setup/preload", requireAuth, async (_req, res) => {
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders();
+
+    try {
+      await services.runOnboardingPreload((event) => {
+        res.write(`data: ${JSON.stringify(event)}\n\n`);
+      });
+    } catch (err) {
+      // Top-level guard — runOnboardingPreload handles per-phase errors
+      // internally, so this only fires on truly unexpected failures.
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error("Onboarding preload aborted with unexpected error", { message });
+      res.write(`data: ${JSON.stringify({ phase: "complete", status: "error", message })}\n\n`);
+    }
+
+    res.end();
+  });
+
   // ---------------------------------------------------------------------------
   // Dashboard
   // ---------------------------------------------------------------------------

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -421,6 +421,12 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     res.end();
   });
 
+  /** Mark onboarding as fully complete so the main app becomes accessible. */
+  app.post("/api/setup/complete", requireAuth, (_req, res) => {
+    db.updateAppSettings({ onboardingComplete: true });
+    res.json({ ok: true });
+  });
+
   // ---------------------------------------------------------------------------
   // Dashboard
   // ---------------------------------------------------------------------------

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -408,14 +408,20 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
    * Phases emitted:
    * activity-cache → graphql-sync → publish-collections → complete
    */
-  app.get("/api/setup/preload", requireAuth, async (_req, res) => {
+  app.get("/api/setup/preload", requireAuth, async (req, res) => {
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Connection", "keep-alive");
     res.flushHeaders();
 
+    let clientDisconnected = false;
+    req.on("close", () => {
+      clientDisconnected = true;
+    });
+
     try {
       await services.runOnboardingPreload((event) => {
+        if (clientDisconnected) return;
         res.write(`data: ${JSON.stringify(event)}\n\n`);
       });
     } catch (err) {
@@ -423,7 +429,9 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       // internally, so this only fires on truly unexpected failures.
       const message = err instanceof Error ? err.message : String(err);
       logger.error("Onboarding preload aborted with unexpected error", { message });
-      res.write(`data: ${JSON.stringify({ phase: "complete", status: "error", message })}\n\n`);
+      if (!clientDisconnected) {
+        res.write(`data: ${JSON.stringify({ phase: "complete", status: "error", message })}\n\n`);
+      }
     }
 
     res.end();

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -27,14 +27,15 @@ export const defaultAppSettings: AppSettings = {
   collectionNamePattern: "{user}s Watchlist",
   collectionSortOrder: "date-desc",
   visibilityDefaults: {
-    recommended: true,
+    recommended: false,
     home: true,
-    shared: true
+    shared: false
   },
   fullSyncOnStartup: false,
   defaultMovieLibraryId: null,
   defaultShowLibraryId: null,
-  trustProxy: false
+  trustProxy: false,
+  onboardingComplete: false
 };
 
 /**
@@ -107,13 +108,24 @@ export function resolveSessionSecret(db: Database.Database, dataDir: string): st
 export function getBootstrapStatus(db: Database.Database, hasActiveSession: boolean): BootstrapStatus {
   const plexSettings = getSetting<PlexSettingsInput>(db, "plex");
   const appSettings = getAppSettings(db);
+  const setupComplete = Boolean(
+    plexSettings?.serverUrl &&
+      appSettings.defaultMovieLibraryId &&
+      appSettings.defaultShowLibraryId
+  );
+
+  // Backwards-compat: existing installs that were fully configured before the
+  // onboardingComplete flag was introduced won't have the field in stored
+  // settings. For these we derive onboardingComplete from setupComplete so
+  // they aren't forced through the wizard again.
+  const stored = getSetting<AppSettings>(db, "app");
+  const hasFlag = stored !== null && "onboardingComplete" in stored;
+  const onboardingComplete = hasFlag ? appSettings.onboardingComplete : setupComplete;
+
   return {
     hasOwner: Boolean(getSetting<PlexOwnerRecord>(db, "admin")),
-    setupComplete: Boolean(
-      plexSettings?.serverUrl &&
-        appSettings.defaultMovieLibraryId &&
-        appSettings.defaultShowLibraryId
-    ),
+    setupComplete,
+    onboardingComplete,
     hasActiveSession
   };
 }
@@ -124,14 +136,17 @@ export function getCurrentOnboardingStep(db: Database.Database): OnboardingStep 
     return "auth";
   }
 
+  // General comes before Plex in the onboarding order. General has no
+  // persistent completion marker, so if Plex isn't configured yet we resume
+  // at General (the earliest un-gated step before Plex).
   const plexSettings = getPlexSettings(db);
   if (!plexSettings?.serverUrl) {
-    return "plex";
+    return "general";
   }
 
   const appSettings = getAppSettings(db);
   if (!appSettings.defaultMovieLibraryId || !appSettings.defaultShowLibraryId) {
-    return "general";
+    return "collections";
   }
 
   return "collections";

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -106,6 +106,10 @@ export function resolveSessionSecret(db: Database.Database, dataDir: string): st
 // Bootstrap / Auth
 // -------------------------------------------------------------------------
 
+/**
+ * Reports whether the instance has enough persisted configuration to run and
+ * whether the onboarding wizard has been formally completed.
+ */
 export function getBootstrapStatus(db: Database.Database, hasActiveSession: boolean): BootstrapStatus {
   const plexSettings = getSetting<PlexSettingsInput>(db, "plex");
   const appSettings = getAppSettings(db);
@@ -131,6 +135,10 @@ export function getBootstrapStatus(db: Database.Database, hasActiveSession: bool
   };
 }
 
+/**
+ * Resumes onboarding from the earliest step that still lacks a persisted
+ * completion marker.
+ */
 export function getCurrentOnboardingStep(db: Database.Database): OnboardingStep {
   const owner = getPlexOwner(db);
   if (!owner) {

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -35,6 +35,7 @@ export const defaultAppSettings: AppSettings = {
   defaultMovieLibraryId: null,
   defaultShowLibraryId: null,
   trustProxy: false,
+  usersStepComplete: false,
   onboardingComplete: false
 };
 
@@ -149,7 +150,11 @@ export function getCurrentOnboardingStep(db: Database.Database): OnboardingStep 
     return "collections";
   }
 
-  return "collections";
+  if (!appSettings.usersStepComplete) {
+    return "users";
+  }
+
+  return "preload";
 }
 
 export function getPlexOwner(db: Database.Database): PlexOwnerRecord | null {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,8 +22,8 @@ const appSettings = db.getAppSettings();
 // instance while the user is still working through the setup wizard.
 function requiresSetup(task: () => Promise<void>): () => Promise<void> {
   return async () => {
-    if (!db.getBootstrapStatus(false).setupComplete) {
-      logger.debug("Skipping scheduled task — setup is not complete");
+    if (!db.getBootstrapStatus(false).onboardingComplete) {
+      logger.debug("Skipping scheduled task — onboarding is not complete");
       return;
     }
     await task();
@@ -99,18 +99,18 @@ scheduler.registerDailyJob({
   })
 });
 
-const setupComplete = db.getBootstrapStatus(false).setupComplete;
+const onboardingComplete = db.getBootstrapStatus(false).onboardingComplete;
 
 // Activity cache — run on startup (full fetch on first run, incremental thereafter).
-// Skipped if setup is not complete to avoid errors against an unconfigured instance.
-if (setupComplete) {
+// Skipped until onboarding is fully complete to avoid racing the setup wizard.
+if (onboardingComplete) {
   services.syncActivityCache().catch((error) => {
     logger.warn("Activity cache sync failed at startup", {
       error: error instanceof Error ? error.message : String(error)
     });
   });
 } else {
-  logger.info("Skipping startup activity cache sync — setup is not complete");
+  logger.info("Skipping startup activity cache sync — onboarding is not complete");
 }
 
 scheduler.registerRecurringJob({
@@ -121,7 +121,7 @@ scheduler.registerRecurringJob({
   })
 });
 
-if (setupComplete && appSettings.rssEnabled) {
+if (onboardingComplete && appSettings.rssEnabled) {
   services.initRss().catch((error) => {
     logger.warn("RSS initialization failed at startup", {
       error: error instanceof Error ? error.message : String(error)
@@ -144,8 +144,8 @@ scheduler.registerRecurringJob({
   })
 });
 
-// Startup sync sequence (if enabled and setup is complete)
-if (setupComplete && appSettings.fullSyncOnStartup) {
+// Startup sync sequence (if enabled and onboarding is complete)
+if (onboardingComplete && appSettings.fullSyncOnStartup) {
   void (async () => {
     logger.info("Startup sync sequence started", {
       steps: ["plex-full-library-scan", "full-sync", "collection-publish"]
@@ -183,6 +183,6 @@ if (setupComplete && appSettings.fullSyncOnStartup) {
 
     logger.info("Startup sync sequence finished");
   })();
-} else if (!setupComplete && appSettings.fullSyncOnStartup) {
-  logger.info("Skipping startup sync sequence — setup is not complete");
+} else if (!onboardingComplete && appSettings.fullSyncOnStartup) {
+  logger.info("Skipping startup sync sequence — onboarding is not complete");
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,10 +17,23 @@ app.listen(config.port, () => {
 
 const appSettings = db.getAppSettings();
 
+// Guard that skips a scheduled task when onboarding is not yet complete.
+// This prevents background jobs from firing errors against an unconfigured
+// instance while the user is still working through the setup wizard.
+function requiresSetup(task: () => Promise<void>): () => Promise<void> {
+  return async () => {
+    if (!db.getBootstrapStatus(false).setupComplete) {
+      logger.debug("Skipping scheduled task — setup is not complete");
+      return;
+    }
+    await task();
+  };
+}
+
 scheduler.registerRecurringJob({
   id: "collection-publish",
   intervalMs: appSettings.collectionPublishIntervalMinutes * 60 * 1000,
-  task: async () => {
+  task: requiresSetup(async () => {
     try {
       await services.runPublishPass();
     } catch (error) {
@@ -28,13 +41,13 @@ scheduler.registerRecurringJob({
         error: error instanceof Error ? error.message : String(error)
       });
     }
-  }
+  })
 });
 
 scheduler.registerRecurringJob({
   id: "full-sync",
   intervalMs: appSettings.reconciliationIntervalMinutes * 60 * 1000,
-  task: async () => {
+  task: requiresSetup(async () => {
     try {
       await services.runFullSync();
     } catch (error) {
@@ -42,66 +55,73 @@ scheduler.registerRecurringJob({
         error: error instanceof Error ? error.message : String(error)
       });
     }
-  },
+  }),
 });
 
 scheduler.registerRecurringJob({
   id: "plex-recently-added-scan",
   intervalMs: appSettings.plexRecentlyAddedScanIntervalMinutes * 60 * 1000,
-  task: async () => {
+  task: requiresSetup(async () => {
     await services.runPlexRecentlyAddedScan(scheduler.getLastRunAt("plex-recently-added-scan"));
-  },
+  }),
 });
 
 scheduler.registerRecurringJob({
   id: "plex-full-library-scan",
   intervalMs: appSettings.plexFullLibraryScanIntervalMinutes * 60 * 1000,
-  task: async () => {
+  task: requiresSetup(async () => {
     await services.runPlexFullLibraryScan();
-  },
+  }),
 });
 
 scheduler.registerDailyJob({
   id: "plex-refresh-token",
   hour: 5,
-  task: async () => {
+  task: requiresSetup(async () => {
     await services.refreshPlexToken();
-  }
+  })
 });
 
 scheduler.registerDailyJob({
   id: "users-discover",
   hour: 5,
-  task: async () => {
+  task: requiresSetup(async () => {
     await services.runUsersDiscoverJob();
-  }
+  })
 });
 
 scheduler.registerDailyJob({
   id: "maintenance-tasks",
   hour: 5,
   minute: 30,
-  task: async () => {
+  task: requiresSetup(async () => {
     services.runMaintenanceTasks();
-  }
+  })
 });
 
-// Activity cache — run on startup (full fetch on first run, incremental thereafter)
-services.syncActivityCache().catch((error) => {
-  logger.warn("Activity cache sync failed at startup", {
-    error: error instanceof Error ? error.message : String(error)
+const setupComplete = db.getBootstrapStatus(false).setupComplete;
+
+// Activity cache — run on startup (full fetch on first run, incremental thereafter).
+// Skipped if setup is not complete to avoid errors against an unconfigured instance.
+if (setupComplete) {
+  services.syncActivityCache().catch((error) => {
+    logger.warn("Activity cache sync failed at startup", {
+      error: error instanceof Error ? error.message : String(error)
+    });
   });
-});
+} else {
+  logger.info("Skipping startup activity cache sync — setup is not complete");
+}
 
 scheduler.registerRecurringJob({
   id: "activity-cache-fetch",
   intervalMs: appSettings.activityCacheFetchIntervalMinutes * 60 * 1000,
-  task: async () => {
+  task: requiresSetup(async () => {
     await services.syncActivityCache();
-  }
+  })
 });
 
-if (appSettings.rssEnabled) {
+if (setupComplete && appSettings.rssEnabled) {
   services.initRss().catch((error) => {
     logger.warn("RSS initialization failed at startup", {
       error: error instanceof Error ? error.message : String(error)
@@ -113,7 +133,7 @@ scheduler.registerRecurringJob({
   id: "rss-sync",
   intervalMs: appSettings.rssPollIntervalSeconds * 1000,
   enabled: appSettings.rssEnabled,
-  task: async () => {
+  task: requiresSetup(async () => {
     try {
       await services.pollRss();
     } catch (error) {
@@ -121,11 +141,11 @@ scheduler.registerRecurringJob({
         error: error instanceof Error ? error.message : String(error)
       });
     }
-  }
+  })
 });
 
-// Startup sync sequence (if enabled)
-if (appSettings.fullSyncOnStartup) {
+// Startup sync sequence (if enabled and setup is complete)
+if (setupComplete && appSettings.fullSyncOnStartup) {
   void (async () => {
     logger.info("Startup sync sequence started", {
       steps: ["plex-full-library-scan", "full-sync", "collection-publish"]
@@ -163,4 +183,6 @@ if (appSettings.fullSyncOnStartup) {
 
     logger.info("Startup sync sequence finished");
   })();
+} else if (!setupComplete && appSettings.fullSyncOnStartup) {
+  logger.info("Skipping startup sync sequence — setup is not complete");
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,13 +17,23 @@ app.listen(config.port, () => {
 
 const appSettings = db.getAppSettings();
 
-// Guard that skips a scheduled task when onboarding is not yet complete.
-// This prevents background jobs from firing errors against an unconfigured
-// instance while the user is still working through the setup wizard.
+/**
+ * Returns true only when the onboarding flow is finished and the persisted
+ * runtime configuration is still complete enough for background jobs to run.
+ */
+function isSetupReady(): boolean {
+  const bootstrap = db.getBootstrapStatus(false);
+  return bootstrap.onboardingComplete && bootstrap.setupComplete;
+}
+
+/**
+ * Wraps background work so recurring and startup jobs stay idle until the
+ * onboarding flow is finished and the live configuration is usable.
+ */
 function requiresSetup(task: () => Promise<void>): () => Promise<void> {
   return async () => {
-    if (!db.getBootstrapStatus(false).onboardingComplete) {
-      logger.debug("Skipping scheduled task — onboarding is not complete");
+    if (!isSetupReady()) {
+      logger.debug("Skipping scheduled task — setup is not complete");
       return;
     }
     await task();
@@ -99,18 +109,18 @@ scheduler.registerDailyJob({
   })
 });
 
-const onboardingComplete = db.getBootstrapStatus(false).onboardingComplete;
+const setupReady = isSetupReady();
 
 // Activity cache — run on startup (full fetch on first run, incremental thereafter).
-// Skipped until onboarding is fully complete to avoid racing the setup wizard.
-if (onboardingComplete) {
+// Skipped until onboarding is finished and the live configuration is usable.
+if (setupReady) {
   services.syncActivityCache().catch((error) => {
     logger.warn("Activity cache sync failed at startup", {
       error: error instanceof Error ? error.message : String(error)
     });
   });
 } else {
-  logger.info("Skipping startup activity cache sync — onboarding is not complete");
+  logger.info("Skipping startup activity cache sync — setup is not complete");
 }
 
 scheduler.registerRecurringJob({
@@ -121,7 +131,7 @@ scheduler.registerRecurringJob({
   })
 });
 
-if (onboardingComplete && appSettings.rssEnabled) {
+if (setupReady && appSettings.rssEnabled) {
   services.initRss().catch((error) => {
     logger.warn("RSS initialization failed at startup", {
       error: error instanceof Error ? error.message : String(error)
@@ -144,8 +154,8 @@ scheduler.registerRecurringJob({
   })
 });
 
-// Startup sync sequence (if enabled and onboarding is complete)
-if (onboardingComplete && appSettings.fullSyncOnStartup) {
+// Startup sync sequence (if enabled and the instance is fully ready)
+if (setupReady && appSettings.fullSyncOnStartup) {
   void (async () => {
     logger.info("Startup sync sequence started", {
       steps: ["plex-full-library-scan", "full-sync", "collection-publish"]
@@ -183,6 +193,6 @@ if (onboardingComplete && appSettings.fullSyncOnStartup) {
 
     logger.info("Startup sync sequence finished");
   })();
-} else if (!onboardingComplete && appSettings.fullSyncOnStartup) {
-  logger.info("Skipping startup sync sequence — onboarding is not complete");
+} else if (!setupReady && appSettings.fullSyncOnStartup) {
+  logger.info("Skipping startup sync sequence — setup is not complete");
 }

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -307,6 +307,20 @@ export class HubarrServices {
       this.logger.info("Onboarding preload: watchlist sync complete", { succeeded, failed: total - succeeded });
     }
 
+    // ------------------------------------------------------------------
+    // Phase 4: Publish collections so they are live in Plex immediately
+    // ------------------------------------------------------------------
+    emit("publish-collections", "running", "Publishing collections...");
+    try {
+      await this.runPublishPass();
+      emit("publish-collections", "done", "Collections published");
+      this.logger.info("Onboarding preload: collection publish complete");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn("Onboarding preload: collection publish failed — continuing", { message });
+      emit("publish-collections", "error", `Could not publish collections: ${message}`);
+    }
+
     emit("complete", "done", "Hubarr is ready");
     this.logger.info("Onboarding preload complete");
   }

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -240,18 +240,20 @@ export class HubarrServices {
    */
   async runOnboardingPreload(onProgress: (event: PreloadProgressEvent) => void): Promise<void> {
     if (this.onboardingPreloadSession !== null) {
-      for (const event of this.onboardingPreloadSession.events) {
-        onProgress(event);
-      }
-      if (this.onboardingPreloadSession.completed) {
-        return;
-      }
-
-      this.onboardingPreloadSession.listeners.add(onProgress);
+      const session = this.onboardingPreloadSession;
+      session.listeners.add(onProgress);
       try {
-        await this.onboardingPreloadSession.promise;
+        for (const event of session.events) {
+          this.deliverPreloadEvent(session, onProgress, event);
+        }
+        if (session.completed) {
+          session.listeners.delete(onProgress);
+          return;
+        }
+
+        await session.promise;
       } finally {
-        this.onboardingPreloadSession?.listeners.delete(onProgress);
+        session.listeners.delete(onProgress);
       }
       return;
     }
@@ -272,8 +274,8 @@ export class HubarrServices {
     ) => {
       const event: PreloadProgressEvent = { phase, status, message, ...extra };
       session.events.push(event);
-      for (const listener of session.listeners) {
-        listener(event);
+      for (const listener of [...session.listeners]) {
+        this.deliverPreloadEvent(session, listener, event);
       }
     };
 
@@ -370,6 +372,27 @@ export class HubarrServices {
       await session.promise;
     } finally {
       session.listeners.delete(onProgress);
+    }
+  }
+
+  /**
+   * Protect the shared preload workflow from listener-specific failures such
+   * as disconnected SSE responses throwing while we replay or broadcast.
+   */
+  private deliverPreloadEvent(
+    session: NonNullable<HubarrServices["onboardingPreloadSession"]>,
+    listener: (event: PreloadProgressEvent) => void,
+    event: PreloadProgressEvent
+  ): void {
+    try {
+      listener(event);
+    } catch (error) {
+      session.listeners.delete(listener);
+      this.logger.debug("Dropped onboarding preload listener after delivery failure", {
+        phase: event.phase,
+        status: event.status,
+        message: error instanceof Error ? error.message : String(error)
+      });
     }
   }
 

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -241,9 +241,10 @@ export class HubarrServices {
   async runOnboardingPreload(onProgress: (event: PreloadProgressEvent) => void): Promise<void> {
     if (this.onboardingPreloadSession !== null) {
       const session = this.onboardingPreloadSession;
+      const snapshot = Array.from(session.events);
       session.listeners.add(onProgress);
       try {
-        for (const event of [...session.events]) {
+        for (const event of snapshot) {
           this.deliverPreloadEvent(session, onProgress, event);
         }
         if (session.completed) {
@@ -394,6 +395,10 @@ export class HubarrServices {
         message: error instanceof Error ? error.message : String(error)
       });
     }
+  }
+
+  isPreloadComplete(): boolean {
+    return this.onboardingPreloadSession?.completed === true;
   }
 
   clearOnboardingPreloadSession(): void {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -243,7 +243,7 @@ export class HubarrServices {
       const session = this.onboardingPreloadSession;
       session.listeners.add(onProgress);
       try {
-        for (const event of session.events) {
+        for (const event of [...session.events]) {
           this.deliverPreloadEvent(session, onProgress, event);
         }
         if (session.completed) {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -219,13 +219,14 @@ export class HubarrServices {
   }
 
   /**
-   * Runs the three-phase onboarding preload sequence and streams progress
+   * Runs the four-phase onboarding preload sequence and streams progress
    * events back to the caller via the provided callback.
    *
    * Phases:
    *  1. discover-users  — fetch Plex friends + managed users, cache avatars
    *  2. activity-cache  — initial watchlist activity feed sync
    *  3. graphql-sync    — watchlist GraphQL sync for all tracked users
+   *  4. publish-collections — create/update Plex collections for enabled users
    *
    * Individual phase failures are reported but do not abort the remaining
    * phases — the sequence always runs to completion.

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -280,6 +280,7 @@ export class HubarrServices {
 
       const runId = this.db.createSyncRun("full", "Onboarding preload watchlist sync.");
       let succeeded = 0;
+      const failures: string[] = [];
 
       for (let i = 0; i < trackedUsers.length; i++) {
         const user = trackedUsers[i];
@@ -289,6 +290,7 @@ export class HubarrServices {
           succeeded++;
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
+          failures.push(`${user.displayName}: ${message}`);
           this.logger.warn("Onboarding preload: user sync failed — continuing", {
             userId: user.id,
             displayName: user.displayName,
@@ -303,7 +305,12 @@ export class HubarrServices {
       }
 
       const runStatus = succeeded === total ? "success" : "error";
-      this.db.completeSyncRun(runId, runStatus, `Onboarding preload: ${succeeded}/${total} users synced.`, null);
+      this.db.completeSyncRun(
+        runId,
+        runStatus,
+        `Onboarding preload: ${succeeded}/${total} users synced.`,
+        failures.length > 0 ? failures.join(" | ") : null
+      );
       emit("graphql-sync", "done", `Synced watchlists for ${succeeded} of ${total} user${total !== 1 ? "s" : ""}`, { progress: total, total });
       this.logger.info("Onboarding preload: watchlist sync complete", { succeeded, failed: total - succeeded });
     }

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -280,13 +280,13 @@ export class HubarrServices {
       }
     };
 
-    const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> =>
-      Promise.race([
-        promise,
-        new Promise<T>((_, reject) =>
-          setTimeout(() => reject(new Error(`${label} timed out after ${ms / 1000}s`)), ms)
-        )
-      ]);
+    const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> => {
+      let timerId: ReturnType<typeof setTimeout>;
+      const timer = new Promise<T>((_, reject) => {
+        timerId = setTimeout(() => reject(new Error(`${label} timed out after ${ms / 1000}s`)), ms);
+      });
+      return Promise.race([promise, timer]).finally(() => clearTimeout(timerId));
+    };
 
     session.promise = (async () => {
       this.logger.info("Onboarding preload started");

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -108,6 +108,12 @@ export class HubarrServices {
   private usersRssUrl: string | null = null;
   private usersRssPrimed = false;
   private readonly usersRssCache = new RssCache();
+  private onboardingPreloadSession: {
+    events: PreloadProgressEvent[];
+    listeners: Set<(event: PreloadProgressEvent) => void>;
+    promise: Promise<void>;
+    completed: boolean;
+  } | null = null;
 
   constructor(
     private readonly db: HubarrDatabase,
@@ -219,118 +225,156 @@ export class HubarrServices {
   }
 
   /**
-   * Runs the four-phase onboarding preload sequence and streams progress
+   * Runs the three-phase onboarding preload sequence and streams progress
    * events back to the caller via the provided callback.
    *
    * Phases:
-   *  1. discover-users  — fetch Plex friends + managed users, cache avatars
-   *  2. activity-cache  — initial watchlist activity feed sync
-   *  3. graphql-sync    — watchlist GraphQL sync for all tracked users
-   *  4. publish-collections — create/update Plex collections for enabled users
+   *  1. activity-cache  — initial watchlist activity feed sync
+   *  2. graphql-sync    — watchlist GraphQL sync for all tracked users
+   *  3. publish-collections — create/update Plex collections for enabled users
    *
    * Individual phase failures are reported but do not abort the remaining
-   * phases — the sequence always runs to completion.
+   * phases — the sequence always runs to completion. If the client refreshes
+   * mid-run, reconnecting callers subscribe to the same in-flight preload
+   * session instead of starting over.
    */
   async runOnboardingPreload(onProgress: (event: PreloadProgressEvent) => void): Promise<void> {
-    this.logger.info("Onboarding preload started");
-
-    const emit = (phase: PreloadPhase, status: PreloadProgressEvent["status"], message: string, extra?: Pick<PreloadProgressEvent, "progress" | "total">) => {
-      onProgress({ phase, status, message, ...extra });
-    };
-
-    // ------------------------------------------------------------------
-    // Phase 1: Discover users and cache avatars
-    // ------------------------------------------------------------------
-    emit("discover-users", "running", "Fetching Plex users and avatars...");
-    try {
-      const users = await this.discoverUsers();
-      const count = users.length;
-      emit("discover-users", "done", `Found ${count} user${count !== 1 ? "s" : ""}`);
-      this.logger.info("Onboarding preload: user discovery complete", { userCount: count });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.warn("Onboarding preload: user discovery failed — continuing", { message });
-      emit("discover-users", "error", `Could not fetch users: ${message}`);
-    }
-
-    // ------------------------------------------------------------------
-    // Phase 2: Activity cache sync
-    // ------------------------------------------------------------------
-    emit("activity-cache", "running", "Syncing activity feed...");
-    try {
-      await this.syncActivityCache();
-      emit("activity-cache", "done", "Activity feed synced");
-      this.logger.info("Onboarding preload: activity cache sync complete");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.warn("Onboarding preload: activity cache sync failed — continuing", { message });
-      emit("activity-cache", "error", `Could not sync activity feed: ${message}`);
-    }
-
-    // ------------------------------------------------------------------
-    // Phase 3: GraphQL watchlist sync for tracked users
-    // ------------------------------------------------------------------
-    const { trackedUsers } = this.getUserScopes();
-    if (trackedUsers.length === 0) {
-      emit("graphql-sync", "done", "No users to sync yet", { progress: 0, total: 0 });
-      this.logger.info("Onboarding preload: no tracked users, skipping watchlist sync");
-    } else {
-      const total = trackedUsers.length;
-      emit("graphql-sync", "running", `Syncing watchlists for ${total} user${total !== 1 ? "s" : ""}...`, { progress: 0, total });
-
-      const runId = this.db.createSyncRun("full", "Onboarding preload watchlist sync.");
-      let succeeded = 0;
-      const failures: string[] = [];
-
-      for (let i = 0; i < trackedUsers.length; i++) {
-        const user = trackedUsers[i];
-        emit("graphql-sync", "running", `Syncing ${user.displayName}...`, { progress: i, total });
-        try {
-          await this.syncUser(user, runId);
-          succeeded++;
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          failures.push(`${user.displayName}: ${message}`);
-          this.logger.warn("Onboarding preload: user sync failed — continuing", {
-            userId: user.id,
-            displayName: user.displayName,
-            message
-          });
-          this.db.addSyncRunItem(runId, "sync.user", "error", {
-            userId: user.id,
-            displayName: user.displayName,
-            message
-          }, user.id);
-        }
+    if (this.onboardingPreloadSession !== null) {
+      for (const event of this.onboardingPreloadSession.events) {
+        onProgress(event);
+      }
+      if (this.onboardingPreloadSession.completed) {
+        return;
       }
 
-      const runStatus = succeeded === total ? "success" : "error";
-      this.db.completeSyncRun(
-        runId,
-        runStatus,
-        `Onboarding preload: ${succeeded}/${total} users synced.`,
-        failures.length > 0 ? failures.join(" | ") : null
-      );
-      emit("graphql-sync", "done", `Synced watchlists for ${succeeded} of ${total} user${total !== 1 ? "s" : ""}`, { progress: total, total });
-      this.logger.info("Onboarding preload: watchlist sync complete", { succeeded, failed: total - succeeded });
+      this.onboardingPreloadSession.listeners.add(onProgress);
+      try {
+        await this.onboardingPreloadSession.promise;
+      } finally {
+        this.onboardingPreloadSession?.listeners.delete(onProgress);
+      }
+      return;
     }
 
-    // ------------------------------------------------------------------
-    // Phase 4: Publish collections so they are live in Plex immediately
-    // ------------------------------------------------------------------
-    emit("publish-collections", "running", "Publishing collections...");
+    const session = {
+      events: [] as PreloadProgressEvent[],
+      listeners: new Set<(event: PreloadProgressEvent) => void>([onProgress]),
+      promise: Promise.resolve(),
+      completed: false
+    };
+    this.onboardingPreloadSession = session;
+
+    const emit = (
+      phase: PreloadPhase,
+      status: PreloadProgressEvent["status"],
+      message: string,
+      extra?: Pick<PreloadProgressEvent, "progress" | "total">
+    ) => {
+      const event: PreloadProgressEvent = { phase, status, message, ...extra };
+      session.events.push(event);
+      for (const listener of session.listeners) {
+        listener(event);
+      }
+    };
+
+    session.promise = (async () => {
+      this.logger.info("Onboarding preload started");
+
+      // ------------------------------------------------------------------
+      // Phase 1: Activity cache sync
+      // ------------------------------------------------------------------
+      emit("activity-cache", "running", "Syncing activity feed...");
+      try {
+        await this.syncActivityCache();
+        emit("activity-cache", "done", "Activity feed synced");
+        this.logger.info("Onboarding preload: activity cache sync complete");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn("Onboarding preload: activity cache sync failed — continuing", { message });
+        emit("activity-cache", "error", `Could not sync activity feed: ${message}`);
+      }
+
+      // ------------------------------------------------------------------
+      // Phase 2: GraphQL watchlist sync for tracked users
+      // ------------------------------------------------------------------
+      const { trackedUsers } = this.getUserScopes();
+      if (trackedUsers.length === 0) {
+        emit("graphql-sync", "done", "No users to sync yet", { progress: 0, total: 0 });
+        this.logger.info("Onboarding preload: no tracked users, skipping watchlist sync");
+      } else {
+        const total = trackedUsers.length;
+        emit("graphql-sync", "running", `Syncing watchlists for ${total} user${total !== 1 ? "s" : ""}...`, { progress: 0, total });
+
+        const runId = this.db.createSyncRun("full", "Onboarding preload watchlist sync.");
+        let succeeded = 0;
+        const failures: string[] = [];
+
+        for (let i = 0; i < trackedUsers.length; i++) {
+          const user = trackedUsers[i];
+          emit("graphql-sync", "running", `Syncing ${user.displayName}...`, { progress: i, total });
+          try {
+            await this.syncUser(user, runId);
+            succeeded++;
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            failures.push(`${user.displayName}: ${message}`);
+            this.logger.warn("Onboarding preload: user sync failed — continuing", {
+              userId: user.id,
+              displayName: user.displayName,
+              message
+            });
+            this.db.addSyncRunItem(runId, "sync.user", "error", {
+              userId: user.id,
+              displayName: user.displayName,
+              message
+            }, user.id);
+          }
+        }
+
+        const runStatus = succeeded === total ? "success" : "error";
+        this.db.completeSyncRun(
+          runId,
+          runStatus,
+          `Onboarding preload: ${succeeded}/${total} users synced.`,
+          failures.length > 0 ? failures.join(" | ") : null
+        );
+        emit("graphql-sync", "done", `Synced watchlists for ${succeeded} of ${total} user${total !== 1 ? "s" : ""}`, { progress: total, total });
+        this.logger.info("Onboarding preload: watchlist sync complete", { succeeded, failed: total - succeeded });
+      }
+
+      // ------------------------------------------------------------------
+      // Phase 3: Publish collections so they are live in Plex immediately
+      // ------------------------------------------------------------------
+      emit("publish-collections", "running", "Publishing collections...");
+      try {
+        await this.runPublishPass();
+        emit("publish-collections", "done", "Collections published");
+        this.logger.info("Onboarding preload: collection publish complete");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn("Onboarding preload: collection publish failed — continuing", { message });
+        emit("publish-collections", "error", `Could not publish collections: ${message}`);
+      }
+
+      emit("complete", "done", "Hubarr is ready");
+      session.completed = true;
+      this.logger.info("Onboarding preload complete");
+    })().catch((error) => {
+      if (this.onboardingPreloadSession === session) {
+        this.onboardingPreloadSession = null;
+      }
+      throw error;
+    });
+
     try {
-      await this.runPublishPass();
-      emit("publish-collections", "done", "Collections published");
-      this.logger.info("Onboarding preload: collection publish complete");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.warn("Onboarding preload: collection publish failed — continuing", { message });
-      emit("publish-collections", "error", `Could not publish collections: ${message}`);
+      await session.promise;
+    } finally {
+      session.listeners.delete(onProgress);
     }
+  }
 
-    emit("complete", "done", "Hubarr is ready");
-    this.logger.info("Onboarding preload complete");
+  clearOnboardingPreloadSession(): void {
+    this.onboardingPreloadSession = null;
   }
 
   runMaintenanceTasks() {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -280,6 +280,14 @@ export class HubarrServices {
       }
     };
 
+    const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> =>
+      Promise.race([
+        promise,
+        new Promise<T>((_, reject) =>
+          setTimeout(() => reject(new Error(`${label} timed out after ${ms / 1000}s`)), ms)
+        )
+      ]);
+
     session.promise = (async () => {
       this.logger.info("Onboarding preload started");
 
@@ -288,7 +296,7 @@ export class HubarrServices {
       // ------------------------------------------------------------------
       emit("activity-cache", "running", "Syncing activity feed...");
       try {
-        await this.syncActivityCache();
+        await withTimeout(this.syncActivityCache(), 120_000, "Activity cache sync");
         emit("activity-cache", "done", "Activity feed synced");
         this.logger.info("Onboarding preload: activity cache sync complete");
       } catch (err) {
@@ -316,7 +324,7 @@ export class HubarrServices {
           const user = trackedUsers[i];
           emit("graphql-sync", "running", `Syncing ${user.displayName}...`, { progress: i, total });
           try {
-            await this.syncUser(user, runId);
+            await withTimeout(this.syncUser(user, runId), 60_000, `User sync for ${user.displayName}`);
             succeeded++;
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
@@ -350,7 +358,7 @@ export class HubarrServices {
       // ------------------------------------------------------------------
       emit("publish-collections", "running", "Publishing collections...");
       try {
-        await this.runPublishPass();
+        await withTimeout(this.runPublishPass(), 120_000, "Publish collections");
         emit("publish-collections", "done", "Collections published");
         this.logger.info("Onboarding preload: collection publish complete");
       } catch (err) {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1,6 +1,8 @@
 import type {
   AppSettings,
   CollectionSortOrder,
+  PreloadPhase,
+  PreloadProgressEvent,
   UserRecord,
   PlexSettingsInput,
   WatchlistItem
@@ -214,6 +216,99 @@ export class HubarrServices {
       });
       throw error;
     }
+  }
+
+  /**
+   * Runs the three-phase onboarding preload sequence and streams progress
+   * events back to the caller via the provided callback.
+   *
+   * Phases:
+   *  1. discover-users  — fetch Plex friends + managed users, cache avatars
+   *  2. activity-cache  — initial watchlist activity feed sync
+   *  3. graphql-sync    — watchlist GraphQL sync for all tracked users
+   *
+   * Individual phase failures are reported but do not abort the remaining
+   * phases — the sequence always runs to completion.
+   */
+  async runOnboardingPreload(onProgress: (event: PreloadProgressEvent) => void): Promise<void> {
+    this.logger.info("Onboarding preload started");
+
+    const emit = (phase: PreloadPhase, status: PreloadProgressEvent["status"], message: string, extra?: Pick<PreloadProgressEvent, "progress" | "total">) => {
+      onProgress({ phase, status, message, ...extra });
+    };
+
+    // ------------------------------------------------------------------
+    // Phase 1: Discover users and cache avatars
+    // ------------------------------------------------------------------
+    emit("discover-users", "running", "Fetching Plex users and avatars...");
+    try {
+      const users = await this.discoverUsers();
+      const count = users.length;
+      emit("discover-users", "done", `Found ${count} user${count !== 1 ? "s" : ""}`);
+      this.logger.info("Onboarding preload: user discovery complete", { userCount: count });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn("Onboarding preload: user discovery failed — continuing", { message });
+      emit("discover-users", "error", `Could not fetch users: ${message}`);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 2: Activity cache sync
+    // ------------------------------------------------------------------
+    emit("activity-cache", "running", "Syncing activity feed...");
+    try {
+      await this.syncActivityCache();
+      emit("activity-cache", "done", "Activity feed synced");
+      this.logger.info("Onboarding preload: activity cache sync complete");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn("Onboarding preload: activity cache sync failed — continuing", { message });
+      emit("activity-cache", "error", `Could not sync activity feed: ${message}`);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 3: GraphQL watchlist sync for tracked users
+    // ------------------------------------------------------------------
+    const { trackedUsers } = this.getUserScopes();
+    if (trackedUsers.length === 0) {
+      emit("graphql-sync", "done", "No users to sync yet", { progress: 0, total: 0 });
+      this.logger.info("Onboarding preload: no tracked users, skipping watchlist sync");
+    } else {
+      const total = trackedUsers.length;
+      emit("graphql-sync", "running", `Syncing watchlists for ${total} user${total !== 1 ? "s" : ""}...`, { progress: 0, total });
+
+      const runId = this.db.createSyncRun("full", "Onboarding preload watchlist sync.");
+      let succeeded = 0;
+
+      for (let i = 0; i < trackedUsers.length; i++) {
+        const user = trackedUsers[i];
+        emit("graphql-sync", "running", `Syncing ${user.displayName}...`, { progress: i, total });
+        try {
+          await this.syncUser(user, runId);
+          succeeded++;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.logger.warn("Onboarding preload: user sync failed — continuing", {
+            userId: user.id,
+            displayName: user.displayName,
+            message
+          });
+          this.db.addSyncRunItem(runId, "sync.user", "error", {
+            userId: user.id,
+            displayName: user.displayName,
+            message
+          }, user.id);
+        }
+      }
+
+      const runStatus = succeeded === total ? "success" : "error";
+      this.db.completeSyncRun(runId, runStatus, `Onboarding preload: ${succeeded}/${total} users synced.`, null);
+      emit("graphql-sync", "done", `Synced watchlists for ${succeeded} of ${total} user${total !== 1 ? "s" : ""}`, { progress: total, total });
+      this.logger.info("Onboarding preload: watchlist sync complete", { succeeded, failed: total - succeeded });
+    }
+
+    emit("complete", "done", "Hubarr is ready");
+    this.logger.info("Onboarding preload complete");
   }
 
   runMaintenanceTasks() {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,12 +4,13 @@ export type MediaType = "movie" | "show";
 export interface BootstrapStatus {
   hasOwner: boolean;
   setupComplete: boolean;
+  onboardingComplete: boolean;
   hasActiveSession: boolean;
 }
 
-export type OnboardingStep = "auth" | "plex" | "general" | "collections" | "preload";
+export type OnboardingStep = "auth" | "plex" | "general" | "collections" | "users" | "preload";
 
-export type PreloadPhase = "discover-users" | "activity-cache" | "graphql-sync" | "complete";
+export type PreloadPhase = "discover-users" | "activity-cache" | "graphql-sync" | "publish-collections" | "complete";
 
 export interface PreloadProgressEvent {
   phase: PreloadPhase;
@@ -82,6 +83,7 @@ export interface AppSettings {
   defaultMovieLibraryId: string | null;
   defaultShowLibraryId: string | null;
   trustProxy: boolean;
+  onboardingComplete: boolean;
 }
 
 export interface UserRecord {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,7 +7,19 @@ export interface BootstrapStatus {
   hasActiveSession: boolean;
 }
 
-export type OnboardingStep = "auth" | "plex" | "general" | "collections";
+export type OnboardingStep = "auth" | "plex" | "general" | "collections" | "preload";
+
+export type PreloadPhase = "discover-users" | "activity-cache" | "graphql-sync" | "complete";
+
+export interface PreloadProgressEvent {
+  phase: PreloadPhase;
+  status: "running" | "done" | "error";
+  message: string;
+  /** Current number of items processed (graphql-sync phase only). */
+  progress?: number;
+  /** Total number of items to process (graphql-sync phase only). */
+  total?: number;
+}
 
 export interface SessionUser {
   plexId: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -83,6 +83,7 @@ export interface AppSettings {
   defaultMovieLibraryId: string | null;
   defaultShowLibraryId: string | null;
   trustProxy: boolean;
+  usersStepComplete: boolean;
   onboardingComplete: boolean;
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -10,7 +10,7 @@ export interface BootstrapStatus {
 
 export type OnboardingStep = "auth" | "plex" | "general" | "collections" | "users" | "preload";
 
-export type PreloadPhase = "discover-users" | "activity-cache" | "graphql-sync" | "publish-collections" | "complete";
+export type PreloadPhase = "activity-cache" | "graphql-sync" | "publish-collections" | "complete";
 
 export interface PreloadProgressEvent {
   phase: PreloadPhase;


### PR DESCRIPTION
## Summary

Implements a full onboarding wizard experience for Hubarr (closes #55). The wizard now guides the admin through five sequential steps — Sign in, General, Plex, Collections, Users — followed by a live preload phase that runs the first full sync before handing off to the main app. Users can no longer bypass the wizard by navigating to the main app after completing Collections.

## Changes

**`src/shared/types.ts`**
- Added `"users"` and `"preload"` to `OnboardingStep`
- Added `PreloadPhase`, `PreloadProgressEvent` types for SSE streaming
- Added `onboardingComplete: boolean` to `AppSettings` and `BootstrapStatus`

**`src/server/db/settings.ts`**
- Added `onboardingComplete: false` to `defaultAppSettings`
- `getBootstrapStatus()` now returns `onboardingComplete`; derives it from `setupComplete` for existing installs (backwards-compat — no forced re-onboarding)
- `getCurrentOnboardingStep()` reordered: General precedes Plex

**`src/server/app.ts`**
- Added `GET /api/setup/preload` SSE endpoint streaming four preload phases
- Added `POST /api/setup/complete` endpoint that sets `onboardingComplete: true`

**`src/server/services.ts`**
- Added `runOnboardingPreload(onProgress)` running four phases: discover-users, activity-cache, graphql-sync, publish-collections

**`src/server/index.ts`**
- Added `requiresSetup()` guard wrapping all scheduled jobs and startup one-shots so nothing fires against an unconfigured instance

**`src/client/pages/Onboarding.tsx`**
- Full wizard rewrite: Auth → General → Plex → Collections → Users → Preload
- `UsersOnboardingStep`: avatar grid with background poll (up to 6×), pre-selects self, bulk-enables selected users via `POST /api/users/bulk`
- `PreloadStep`: EventSource SSE consumer with phase rows and progress bar; calls `POST /api/setup/complete` then `onComplete()` when done
- Consistent two-button footer on every step (Back bottom-left, Continue bottom-right)

**`src/client/components/FormControls.tsx`**
- `SaveBar` accepts optional `onBack?: () => void`; when provided renders a two-column footer with matching Back and Continue buttons

**`src/client/components/PlexConfigForm.tsx` / `CollectionsConfigForm.tsx`**
- Added `onBack?` prop forwarded to `SaveBar`

**`src/client/App.tsx`**
- Main app routes now gated on `bootstrap.onboardingComplete` instead of `bootstrap.setupComplete`

**`src/client/pages/Settings.tsx`**
- Minor copy updates to Track All Users and Startup Sync hints

## Test plan

- [x] Fresh install: navigate to `/` — redirected to `/onboarding`, Auth step shown
- [x] Sign in with Plex → lands on General step
- [x] Click Continue → advances to Plex step; Back button returns to General
- [x] Save Plex config → advances to Collections; Back returns to Plex
- [x] Save Collections → advances to Users step; Back returns to Collections
- [x] Users step: avatar cards load, selecting/deselecting works, "Select all" / "Deselect all" toggle works
- [x] Clicking Continue on Users triggers preload; all four phase rows progress and complete
- [x] After preload completes, app enters dashboard automatically
- [x] Attempt to navigate to `/dashboard` before completing preload (e.g. mid-wizard) — redirected back to `/onboarding`
- [x] Existing install (already fully configured): loads directly into dashboard without hitting onboarding wizard

Closes #55

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Users onboarding step with bulk enable/disable, avatar handling, polling, skip/save
  - Preload streaming with phased progress, retry UI, and finalization
  - Back navigation controls on onboarding forms

* **Improvements**
  - Reworked onboarding sequence, copy and step labels; routing now waits for onboarding completion
  - Onboarding completion gates background jobs and startup tasks
  - Default visibility for recommended/shared collections set to off
<!-- end of auto-generated comment: release notes by coderabbit.ai -->