### PR TITLE
fix: reconcile stale running sync_runs on startup

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -48,7 +48,7 @@ function signedValue(secret: string, value: string) {
 
 export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   const logger = new Logger(config.dataDir);
-  const db = new HubarrDatabase(config);
+  const db = new HubarrDatabase(config, logger);
   const sessionSecret = db.getSessionSecret();
   const imageCache = new ImageCacheService(config.dataDir, db, logger);
   const services = new HubarrServices(db, logger, imageCache);

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -27,17 +27,20 @@ import * as settingsRepo from "./settings.js";
 import * as syncRepo from "./sync.js";
 import * as usersRepo from "./users.js";
 import * as watchlistRepo from "./watchlist.js";
+import type { Logger } from "../logger.js";
 
 export class HubarrDatabase {
   private readonly db: Database.Database;
   private readonly sessionSecret: string;
 
-  constructor(config: RuntimeConfig) {
+  constructor(config: RuntimeConfig, logger?: Logger) {
     this.db = new Database(path.join(config.dataDir, "hubarr.db"));
     this.db.pragma("journal_mode = WAL");
     this.db.pragma("foreign_keys = ON");
     runMigrations(this.db);
-    syncRepo.reconcileStaleRuns(this.db);
+    // reconcileStaleRuns must run after migrations and before any job scheduling/registration
+    // to prevent stale rows left in a `running` state during startup.
+    syncRepo.reconcileStaleRuns(this.db, logger);
     settingsRepo.seedDefaultSettings(this.db);
     this.sessionSecret = settingsRepo.resolveSessionSecret(this.db, config.dataDir);
   }

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -37,6 +37,7 @@ export class HubarrDatabase {
     this.db.pragma("journal_mode = WAL");
     this.db.pragma("foreign_keys = ON");
     runMigrations(this.db);
+    syncRepo.reconcileStaleRuns(this.db);
     settingsRepo.seedDefaultSettings(this.db);
     this.sessionSecret = settingsRepo.resolveSessionSecret(this.db, config.dataDir);
   }

--- a/src/server/db/sync.ts
+++ b/src/server/db/sync.ts
@@ -37,6 +37,16 @@ export function saveJobRunState(
 // Sync Runs
 // -------------------------------------------------------------------------
 
+export function reconcileStaleRuns(db: Database.Database): void {
+  db.prepare(`
+    UPDATE sync_runs
+    SET status = 'error',
+        completed_at = ?,
+        error = 'Aborted: process restarted while job was running'
+    WHERE status = 'running'
+  `).run(new Date().toISOString());
+}
+
 export function pruneSyncRuns(db: Database.Database, maxEvents: number): void {
   const retention = Math.max(1, Math.floor(maxEvents));
   db.prepare(`

--- a/src/server/db/sync.ts
+++ b/src/server/db/sync.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { DashboardResponse, RecentlyAddedItem, SyncRun } from "../../shared/types.js";
+import type { Logger } from "../logger.js";
 import { buildGuidMergePlan, mergeRawPayloadGuids } from "./guid-dedupe.js";
 import { calculateHistoryRetentionEvents, getAppSettings } from "./settings.js";
 
@@ -37,14 +38,21 @@ export function saveJobRunState(
 // Sync Runs
 // -------------------------------------------------------------------------
 
-export function reconcileStaleRuns(db: Database.Database): void {
-  db.prepare(`
+export function reconcileStaleRuns(db: Database.Database, logger?: Logger): void {
+  const completedAtIso = new Date().toISOString();
+  const result = db.prepare(`
     UPDATE sync_runs
     SET status = 'error',
         completed_at = ?,
         error = 'Aborted: process restarted while job was running'
     WHERE status = 'running'
-  `).run(new Date().toISOString());
+  `).run(completedAtIso);
+  const meta = { reconciledRuns: result.changes, completedAt: completedAtIso };
+  if (result.changes > 0) {
+    logger?.warn("Reconciled stale sync runs", meta);
+  } else {
+    logger?.debug("No stale sync runs to reconcile", meta);
+  }
 }
 
 export function pruneSyncRuns(db: Database.Database, maxEvents: number): void {


### PR DESCRIPTION
## Summary

On startup, any `sync_runs` rows still in `running` status are artefacts of a previous process that crashed or was killed mid-job. Without a reconciliation step these rows remain `running` indefinitely — they can never transition because the process that would have called `completeSyncRun` is gone.

This adds a startup reconciliation pass that immediately marks all orphaned `running` rows as `error` with a clear message (`Aborted: process restarted while job was running`), so the history UI never shows permanently stuck jobs.

Closes #89

## Changes

- `src/server/db/sync.ts` — adds `reconcileStaleRuns(db)` which issues a single `UPDATE` to flip every `running` row to `error` with a `completed_at` timestamp and a descriptive error message.
- `src/server/db/index.ts` — calls `syncRepo.reconcileStaleRuns(this.db)` in the `HubarrDatabase` constructor, immediately after migrations run, so reconciliation happens on every process start before any jobs are registered or scheduled.

## Test plan

- [ ] Start the app normally, trigger a full sync, confirm it completes and shows `success` in the history.
- [ ] Start a sync, kill the process mid-run, restart — confirm the previously `running` row now shows `error` with the message `Aborted: process restarted while job was running`.
- [ ] Confirm no `running` rows remain in the history after startup under any normal condition.
- [ ] Confirm newly started jobs still transition through `running → success/error` correctly after the fix.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically mark interrupted sync jobs as failed during startup to prevent them from remaining stuck in a running state.
  * Emit warnings when interrupted jobs are found and reconciled, and debug messages when none are found.
  * Improved startup logging around the database recovery process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->