### PR TITLE
docs: add CodeRabbit repo-level configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,99 @@
+language: "en-US"
+tone_instructions: "Be direct and concise. Focus on correctness, security, and maintainability. Skip compliments and filler. Use plain language."
+
+reviews:
+  profile: "assertive"
+  high_level_summary: true
+  collapse_walkthrough: true
+  changed_files_summary: true
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: false
+  poem: false
+  sequence_diagrams: false
+  abort_on_close: true
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    base_branches:
+      - "develop"
+    auto_pause_after_reviewed_commits: 0
+
+  path_filters:
+    - "!package-lock.json"
+
+  path_instructions:
+    - path: "src/server/**"
+      instructions: "This is a Node.js/Express backend. Focus on async error handling, missing awaits, and unhandled promise rejections."
+    - path: "tests/playwright/**"
+      instructions: "These are Playwright E2E tests hitting a live instance. Flag flaky selectors or missing waits, not missing mocks."
+
+pre_merge_checks:
+  title:
+    mode: "warning"
+    requirements: "PR title must start with a conventional commit type: feat:, fix:, chore:, docs:, refactor:, ci:"
+  description:
+    mode: "warning"
+
+finishing_touches:
+  docstrings:
+    enabled: false
+  unit_tests:
+    enabled: true
+
+tools:
+  eslint:
+    enabled: true
+  markdownlint:
+    enabled: true
+  actionlint:
+    enabled: true
+  hadolint:
+    enabled: true
+  gitleaks:
+    enabled: true
+  shellcheck:
+    enabled: true
+  biome:
+    enabled: false
+  ruff:
+    enabled: false
+  phpstan:
+    enabled: false
+  phpcs:
+    enabled: false
+  phpmd:
+    enabled: false
+  golangci-lint:
+    enabled: false
+  rubocop:
+    enabled: false
+  swiftlint:
+    enabled: false
+  detekt:
+    enabled: false
+  pmd:
+    enabled: false
+  flake8:
+    enabled: false
+  buf:
+    enabled: false
+  checkov:
+    enabled: false
+  tflint:
+    enabled: false
+
+knowledge_base:
+  opt_out: false
+  learnings:
+    scope: "local"
+  issues:
+    scope: "local"
+  pull_requests:
+    scope: "local"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,6 +17,7 @@ reviews:
   in_progress_fortune: false
   sequence_diagrams: false
   abort_on_close: true
+  commit_status: true
 
   auto_review:
     enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,7 @@ reviews:
   auto_apply_labels: false
   suggested_reviewers: false
   poem: false
+  in_progress_fortune: false
   sequence_diagrams: false
   abort_on_close: true
 
@@ -34,60 +35,60 @@ reviews:
     - path: "tests/playwright/**"
       instructions: "These are Playwright E2E tests hitting a live instance. Flag flaky selectors or missing waits, not missing mocks."
 
-pre_merge_checks:
-  title:
-    mode: "warning"
-    requirements: "PR title must start with a conventional commit type: feat:, fix:, chore:, docs:, refactor:, ci:"
-  description:
-    mode: "warning"
+  pre_merge_checks:
+    title:
+      mode: "warning"
+      requirements: "PR title must start with a conventional commit type: feat:, fix:, chore:, docs:, refactor:, ci:"
+    description:
+      mode: "warning"
 
-finishing_touches:
-  docstrings:
-    enabled: false
-  unit_tests:
-    enabled: true
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: true
 
-tools:
-  eslint:
-    enabled: true
-  markdownlint:
-    enabled: true
-  actionlint:
-    enabled: true
-  hadolint:
-    enabled: true
-  gitleaks:
-    enabled: true
-  shellcheck:
-    enabled: true
-  biome:
-    enabled: false
-  ruff:
-    enabled: false
-  phpstan:
-    enabled: false
-  phpcs:
-    enabled: false
-  phpmd:
-    enabled: false
-  golangci-lint:
-    enabled: false
-  rubocop:
-    enabled: false
-  swiftlint:
-    enabled: false
-  detekt:
-    enabled: false
-  pmd:
-    enabled: false
-  flake8:
-    enabled: false
-  buf:
-    enabled: false
-  checkov:
-    enabled: false
-  tflint:
-    enabled: false
+  tools:
+    eslint:
+      enabled: true
+    markdownlint:
+      enabled: true
+    actionlint:
+      enabled: true
+    hadolint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    shellcheck:
+      enabled: true
+    biome:
+      enabled: false
+    ruff:
+      enabled: false
+    phpstan:
+      enabled: false
+    phpcs:
+      enabled: false
+    phpmd:
+      enabled: false
+    golangci-lint:
+      enabled: false
+    rubocop:
+      enabled: false
+    swiftlint:
+      enabled: false
+    detekt:
+      enabled: false
+    pmd:
+      enabled: false
+    flake8:
+      enabled: false
+    buf:
+      enabled: false
+    checkov:
+      enabled: false
+    tflint:
+      enabled: false
 
 knowledge_base:
   opt_out: false


### PR DESCRIPTION
## Summary

Adds `.coderabbit.yaml` to configure CodeRabbit's PR review behaviour for Hubarr. The goal is useful, low-noise reviews that fit the existing workflow — assertive profile, continuous incremental reviews, develop-branch targeting, and only the tools relevant to a TypeScript/Node.js project enabled.

## Changes

- **`.coderabbit.yaml`** — new repo-level config file covering:
  - Assertive review profile (flags bugs, security, logic, style, naming)
  - Auto-review enabled on PRs targeting `develop` only (not `main`)
  - Incremental review on every new commit with no pause limit (`auto_pause_after_reviewed_commits: 0`) — keeps reviewing until findings are resolved
  - Draft PRs skipped
  - Noise disabled: poems, sequence diagrams, fortune messages all off
  - `package-lock.json` excluded from path filters (committed but not reviewable)
  - Path-specific instructions for `src/server/**` (async/await focus) and `tests/playwright/**` (live-instance context)
  - Pre-merge warnings for non-semantic PR titles and incomplete descriptions
  - Finishing touches: docstring generation off (no JSDoc convention), unit test generation on as an on-demand option
  - Non-applicable linting tools disabled (PHP, Go, Ruby, Python, Kotlin, Terraform, etc.)
  - Knowledge base scope set to `local` so learnings stay within this repo

## Test plan

- [ ] Open a draft PR — confirm CodeRabbit does not post a review
- [ ] Mark the draft ready — confirm CodeRabbit posts a walkthrough targeting `develop`
- [ ] Check the walkthrough includes a summary, effort estimate, and linked issue assessment
- [ ] Confirm poems and sequence diagrams are absent from the walkthrough
- [ ] Push a follow-up commit to the open PR — confirm CodeRabbit re-reviews it

Closes #94

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated code-review configuration to enable continuous reviews, commit status, and review reporting (high-level summary, walkthroughs, changed-files summary, effort estimates, and suggested labels).
  * Enabled targeted review rules for specific paths, pre-merge title/description checks (warnings), selected tooling linters, and scoped knowledge-base behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->