### PR TITLE
perf: improve full sync speed for large user counts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express-rate-limit": "^8.3.2",
         "helmet": "^8.1.0",
         "lucide-react": "^1.8.0",
+        "p-limit": "^7.3.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.1",
@@ -3114,6 +3115,21 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4148,6 +4164,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express-rate-limit": "^8.3.2",
     "helmet": "^8.1.0",
     "lucide-react": "^1.8.0",
+    "p-limit": "^7.3.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.1",

--- a/src/server/db/identifiers.ts
+++ b/src/server/db/identifiers.ts
@@ -142,10 +142,111 @@ export function batchUpsertMediaItemIdentifiers(
   db: Database.Database,
   items: Array<Pick<WatchlistItem, "plexItemId" | "type" | "guids" | "discoverKey">>
 ): void {
-  db.transaction(() => {
-    for (const item of items) {
-      upsertMediaItemIdentifiers(db, item);
+  const mediaSeeds = new Map<string, { mediaType: WatchlistItem["type"]; identifiers: Set<string> }>();
+
+  for (const item of items) {
+    const canonicalPlexItemId = normalizeIdentifierValue(item.plexItemId);
+    if (!canonicalPlexItemId) continue;
+
+    const existing = mediaSeeds.get(canonicalPlexItemId);
+    const seed = existing ?? {
+      mediaType: item.type,
+      identifiers: new Set<string>()
+    };
+
+    seed.mediaType = item.type;
+    seed.identifiers.add(canonicalPlexItemId);
+
+    if (item.discoverKey) {
+      const normalizedDiscoverKey = normalizeIdentifierValue(item.discoverKey);
+      if (normalizedDiscoverKey) {
+        seed.identifiers.add(normalizedDiscoverKey);
+      }
     }
+
+    for (const guid of item.guids ?? []) {
+      if (typeof guid !== "string") continue;
+      const normalizedGuid = normalizeIdentifierValue(guid);
+      if (normalizedGuid) {
+        seed.identifiers.add(normalizedGuid);
+      }
+    }
+
+    mediaSeeds.set(canonicalPlexItemId, seed);
+  }
+
+  if (mediaSeeds.size === 0) return;
+
+  db.transaction(() => {
+    db.exec(`
+      CREATE TEMP TABLE IF NOT EXISTS temp_media_item_seed (
+        canonical_plex_item_id TEXT PRIMARY KEY,
+        media_type TEXT NOT NULL
+      );
+      CREATE TEMP TABLE IF NOT EXISTS temp_media_identifier_seed (
+        canonical_plex_item_id TEXT NOT NULL,
+        identifier_type TEXT NOT NULL,
+        identifier_value TEXT NOT NULL,
+        PRIMARY KEY (identifier_type, identifier_value)
+      );
+      DELETE FROM temp_media_item_seed;
+      DELETE FROM temp_media_identifier_seed;
+    `);
+
+    const insertMediaSeed = db.prepare(`
+      INSERT INTO temp_media_item_seed (canonical_plex_item_id, media_type)
+      VALUES (?, ?)
+      ON CONFLICT(canonical_plex_item_id) DO UPDATE SET
+        media_type = excluded.media_type
+    `);
+    const insertIdentifierSeed = db.prepare(`
+      INSERT INTO temp_media_identifier_seed (canonical_plex_item_id, identifier_type, identifier_value)
+      VALUES (?, ?, ?)
+      ON CONFLICT(identifier_type, identifier_value) DO UPDATE SET
+        canonical_plex_item_id = excluded.canonical_plex_item_id
+    `);
+
+    for (const [canonicalPlexItemId, seed] of mediaSeeds) {
+      insertMediaSeed.run(canonicalPlexItemId, seed.mediaType);
+      for (const identifier of seed.identifiers) {
+        insertIdentifierSeed.run(
+          canonicalPlexItemId,
+          inferMediaIdentifierType(identifier),
+          identifier
+        );
+      }
+    }
+
+    db.prepare(`
+      INSERT OR IGNORE INTO media_items (canonical_plex_item_id, media_type)
+      SELECT canonical_plex_item_id, media_type
+      FROM temp_media_item_seed
+    `).run();
+
+    db.prepare(`
+      UPDATE media_items
+      SET media_type = (
+        SELECT seed.media_type
+        FROM temp_media_item_seed seed
+        WHERE seed.canonical_plex_item_id = media_items.canonical_plex_item_id
+      )
+      WHERE canonical_plex_item_id IN (
+        SELECT canonical_plex_item_id
+        FROM temp_media_item_seed
+      )
+    `).run();
+
+    db.prepare(`
+      INSERT OR REPLACE INTO media_item_identifiers (media_item_id, identifier_type, identifier_value)
+      SELECT mi.id, seed.identifier_type, seed.identifier_value
+      FROM temp_media_identifier_seed seed
+      JOIN media_items mi ON mi.canonical_plex_item_id = seed.canonical_plex_item_id
+    `).run();
+
+    db.exec(`
+      DELETE FROM temp_media_item_seed;
+      DELETE FROM temp_media_identifier_seed;
+    `);
   })();
 }
 

--- a/src/server/db/identifiers.ts
+++ b/src/server/db/identifiers.ts
@@ -133,6 +133,23 @@ export function getActivityCacheDateForUserItem(
 }
 
 /**
+ * Wraps multiple upsertMediaItemIdentifiers calls in a single transaction.
+ * Batching the writes this way avoids an auto-commit round-trip per item,
+ * which matters when pre-registering a full watchlist before the activity
+ * cache lookup.
+ */
+export function batchUpsertMediaItemIdentifiers(
+  db: Database.Database,
+  items: Array<Pick<WatchlistItem, "plexItemId" | "type" | "guids" | "discoverKey">>
+): void {
+  db.transaction(() => {
+    for (const item of items) {
+      upsertMediaItemIdentifiers(db, item);
+    }
+  })();
+}
+
+/**
  * Bulk variant of getActivityCacheDateForUserItem. Returns a map of
  * normalized identifier value → best watchlisted_at for every media item
  * that has an activity cache entry for the given user. A single query

--- a/src/server/db/identifiers.ts
+++ b/src/server/db/identifiers.ts
@@ -131,3 +131,56 @@ export function getActivityCacheDateForUserItem(
 
   return row?.watchlistedAt ?? null;
 }
+
+/**
+ * Bulk variant of getActivityCacheDateForUserItem. Returns a map of
+ * normalized identifier value → best watchlisted_at for every media item
+ * that has an activity cache entry for the given user. A single query
+ * replaces the per-item loop that would otherwise run once per watchlist item.
+ */
+export function getActivityCacheDatesForUser(
+  db: Database.Database,
+  userId: number
+): Map<string, string> {
+  const rows = db.prepare(`
+    WITH user_aliases AS (
+      SELECT lower(identifier_value) AS plex_user_id
+      FROM user_identifier_aliases
+      WHERE user_id = ?
+    ),
+    user_cache AS (
+      SELECT lower(plex_item_id) AS plex_item_id, watchlisted_at
+      FROM watchlist_activity_cache
+      WHERE lower(plex_user_id) IN (SELECT plex_user_id FROM user_aliases)
+    ),
+    media_via_identifier AS (
+      SELECT mii.media_item_id, uce.watchlisted_at
+      FROM user_cache uce
+      JOIN media_item_identifiers mii ON mii.identifier_value = uce.plex_item_id
+    ),
+    media_via_canonical AS (
+      SELECT mi.id AS media_item_id, uce.watchlisted_at
+      FROM user_cache uce
+      JOIN media_items mi ON mi.canonical_plex_item_id = uce.plex_item_id
+    ),
+    all_matched_media AS (
+      SELECT media_item_id, watchlisted_at FROM media_via_identifier
+      UNION ALL
+      SELECT media_item_id, watchlisted_at FROM media_via_canonical
+    ),
+    all_lookup_keys AS (
+      SELECT mii.identifier_value AS lookup_key, amm.watchlisted_at
+      FROM all_matched_media amm
+      JOIN media_item_identifiers mii ON mii.media_item_id = amm.media_item_id
+      UNION ALL
+      SELECT mi.canonical_plex_item_id AS lookup_key, amm.watchlisted_at
+      FROM all_matched_media amm
+      JOIN media_items mi ON mi.id = amm.media_item_id
+    )
+    SELECT lookup_key, MAX(watchlisted_at) AS watchlistedAt
+    FROM all_lookup_keys
+    GROUP BY lookup_key
+  `).all(userId) as Array<{ lookup_key: string; watchlistedAt: string }>;
+
+  return new Map(rows.map((r) => [r.lookup_key, r.watchlistedAt]));
+}

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -258,6 +258,10 @@ export class HubarrDatabase {
     return identifiersRepo.getActivityCacheDateForUserItem(this.db, userId, plexItemId);
   }
 
+  getActivityCacheDatesForUser(userId: number): Map<string, string> {
+    return identifiersRepo.getActivityCacheDatesForUser(this.db, userId);
+  }
+
   clearActivityCache(): number {
     return watchlistRepo.clearActivityCache(this.db);
   }

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -221,6 +221,10 @@ export class HubarrDatabase {
     identifiersRepo.upsertMediaItemIdentifiers(this.db, item);
   }
 
+  batchUpsertMediaItemIdentifiers(items: Array<Pick<WatchlistItem, "plexItemId" | "type" | "guids" | "discoverKey">>): void {
+    identifiersRepo.batchUpsertMediaItemIdentifiers(this.db, items);
+  }
+
   replaceWatchlistItems(userId: number, items: WatchlistItem[]): void {
     watchlistRepo.replaceWatchlistItems(this.db, userId, items);
   }

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -1,9 +1,283 @@
 import crypto from "node:crypto";
 import type Database from "better-sqlite3";
 import type { WatchlistGroupedItem, WatchlistItem, WatchlistPageResponse, WatchlistSortBy } from "../../shared/types.js";
-import { buildGuidMergePlan, mergeRawPayloadGuids } from "./guid-dedupe.js";
+import { mergeRawPayloadGuids } from "./guid-dedupe.js";
 import { getDiscoverKeyForPlexItemId, upsertMediaItemIdentifiers } from "./identifiers.js";
 import { getAppSettings } from "./settings.js";
+
+type ItemSummaryRow = {
+  plexItemId: string;
+  title: string;
+  type: "movie" | "show";
+  year: number | null;
+  addedAt: string;
+  matchedRatingKey: string | null;
+  userId: number;
+  rawPayload: string;
+  discoverKey: string | null;
+};
+
+type BaseWatchlistItemGroup = {
+  plexItemId: string;
+  title: string;
+  year: number | null;
+  type: "movie" | "show";
+  addedAt: string;
+  matchedRatingKey: string | null;
+  plexAvailable: boolean;
+  memberItemIds: Set<string>;
+  userAddedAt: Map<number, string>;
+};
+
+class ItemDisjointSet {
+  private readonly parent = new Map<string, string>();
+
+  add(itemId: string): void {
+    if (!this.parent.has(itemId)) {
+      this.parent.set(itemId, itemId);
+    }
+  }
+
+  find(itemId: string): string {
+    const parent = this.parent.get(itemId);
+    if (!parent || parent === itemId) return itemId;
+    const root = this.find(parent);
+    this.parent.set(itemId, root);
+    return root;
+  }
+
+  union(left: string, right: string): void {
+    const leftRoot = this.find(left);
+    const rightRoot = this.find(right);
+    if (leftRoot !== rightRoot) {
+      this.parent.set(rightRoot, leftRoot);
+    }
+  }
+}
+
+function compareRepresentativeCandidate(
+  left: Pick<BaseWatchlistItemGroup, "matchedRatingKey" | "addedAt" | "userAddedAt" | "plexItemId">,
+  right: Pick<BaseWatchlistItemGroup, "matchedRatingKey" | "addedAt" | "userAddedAt" | "plexItemId">
+): number {
+  if (Boolean(left.matchedRatingKey) !== Boolean(right.matchedRatingKey)) {
+    return left.matchedRatingKey ? 1 : -1;
+  }
+
+  if (left.addedAt !== right.addedAt) {
+    return left.addedAt > right.addedAt ? 1 : -1;
+  }
+
+  if (left.userAddedAt.size !== right.userAddedAt.size) {
+    return left.userAddedAt.size > right.userAddedAt.size ? 1 : -1;
+  }
+
+  return right.plexItemId.localeCompare(left.plexItemId);
+}
+
+function compareGroupedItems(
+  left: BaseWatchlistItemGroup,
+  right: BaseWatchlistItemGroup,
+  sortBy: WatchlistSortBy
+): number {
+  switch (sortBy) {
+    case "added-asc": {
+      const addedCmp = new Date(left.addedAt).getTime() - new Date(right.addedAt).getTime();
+      if (addedCmp !== 0) return addedCmp;
+      break;
+    }
+    case "title-asc": {
+      const titleCmp = left.title.localeCompare(right.title, undefined, { sensitivity: "base" });
+      if (titleCmp !== 0) return titleCmp;
+      break;
+    }
+    case "title-desc": {
+      const titleCmp = right.title.localeCompare(left.title, undefined, { sensitivity: "base" });
+      if (titleCmp !== 0) return titleCmp;
+      break;
+    }
+    case "year-desc": {
+      const yearCmp = (right.year ?? 0) - (left.year ?? 0);
+      if (yearCmp !== 0) return yearCmp;
+      break;
+    }
+    case "year-asc": {
+      const yearCmp = (left.year ?? 0) - (right.year ?? 0);
+      if (yearCmp !== 0) return yearCmp;
+      break;
+    }
+    default: {
+      const addedCmp = new Date(right.addedAt).getTime() - new Date(left.addedAt).getTime();
+      if (addedCmp !== 0) return addedCmp;
+      break;
+    }
+  }
+
+  const titleCmp = left.title.localeCompare(right.title, undefined, { sensitivity: "base" });
+  if (titleCmp !== 0) return titleCmp;
+
+  const yearCmp = (right.year ?? 0) - (left.year ?? 0);
+  if (yearCmp !== 0) return yearCmp;
+
+  return left.plexItemId.localeCompare(right.plexItemId);
+}
+
+function buildWhereClause(options: {
+  allowSelectedDisabledOnly: boolean;
+  userId?: number;
+  mediaType?: "movie" | "show";
+}): { sql: string; params: (string | number)[] } {
+  const whereParts: string[] = [options.allowSelectedDisabledOnly ? "f.id = ?" : "f.enabled = 1"];
+  const params: (string | number)[] = options.allowSelectedDisabledOnly && options.userId ? [options.userId] : [];
+
+  if (options.mediaType) {
+    whereParts.push("w.type = ?");
+    params.push(options.mediaType);
+  }
+
+  return {
+    sql: whereParts.join(" AND "),
+    params
+  };
+}
+
+function loadWatchlistItemSummaries(
+  db: Database.Database,
+  whereClause: string,
+  whereParams: (string | number)[]
+): ItemSummaryRow[] {
+  return db.prepare(`
+    SELECT
+      w.plex_item_id AS plexItemId,
+      w.title AS title,
+      w.type AS type,
+      w.year AS year,
+      w.added_at AS addedAt,
+      w.matched_rating_key AS matchedRatingKey,
+      w.user_id AS userId,
+      w.raw_payload AS rawPayload,
+      w.discover_key AS discoverKey
+    FROM watchlist_cache w
+    JOIN users f ON f.id = w.user_id
+    WHERE ${whereClause}
+    ORDER BY
+      w.added_at DESC,
+      w.year DESC,
+      w.title COLLATE NOCASE ASC,
+      w.plex_item_id ASC,
+      w.user_id ASC
+  `).all(...whereParams) as ItemSummaryRow[];
+}
+
+function buildMergedWatchlistGroups(
+  rows: ItemSummaryRow[]
+): BaseWatchlistItemGroup[] {
+  const itemsById = new Map<string, BaseWatchlistItemGroup>();
+  const dsu = new ItemDisjointSet();
+  const itemGuids = new Map<string, Set<string>>();
+
+  for (const row of rows) {
+    dsu.add(row.plexItemId);
+
+    const existing = itemsById.get(row.plexItemId);
+    if (existing) {
+      const currentAddedAt = existing.userAddedAt.get(row.userId);
+      if (!currentAddedAt || row.addedAt > currentAddedAt) {
+        existing.userAddedAt.set(row.userId, row.addedAt);
+      }
+      if (row.addedAt > existing.addedAt) {
+        existing.addedAt = row.addedAt;
+      }
+      if (row.matchedRatingKey && !existing.matchedRatingKey) {
+        existing.matchedRatingKey = row.matchedRatingKey;
+      }
+      existing.plexAvailable = existing.plexAvailable || Boolean(row.matchedRatingKey);
+      continue;
+    }
+
+    mergeRawPayloadGuids(itemGuids, row.plexItemId, row.rawPayload);
+    if (row.discoverKey?.trim()) {
+      const identifiers = itemGuids.get(row.plexItemId) ?? new Set<string>();
+      identifiers.add(row.discoverKey.trim().toLowerCase());
+      itemGuids.set(row.plexItemId, identifiers);
+    }
+
+    itemsById.set(row.plexItemId, {
+      plexItemId: row.plexItemId,
+      title: row.title,
+      year: row.year,
+      type: row.type,
+      addedAt: row.addedAt,
+      matchedRatingKey: row.matchedRatingKey,
+      plexAvailable: Boolean(row.matchedRatingKey),
+      memberItemIds: new Set([row.plexItemId]),
+      userAddedAt: new Map([[row.userId, row.addedAt]])
+    });
+  }
+
+  const firstItemByIdentifier = new Map<string, string>();
+  for (const [itemId, identifiers] of itemGuids) {
+    if (!itemsById.has(itemId)) continue;
+    for (const identifier of identifiers) {
+      const existing = firstItemByIdentifier.get(identifier);
+      if (existing) {
+        const existingItem = itemsById.get(existing);
+        const currentItem = itemsById.get(itemId);
+        if (existingItem && currentItem && existingItem.type === currentItem.type) {
+          dsu.union(existing, itemId);
+        }
+      } else {
+        firstItemByIdentifier.set(identifier, itemId);
+      }
+    }
+  }
+
+  const groupsByRoot = new Map<string, BaseWatchlistItemGroup>();
+  for (const item of itemsById.values()) {
+    const root = dsu.find(item.plexItemId);
+    const existing = groupsByRoot.get(root);
+    if (!existing) {
+      groupsByRoot.set(root, {
+        plexItemId: item.plexItemId,
+        title: item.title,
+        year: item.year,
+        type: item.type,
+        addedAt: item.addedAt,
+        matchedRatingKey: item.matchedRatingKey,
+        plexAvailable: item.plexAvailable,
+        memberItemIds: new Set(item.memberItemIds),
+        userAddedAt: new Map(item.userAddedAt)
+      });
+      continue;
+    }
+
+    if (compareRepresentativeCandidate(item, existing) > 0) {
+      existing.plexItemId = item.plexItemId;
+      existing.title = item.title;
+      existing.year = item.year;
+      existing.type = item.type;
+    }
+
+    if (item.addedAt > existing.addedAt) {
+      existing.addedAt = item.addedAt;
+    }
+    if (item.matchedRatingKey && !existing.matchedRatingKey) {
+      existing.matchedRatingKey = item.matchedRatingKey;
+    }
+    existing.plexAvailable = existing.plexAvailable || item.plexAvailable;
+
+    for (const memberItemId of item.memberItemIds) {
+      existing.memberItemIds.add(memberItemId);
+    }
+    for (const [userId, addedAt] of item.userAddedAt) {
+      const currentAddedAt = existing.userAddedAt.get(userId);
+      if (!currentAddedAt || addedAt > currentAddedAt) {
+        existing.userAddedAt.set(userId, addedAt);
+      }
+    }
+  }
+
+  return Array.from(groupsByRoot.values());
+}
 
 export function getWatchlistDiscoverKey(db: Database.Database, plexItemId: string): string | null {
   const explicitDiscoverKey = getDiscoverKeyForPlexItemId(db, plexItemId);
@@ -128,47 +402,14 @@ export function getWatchlistGrouped(
     !selectedUser.enabled &&
     getAppSettings(db).trackAllUsers
   );
+  const { sql: whereClause, params: whereParams } = buildWhereClause({
+    allowSelectedDisabledOnly,
+    userId,
+    mediaType
+  });
 
-  type RawRow = {
-    plex_item_id: string;
-    title: string;
-    type: string;
-    year: number | null;
-    thumb: string | null;
-    added_at: string;
-    matched_rating_key: string | null;
-    raw_payload: string;
-    user_id: number;
-    friend_display_name: string;
-    friend_avatar_url: string | null;
-  };
-
-  // Build the WHERE clause dynamically. mediaType is pushed to SQL so only
-  // the relevant half of the dataset is loaded — movies and shows are
-  // type-scoped in the GUID merge so filtering here is safe. ORDER BY is
-  // omitted because TypeScript re-sorts after the merge anyway.
-  const whereParts: string[] = [allowSelectedDisabledOnly ? "f.id = ?" : "f.enabled = 1"];
-  const whereParams: (string | number)[] = allowSelectedDisabledOnly && userId ? [userId] : [];
-  if (mediaType) {
-    whereParts.push("w.type = ?");
-    whereParams.push(mediaType);
-  }
-
-  const rawRows = db
-    .prepare(`
-      SELECT w.plex_item_id, w.title, w.type, w.year,
-             ip.local_web_path AS thumb,
-             w.added_at, w.matched_rating_key, w.raw_payload,
-             f.id AS user_id,
-             COALESCE(f.display_name_override, f.username) AS friend_display_name,
-             ia.local_web_path AS friend_avatar_url
-      FROM watchlist_cache w
-      JOIN users f ON f.id = w.user_id
-      LEFT JOIN image_cache ip ON ip.cache_key = 'poster:' || w.plex_item_id
-      LEFT JOIN image_cache ia ON ia.cache_key = 'avatar:' || f.plex_user_id
-      WHERE ${whereParts.join(" AND ")}
-    `)
-    .all(...whereParams) as RawRow[];
+  const itemRows = loadWatchlistItemSummaries(db, whereClause, whereParams);
+  const allItems = buildMergedWatchlistGroups(itemRows);
 
   const enabledUsers = db
     .prepare(`
@@ -181,97 +422,17 @@ export function getWatchlistGrouped(
     `)
     .all() as Array<{ userId: number; displayName: string; avatarUrl: string | null }>;
 
-  const grouped = new Map<string, WatchlistGroupedItem>();
-  // Track GUIDs per item so we can merge items that share GUIDs but have
-  // different plex_item_id values (e.g. old discover ratingKey vs new plex:// GUID).
-  const itemGuids = new Map<string, Set<string>>();
-  const itemTypes = new Map<string, "movie" | "show">();
-
-  for (const row of rawRows) {
-    itemTypes.set(row.plex_item_id, row.type as "movie" | "show");
-    mergeRawPayloadGuids(itemGuids, row.plex_item_id, row.raw_payload);
-
-    const existing = grouped.get(row.plex_item_id);
-    const userEntry = {
-      userId: row.user_id,
-      displayName: row.friend_display_name,
-      avatarUrl: row.friend_avatar_url,
-      addedAt: row.added_at
-    };
-    if (existing) {
-      existing.users.push(userEntry);
-      existing.userCount++;
-      if (row.added_at > existing.addedAt) existing.addedAt = row.added_at;
-      if (row.matched_rating_key && !existing.matchedRatingKey) {
-        existing.matchedRatingKey = row.matched_rating_key;
-      }
-      existing.plexAvailable = existing.plexAvailable || Boolean(row.matched_rating_key);
-    } else {
-      grouped.set(row.plex_item_id, {
-        plexItemId: row.plex_item_id,
-        title: row.title,
-        year: row.year,
-        type: row.type as "movie" | "show",
-        posterUrl: row.thumb,
-        addedAt: row.added_at,
-        userCount: 1,
-        users: [userEntry],
-        plexAvailable: Boolean(row.matched_rating_key),
-        matchedRatingKey: row.matched_rating_key
-      });
-    }
-  }
-
-  // Second pass: merge entries whose GUIDs overlap but have different plex_item_id.
-  // This handles legacy data where the same media was cached under different ID formats
-  // (e.g. discover ratingKey for self vs plex:// GUID for friend).
-  const mergeInto = buildGuidMergePlan(itemGuids, itemTypes);
-
-  for (const [sourceId, targetId] of mergeInto) {
-    const source = grouped.get(sourceId);
-    const target = grouped.get(targetId);
-    if (!source || !target) continue;
-    for (const user of source.users) {
-      if (!target.users.some((u) => u.userId === user.userId)) {
-        target.users.push(user);
-        target.userCount++;
-      }
-    }
-    if (source.addedAt > target.addedAt) target.addedAt = source.addedAt;
-    if (source.matchedRatingKey && !target.matchedRatingKey) {
-      target.matchedRatingKey = source.matchedRatingKey;
-    }
-    target.plexAvailable = target.plexAvailable || source.plexAvailable;
-    grouped.delete(sourceId);
-  }
-
-  const sortFn = (a: WatchlistGroupedItem, b: WatchlistGroupedItem): number => {
-    switch (sortBy) {
-      case "added-asc":  return new Date(a.addedAt).getTime() - new Date(b.addedAt).getTime();
-      case "title-asc":  return a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
-      case "title-desc": return b.title.localeCompare(a.title, undefined, { sensitivity: "base" });
-      case "year-desc":  return (b.year ?? 0) - (a.year ?? 0);
-      case "year-asc":   return (a.year ?? 0) - (b.year ?? 0);
-      default:           return new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime(); // added-desc
-    }
-  };
-
-  const allItems = Array.from(grouped.values()).sort(sortFn);
-
-  const userFacetRows = rawRows.filter((row) =>
-    mediaType ? row.type === mediaType : true
-  );
   const userCounts = new Map<number, number>();
-  for (const row of userFacetRows) {
-    userCounts.set(row.user_id, (userCounts.get(row.user_id) ?? 0) + 1);
+  for (const item of allItems) {
+    for (const userEntryId of item.userAddedAt.keys()) {
+      userCounts.set(userEntryId, (userCounts.get(userEntryId) ?? 0) + 1);
+    }
   }
 
-  // mediaType is already filtered in SQL so allItems only contains the
-  // requested type; no second pass needed.
   const allUsersCount = allItems.length;
 
   const mediaFacetItems = allItems.filter((item) =>
-    userId ? item.users.some((user) => user.userId === userId) : true
+    userId ? item.userAddedAt.has(userId) : true
   );
   const mediaCounts = {
     all: mediaFacetItems.length,
@@ -280,10 +441,7 @@ export function getWatchlistGrouped(
   };
 
   const filteredItems = allItems.filter((item) => {
-    if (userId && !item.users.some((user) => user.userId === userId)) {
-      return false;
-    }
-    if (mediaType && item.type !== mediaType) {
+    if (userId && !item.userAddedAt.has(userId)) {
       return false;
     }
     if (availability === "available" && !item.plexAvailable) {
@@ -293,10 +451,74 @@ export function getWatchlistGrouped(
       return false;
     }
     return true;
+  }).sort((left, right) => compareGroupedItems(left, right, sortBy));
+
+  const pagedGroups = filteredItems.slice(offset, offset + pageSize);
+
+  const pageMemberItemIds = Array.from(new Set(pagedGroups.flatMap((item) => Array.from(item.memberItemIds))));
+  const posterByItemId = new Map<string, string | null>();
+  if (pageMemberItemIds.length > 0) {
+    const posterRows = db.prepare(`
+      SELECT substr(cache_key, 8) AS plexItemId, local_web_path AS posterUrl
+      FROM image_cache
+      WHERE cache_key IN (${pageMemberItemIds.map(() => "?").join(", ")})
+    `).all(...pageMemberItemIds.map((itemId) => `poster:${itemId}`)) as Array<{ plexItemId: string; posterUrl: string | null }>;
+
+    for (const row of posterRows) {
+      posterByItemId.set(row.plexItemId, row.posterUrl);
+    }
+  }
+
+  const userLookup = new Map<number, { displayName: string; avatarUrl: string | null }>();
+  for (const user of enabledUsers) {
+    userLookup.set(user.userId, {
+      displayName: user.displayName,
+      avatarUrl: user.avatarUrl
+    });
+  }
+  if (selectedUser) {
+    userLookup.set(selectedUser.userId, {
+      displayName: selectedUser.displayName,
+      avatarUrl: selectedUser.avatarUrl
+    });
+  }
+
+  const items: WatchlistGroupedItem[] = pagedGroups.map((item) => {
+    const users = Array.from(item.userAddedAt.entries())
+      .sort((left, right) => {
+        const addedCmp = right[1].localeCompare(left[1]);
+        return addedCmp !== 0 ? addedCmp : left[0] - right[0];
+      })
+      .map(([itemUserId, addedAt]) => ({
+        userId: itemUserId,
+        displayName: userLookup.get(itemUserId)?.displayName ?? `User ${itemUserId}`,
+        avatarUrl: userLookup.get(itemUserId)?.avatarUrl ?? null,
+        addedAt
+      }));
+
+    const posterUrl =
+      posterByItemId.get(item.plexItemId)
+      ?? Array.from(item.memberItemIds)
+        .map((memberItemId) => posterByItemId.get(memberItemId) ?? null)
+        .find((candidate): candidate is string => Boolean(candidate))
+      ?? null;
+
+    return {
+      plexItemId: item.plexItemId,
+      title: item.title,
+      year: item.year,
+      type: item.type,
+      posterUrl,
+      addedAt: item.addedAt,
+      userCount: item.userAddedAt.size,
+      users,
+      plexAvailable: item.plexAvailable,
+      matchedRatingKey: item.matchedRatingKey
+    };
   });
 
   return {
-    items: filteredItems.slice(offset, offset + pageSize),
+    items,
     total: filteredItems.length,
     page,
     pageSize,

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -57,7 +57,6 @@ export function replaceWatchlistItems(db: Database.Database, userId: number, ite
     del.run(userId);
     for (const item of items) {
       insert.run({ userId, ...item, rawPayload: JSON.stringify(item), discoverKey: item.discoverKey ?? null });
-      upsertMediaItemIdentifiers(db, item);
     }
   })();
 }

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -143,6 +143,17 @@ export function getWatchlistGrouped(
     friend_avatar_url: string | null;
   };
 
+  // Build the WHERE clause dynamically. mediaType is pushed to SQL so only
+  // the relevant half of the dataset is loaded — movies and shows are
+  // type-scoped in the GUID merge so filtering here is safe. ORDER BY is
+  // omitted because TypeScript re-sorts after the merge anyway.
+  const whereParts: string[] = [allowSelectedDisabledOnly ? "f.id = ?" : "f.enabled = 1"];
+  const whereParams: (string | number)[] = allowSelectedDisabledOnly && userId ? [userId] : [];
+  if (mediaType) {
+    whereParts.push("w.type = ?");
+    whereParams.push(mediaType);
+  }
+
   const rawRows = db
     .prepare(`
       SELECT w.plex_item_id, w.title, w.type, w.year,
@@ -155,10 +166,9 @@ export function getWatchlistGrouped(
       JOIN users f ON f.id = w.user_id
       LEFT JOIN image_cache ip ON ip.cache_key = 'poster:' || w.plex_item_id
       LEFT JOIN image_cache ia ON ia.cache_key = 'avatar:' || f.plex_user_id
-      WHERE ${allowSelectedDisabledOnly ? "f.id = ?" : "f.enabled = 1"}
-      ORDER BY w.added_at DESC
+      WHERE ${whereParts.join(" AND ")}
     `)
-    .all(...(allowSelectedDisabledOnly && userId ? [userId] : [])) as RawRow[];
+    .all(...whereParams) as RawRow[];
 
   const enabledUsers = db
     .prepare(`
@@ -256,9 +266,9 @@ export function getWatchlistGrouped(
     userCounts.set(row.user_id, (userCounts.get(row.user_id) ?? 0) + 1);
   }
 
-  const allUsersCount = allItems.filter((item) =>
-    mediaType ? item.type === mediaType : true
-  ).length;
+  // mediaType is already filtered in SQL so allItems only contains the
+  // requested type; no second pass needed.
+  const allUsersCount = allItems.length;
 
   const mediaFacetItems = allItems.filter((item) =>
     userId ? item.users.some((user) => user.userId === userId) : true

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -10,6 +10,10 @@ export interface ResolvedWatchlistItem extends WatchlistItem {
   searchCandidates?: SearchCandidate[];
 }
 
+// Use one shared limiter so concurrent full-sync users do not each get their
+// own 10-request budget for discover enrichment and library matching.
+const resolveWatchlistItemLimit = pLimit(10);
+
 // ---------------------------------------------------------------------------
 // Filter string helpers for per-user Plex content isolation
 // ---------------------------------------------------------------------------
@@ -799,11 +803,10 @@ export class PlexIntegration {
   }
 
   async resolveWatchlistItems(items: WatchlistItem[], mediaType: MediaType, libraryId: string): Promise<ResolvedWatchlistItem[]> {
-    const limit = pLimit(10);
     const filteredItems = items.filter((entry) => entry.type === mediaType);
 
     const results = await Promise.all(filteredItems.map((item) =>
-      limit(async (): Promise<ResolvedWatchlistItem> => {
+      resolveWatchlistItemLimit(async (): Promise<ResolvedWatchlistItem> => {
         this.logger.debug("Watchlist item raw data", { item });
 
         // Enrich first so we have tmdb/tvdb/imdb GUIDs from discover.provider.plex.tv

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -510,6 +510,8 @@ export class PlexIntegration {
       `library/metadata/${item.plexItemId}`
     ].filter((endpoint): endpoint is string => Boolean(endpoint))));
 
+    let lastErr: Error | null = null;
+
     for (const endpoint of endpoints) {
       try {
         const response = await fetch(this.buildDiscoverMetadataUrl(endpoint), {
@@ -564,8 +566,19 @@ export class PlexIntegration {
         if (err instanceof Error && (err.message.includes("429") || err.message.toLowerCase().includes("rate limit"))) {
           throw err; // propagate rate-limit errors so adaptiveItemLimiter can handle backoff
         }
-        // Non-rate-limit errors: try next endpoint
+        // Non-rate-limit errors: store and try next endpoint
+        if (err instanceof Error) {
+          lastErr = err;
+        }
       }
+    }
+
+    if (lastErr) {
+      this.logger.warn("Discover metadata lookup failed for all endpoints", {
+        plexItemId: item.plexItemId,
+        message: lastErr.message,
+        stack: lastErr.stack
+      });
     }
 
     return null;

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1,6 +1,5 @@
 ﻿import crypto from "node:crypto";
 import { parseStringPromise } from "xml2js";
-import pLimit from "p-limit";
 import type { RssFeedItem } from "../rss-cache.js";
 import type { Logger } from "../logger.js";
 import { PLEX_USER_AGENT } from "../version.js";
@@ -10,9 +9,121 @@ export interface ResolvedWatchlistItem extends WatchlistItem {
   searchCandidates?: SearchCandidate[];
 }
 
-// Use one shared limiter so concurrent full-sync users do not each get their
-// own 10-request budget for discover enrichment and library matching.
-const resolveWatchlistItemLimit = pLimit(10);
+// ---------------------------------------------------------------------------
+// Adaptive per-item enrichment limiter
+// ---------------------------------------------------------------------------
+// Shared across concurrent user syncs so all users draw from the same pool.
+// Starts at MAX_ENRICHMENT_CONCURRENCY. On a 429 the limit drops by 30% and
+// all in-flight items wait out an exponential-backoff cooldown before retrying.
+// After RECOVERY_THRESHOLD consecutive successes the limit climbs back by 1
+// until it reaches the original max.
+
+const MAX_ENRICHMENT_CONCURRENCY = 3;
+const RECOVERY_THRESHOLD = 5;
+
+class AdaptiveItemLimiter {
+  private currentLimit: number;
+  private readonly maxLimit: number;
+  private active = 0;
+  private consecutiveSuccesses = 0;
+  private consecutiveRateLimits = 0;
+  private readonly pending: Array<() => void> = [];
+  private cooldownUntil = 0;
+  private schedulePending = false;
+
+  constructor(limit: number) {
+    this.currentLimit = limit;
+    this.maxLimit = limit;
+  }
+
+  run<T>(fn: () => Promise<T>, logger?: Logger): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.pending.push(() => {
+        this.active++;
+        this.executeWithRetry(fn, logger)
+          .then((result) => {
+            this.active--;
+            this.onSuccess(logger);
+            this.schedule();
+            resolve(result);
+          })
+          .catch((err) => {
+            this.active--;
+            this.schedule();
+            reject(err);
+          });
+      });
+      this.schedule();
+    });
+  }
+
+  private schedule(): void {
+    const delay = Math.max(0, this.cooldownUntil - Date.now());
+    if (delay > 0) {
+      if (!this.schedulePending) {
+        this.schedulePending = true;
+        setTimeout(() => {
+          this.schedulePending = false;
+          this.schedule();
+        }, delay);
+      }
+      return;
+    }
+    while (this.pending.length > 0 && this.active < this.currentLimit) {
+      const next = this.pending.shift()!;
+      next();
+    }
+  }
+
+  private async executeWithRetry<T>(fn: () => Promise<T>, logger?: Logger): Promise<T> {
+    for (;;) {
+      const wait = this.cooldownUntil - Date.now();
+      if (wait > 0) await new Promise<void>(r => setTimeout(r, wait));
+      try {
+        return await fn();
+      } catch (err) {
+        if (this.is429(err)) {
+          this.onRateLimit(logger);
+        } else {
+          throw err;
+        }
+      }
+    }
+  }
+
+  private is429(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    return err.message.includes("429") || err.message.toLowerCase().includes("rate limit");
+  }
+
+  private onRateLimit(logger?: Logger): void {
+    this.consecutiveSuccesses = 0;
+    this.consecutiveRateLimits++;
+    const base = Math.min(2000 * (1.5 ** (this.consecutiveRateLimits - 1)), 30_000);
+    const jitter = (Math.random() * 2 - 1) * base * 0.1;
+    const cooldownMs = base + jitter;
+    this.cooldownUntil = Math.max(this.cooldownUntil, Date.now() + cooldownMs);
+    const prev = this.currentLimit;
+    this.currentLimit = Math.max(1, Math.floor(this.currentLimit * 0.7));
+    logger?.warn("Plex rate limit detected; reducing enrichment concurrency", {
+      prev,
+      current: this.currentLimit,
+      cooldownSecs: (cooldownMs / 1000).toFixed(1)
+    });
+  }
+
+  private onSuccess(logger?: Logger): void {
+    this.consecutiveRateLimits = 0;
+    this.consecutiveSuccesses++;
+    if (this.currentLimit < this.maxLimit && this.consecutiveSuccesses >= RECOVERY_THRESHOLD) {
+      this.currentLimit = Math.min(this.currentLimit + 1, this.maxLimit);
+      this.consecutiveSuccesses = Math.floor(RECOVERY_THRESHOLD / 2);
+      logger?.debug("Plex rate limit recovery: enrichment concurrency increased", { current: this.currentLimit });
+    }
+  }
+}
+
+const adaptiveItemLimiter = new AdaptiveItemLimiter(MAX_ENRICHMENT_CONCURRENCY);
 
 // ---------------------------------------------------------------------------
 // Filter string helpers for per-user Plex content isolation
@@ -806,7 +917,7 @@ export class PlexIntegration {
     const filteredItems = items.filter((entry) => entry.type === mediaType);
 
     const results = await Promise.all(filteredItems.map((item) =>
-      resolveWatchlistItemLimit(async (): Promise<ResolvedWatchlistItem> => {
+      adaptiveItemLimiter.run(async (): Promise<ResolvedWatchlistItem> => {
         this.logger.debug("Watchlist item raw data", { item });
 
         // Enrich first so we have tmdb/tvdb/imdb GUIDs from discover.provider.plex.tv
@@ -863,7 +974,7 @@ export class PlexIntegration {
             searchCandidates: match.candidates
           };
         }
-      })
+      }, this.logger)
     ));
 
     return results;

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -36,11 +36,11 @@ class AdaptiveItemLimiter {
     this.maxLimit = limit;
   }
 
-  run<T>(fn: () => Promise<T>, logger?: Logger): Promise<T> {
+  run<T>(fn: () => Promise<T>, logger?: Logger, maxRetries = 5): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       this.pending.push(() => {
         this.active++;
-        this.executeWithRetry(fn, logger)
+        this.executeWithRetry(fn, logger, maxRetries)
           .then((result) => {
             this.active--;
             this.onSuccess(logger);
@@ -75,14 +75,20 @@ class AdaptiveItemLimiter {
     }
   }
 
-  private async executeWithRetry<T>(fn: () => Promise<T>, logger?: Logger): Promise<T> {
+  private async executeWithRetry<T>(fn: () => Promise<T>, logger?: Logger, maxRetries = 5): Promise<T> {
+    let attempts = 0;
     for (;;) {
       const wait = this.cooldownUntil - Date.now();
       if (wait > 0) await new Promise<void>(r => setTimeout(r, wait));
       try {
-        return await fn();
+        const result = await fn();
+        return result;
       } catch (err) {
         if (this.is429(err)) {
+          attempts++;
+          if (attempts > maxRetries) {
+            throw new Error(`Rate limit exceeded after ${maxRetries} retries`);
+          }
           this.onRateLimit(logger);
         } else {
           throw err;
@@ -515,7 +521,9 @@ export class PlexIntegration {
         });
 
         if (!response.ok) {
-          continue;
+          let body = "";
+          try { body = await response.text(); } catch { /* ignore */ }
+          throw new Error(`Discover metadata request failed with HTTP ${response.status}: ${body}`);
         }
 
         const json = (await response.json()) as {
@@ -552,8 +560,11 @@ export class PlexIntegration {
             guids
           };
         }
-      } catch {
-        // Best-effort discover metadata lookup only.
+      } catch (err) {
+        if (err instanceof Error && (err.message.includes("429") || err.message.toLowerCase().includes("rate limit"))) {
+          throw err; // propagate rate-limit errors so adaptiveItemLimiter can handle backoff
+        }
+        // Non-rate-limit errors: try next endpoint
       }
     }
 

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1,5 +1,6 @@
 ﻿import crypto from "node:crypto";
 import { parseStringPromise } from "xml2js";
+import pLimit from "p-limit";
 import type { RssFeedItem } from "../rss-cache.js";
 import type { Logger } from "../logger.js";
 import { PLEX_USER_AGENT } from "../version.js";
@@ -798,68 +799,71 @@ export class PlexIntegration {
   }
 
   async resolveWatchlistItems(items: WatchlistItem[], mediaType: MediaType, libraryId: string): Promise<ResolvedWatchlistItem[]> {
-    const resolved: ResolvedWatchlistItem[] = [];
+    const limit = pLimit(10);
+    const filteredItems = items.filter((entry) => entry.type === mediaType);
 
-    for (const item of items.filter((entry) => entry.type === mediaType)) {
-      this.logger.debug("Watchlist item raw data", { item });
+    const results = await Promise.all(filteredItems.map((item) =>
+      limit(async (): Promise<ResolvedWatchlistItem> => {
+        this.logger.debug("Watchlist item raw data", { item });
 
-      // Enrich first so we have tmdb/tvdb/imdb GUIDs from discover.provider.plex.tv
-      // before attempting the library match.
-      const enriched = await this.enrichWatchlistMetadata(item);
-      const enrichedGuids = enriched.guids;
+        // Enrich first so we have tmdb/tvdb/imdb GUIDs from discover.provider.plex.tv
+        // before attempting the library match.
+        const enriched = await this.enrichWatchlistMetadata(item);
+        const enrichedGuids = enriched.guids;
 
-      this.logger.debug("Watchlist item enriched GUIDs", {
-        title: item.title,
-        originalGuids: item.guids ?? [],
-        enrichedGuids
-      });
-
-      const match = await this.searchLibraryItem(
-        item.title,
-        mediaType,
-        libraryId,
-        enriched.year || undefined,
-        enrichedGuids
-      );
-      const matchedRatingKey = match.ratingKey || null;
-
-      if (matchedRatingKey) {
-        this.logger.debug("Watchlist item resolved to library", {
+        this.logger.debug("Watchlist item enriched GUIDs", {
           title: item.title,
-          type: mediaType,
-          ratingKey: matchedRatingKey
+          originalGuids: item.guids ?? [],
+          enrichedGuids
         });
-        resolved.push({
-          ...item,
-          thumb: enriched.thumb,
-          year: enriched.year,
-          releaseDate: enriched.releaseDate,
-          guids: enrichedGuids,
-          matchedRatingKey
-        });
-      } else {
-        this.logger.warn("Watchlist item not matched in library", {
-          title: item.title,
-          type: mediaType,
-          year: enriched.year ?? null,
-          guids: enrichedGuids,
+
+        const match = await this.searchLibraryItem(
+          item.title,
+          mediaType,
           libraryId,
-          candidateCount: match.candidates.length,
-          candidates: match.candidates
-        });
-        resolved.push({
-          ...item,
-          thumb: enriched.thumb,
-          year: enriched.year,
-          releaseDate: enriched.releaseDate,
-          guids: enrichedGuids,
-          matchedRatingKey: null,
-          searchCandidates: match.candidates
-        });
-      }
-    }
+          enriched.year || undefined,
+          enrichedGuids
+        );
+        const matchedRatingKey = match.ratingKey || null;
 
-    return resolved;
+        if (matchedRatingKey) {
+          this.logger.debug("Watchlist item resolved to library", {
+            title: item.title,
+            type: mediaType,
+            ratingKey: matchedRatingKey
+          });
+          return {
+            ...item,
+            thumb: enriched.thumb,
+            year: enriched.year,
+            releaseDate: enriched.releaseDate,
+            guids: enrichedGuids,
+            matchedRatingKey
+          };
+        } else {
+          this.logger.warn("Watchlist item not matched in library", {
+            title: item.title,
+            type: mediaType,
+            year: enriched.year ?? null,
+            guids: enrichedGuids,
+            libraryId,
+            candidateCount: match.candidates.length,
+            candidates: match.candidates
+          });
+          return {
+            ...item,
+            thumb: enriched.thumb,
+            year: enriched.year,
+            releaseDate: enriched.releaseDate,
+            guids: enrichedGuids,
+            matchedRatingKey: null,
+            searchCandidates: match.candidates
+          };
+        }
+      })
+    ));
+
+    return results;
   }
 
   async searchLibraryItem(

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -14,6 +14,8 @@ import { Logger } from "./logger.js";
 import { PlexIntegration, WATCHLIST_DATE_UNKNOWN_SENTINEL, type PlexLibraryItemMatch, type ResolvedWatchlistItem } from "./integrations/plex.js";
 import { RssCache, type RssFeedItem } from "./rss-cache.js";
 
+const PLEX_SYNC_CONCURRENCY = 3;
+
 /**
  * Compare two watchlist items by release date for Plex collection ordering.
  *
@@ -321,7 +323,7 @@ export class HubarrServices {
         let onboardingCompleted = 0;
         const failures: string[] = [];
 
-        const onboardingLimit = pLimit(3);
+        const onboardingLimit = pLimit(PLEX_SYNC_CONCURRENCY);
         await Promise.all(trackedUsers.map((user) =>
           onboardingLimit(async () => {
             const syncPromise = this.syncUser(user, runId);
@@ -1073,7 +1075,7 @@ export class HubarrServices {
       });
     }
 
-    const limit = pLimit(3);
+    const limit = pLimit(PLEX_SYNC_CONCURRENCY);
     let completed = 0;
 
     await Promise.all(friends.map((friend) =>
@@ -1216,7 +1218,7 @@ export class HubarrServices {
 
     this.logger.info("Collection sync started", { userCount: friends.length });
 
-    const publishLimit = pLimit(3);
+    const publishLimit = pLimit(PLEX_SYNC_CONCURRENCY);
     let publishCompleted = 0;
 
     await Promise.all(friends.map((friend) =>

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -796,22 +796,25 @@ export class HubarrServices {
 
     const plexSettings = this.db.getPlexSettings();
     if (plexSettings) {
-      for (const item of mergedWithDates) {
-        if (!item.thumb) continue;
-        if (item.thumb.startsWith("/")) {
-          await this.imageCache.ensurePosterCached(item.plexItemId, {
-            type: "plex-path",
-            value: item.thumb,
-            serverUrl: plexSettings.serverUrl,
-            token: plexSettings.token
-          });
-        } else if (item.thumb.startsWith("https://")) {
-          await this.imageCache.ensurePosterCached(item.plexItemId, {
-            type: "public-url",
-            value: item.thumb
-          });
-        }
-      }
+      const imageLimit = pLimit(5);
+      await Promise.all(mergedWithDates.map((item) =>
+        imageLimit(async () => {
+          if (!item.thumb) return;
+          if (item.thumb.startsWith("/")) {
+            await this.imageCache.ensurePosterCached(item.plexItemId, {
+              type: "plex-path",
+              value: item.thumb,
+              serverUrl: plexSettings.serverUrl,
+              token: plexSettings.token
+            });
+          } else if (item.thumb.startsWith("https://")) {
+            await this.imageCache.ensurePosterCached(item.plexItemId, {
+              type: "public-url",
+              value: item.thumb
+            });
+          }
+        })
+      ));
     }
 
     this.db.addSyncRunItem(

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -747,12 +747,13 @@ export class HubarrServices {
     }
 
     // Step 1: Resolve addedAt from the activity cache for items still carrying
-    // the sentinel. Identifier aliasing is resolved via the DB's explicit user
-    // and media identifier tables, so the lookup can match across self-user ID
-    // aliases and media ID forms without duplicating fallback logic here.
+    // the sentinel. One bulk query fetches all cached dates for this user at
+    // once; the resulting map is keyed by normalized identifier value so any
+    // plexItemId that matches a stored identifier or canonical key will hit.
+    const activityCacheDates = this.db.getActivityCacheDatesForUser(friend.id);
     const afterActivityCache = merged.map((item) => {
       if (item.addedAt !== WATCHLIST_DATE_UNKNOWN_SENTINEL) return item;
-      const cached = this.db.getActivityCacheDateForUserItem(friend.id, item.plexItemId);
+      const cached = activityCacheDates.get(item.plexItemId.trim().toLowerCase());
       if (cached) {
         this.logger.debug("Resolved addedAt from activity cache", { title: item.title, watchlistedAt: cached });
         return { ...item, addedAt: cached };

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -327,27 +327,42 @@ export class HubarrServices {
         await Promise.all(trackedUsers.map((user) =>
           onboardingLimit(async () => {
             const syncPromise = this.syncUser(user, runId);
+            let timedOut = false;
             try {
               await withTimeout(syncPromise, 60_000, `User sync for ${user.displayName}`);
-              succeeded++;
-            } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              failures.push(`${user.displayName}: ${message}`);
-              this.logger.warn("Onboarding preload: user sync failed — continuing", {
-                userId: user.id,
-                displayName: user.displayName,
-                message
-              });
-              this.db.addSyncRunItem(runId, "sync.user", "error", {
-                userId: user.id,
-                displayName: user.displayName,
-                message
-              }, user.id);
+            } catch {
+              timedOut = true;
             } finally {
-              // withTimeout() only rejects the wrapper promise. Always wait for
-              // the underlying sync to settle before advancing onboarding so a
-              // timed-out user sync cannot keep mutating state in Phase 3.
-              await syncPromise.catch(() => {});
+              // Always await the underlying sync before recording the outcome so
+              // a timeout rejection doesn't prematurely mark a user as failed
+              // when syncUser() completes successfully moments later.
+              const outcome = await syncPromise.then(
+                () => ({ ok: true as const }),
+                (err: unknown) => ({ ok: false as const, message: err instanceof Error ? err.message : String(err) })
+              );
+
+              if (outcome.ok) {
+                succeeded++;
+                if (timedOut) {
+                  this.logger.warn("Onboarding preload: user sync exceeded timeout but eventually completed", {
+                    userId: user.id,
+                    displayName: user.displayName
+                  });
+                }
+              } else {
+                failures.push(`${user.displayName}: ${outcome.message}`);
+                this.logger.warn("Onboarding preload: user sync failed — continuing", {
+                  userId: user.id,
+                  displayName: user.displayName,
+                  message: outcome.message
+                });
+                this.db.addSyncRunItem(runId, "sync.user", "error", {
+                  userId: user.id,
+                  displayName: user.displayName,
+                  message: outcome.message
+                }, user.id);
+              }
+
               onboardingCompleted++;
               emit("graphql-sync", "running", `Syncing watchlists (${onboardingCompleted}/${total})...`, { progress: onboardingCompleted, total });
             }
@@ -824,7 +839,13 @@ export class HubarrServices {
               });
             }
           } catch (err) {
-            this.logger.warn("Failed to cache poster image; skipping", { plexItemId: item.plexItemId, thumb: item.thumb, err });
+            this.logger.warn("Failed to cache poster image; skipping", {
+              userId: friend.id,
+              displayName: friend.displayName,
+              plexItemId: item.plexItemId,
+              thumb: item.thumb,
+              message: err instanceof Error ? err.message : String(err)
+            });
           }
         })
       ));

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -603,6 +603,9 @@ export class HubarrServices {
       }
     }
 
+    const userMap = new Map(trackedUsers.map((u) => [u.id, u]));
+    const watchlistByUser = new Map(trackedUsers.map((u) => [u.id, this.db.getWatchlistItems(u.id)]));
+
     let matchedCount = 0;
     let affectedUsers = 0;
 
@@ -622,12 +625,12 @@ export class HubarrServices {
       }
 
       for (const friendId of library.userIds) {
-        const friend = trackedUsers.find((entry) => entry.id === friendId);
+        const friend = userMap.get(friendId);
         if (!friend) {
           continue;
         }
 
-        const watchlistItems = this.db.getWatchlistItems(friendId);
+        const watchlistItems = watchlistByUser.get(friendId) ?? [];
         let friendChanged = false;
 
         for (const item of watchlistItems) {
@@ -742,9 +745,8 @@ export class HubarrServices {
     // Pre-register merged item identifiers before the activity-cache lookup so
     // newly fetched items can resolve dates through the alias catalog on this
     // same sync pass, before replaceWatchlistItems persists the watchlist.
-    for (const item of merged) {
-      this.db.upsertMediaItemIdentifiers(item);
-    }
+    // All writes go in one transaction to avoid per-item auto-commit overhead.
+    this.db.batchUpsertMediaItemIdentifiers(merged);
 
     // Step 1: Resolve addedAt from the activity cache for items still carrying
     // the sentinel. One bulk query fetches all cached dates for this user at

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -7,6 +7,7 @@ import type {
   PlexSettingsInput,
   WatchlistItem
 } from "../shared/types.js";
+import pLimit from "p-limit";
 import { HubarrDatabase } from "./db/index.js";
 import { ImageCacheService } from "./image-cache.js";
 import { Logger } from "./logger.js";
@@ -136,16 +137,15 @@ export class HubarrServices {
   private updateRunProgressSummary(
     runId: number,
     kind: "full" | "publish",
-    user: UserRecord,
-    current: number,
+    completed: number,
     total: number
   ): void {
     if (kind === "publish") {
-      this.db.updateSyncRunSummary(runId, `Collection sync: publishing collections for ${user.displayName} (${current}/${total}).`);
+      this.db.updateSyncRunSummary(runId, `Collection sync: publishing collections (${completed}/${total} users).`);
       return;
     }
 
-    this.db.updateSyncRunSummary(runId, `Full sync: syncing watchlist for ${user.displayName} (${current}/${total}).`);
+    this.db.updateSyncRunSummary(runId, `Full sync: syncing watchlists (${completed}/${total} users).`);
   }
 
   /**
@@ -318,29 +318,34 @@ export class HubarrServices {
 
         const runId = this.db.createSyncRun("full", "Onboarding preload watchlist sync.");
         let succeeded = 0;
+        let onboardingCompleted = 0;
         const failures: string[] = [];
 
-        for (let i = 0; i < trackedUsers.length; i++) {
-          const user = trackedUsers[i];
-          emit("graphql-sync", "running", `Syncing ${user.displayName}...`, { progress: i, total });
-          try {
-            await withTimeout(this.syncUser(user, runId), 60_000, `User sync for ${user.displayName}`);
-            succeeded++;
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            failures.push(`${user.displayName}: ${message}`);
-            this.logger.warn("Onboarding preload: user sync failed — continuing", {
-              userId: user.id,
-              displayName: user.displayName,
-              message
-            });
-            this.db.addSyncRunItem(runId, "sync.user", "error", {
-              userId: user.id,
-              displayName: user.displayName,
-              message
-            }, user.id);
-          }
-        }
+        const onboardingLimit = pLimit(5);
+        await Promise.all(trackedUsers.map((user) =>
+          onboardingLimit(async () => {
+            try {
+              await withTimeout(this.syncUser(user, runId), 60_000, `User sync for ${user.displayName}`);
+              succeeded++;
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              failures.push(`${user.displayName}: ${message}`);
+              this.logger.warn("Onboarding preload: user sync failed — continuing", {
+                userId: user.id,
+                displayName: user.displayName,
+                message
+              });
+              this.db.addSyncRunItem(runId, "sync.user", "error", {
+                userId: user.id,
+                displayName: user.displayName,
+                message
+              }, user.id);
+            } finally {
+              onboardingCompleted++;
+              emit("graphql-sync", "running", `Syncing watchlists (${onboardingCompleted}/${total})...`, { progress: onboardingCompleted, total });
+            }
+          })
+        ));
 
         const runStatus = succeeded === total ? "success" : "error";
         this.db.completeSyncRun(
@@ -711,8 +716,10 @@ export class HubarrServices {
       return [await plex.fetchUserWatchlist(friend.plexUserId), null] as const;
     })();
 
-    const movieItems = await plex.resolveWatchlistItems(rawItems, "movie", movieLibraryId);
-    const showItems = await plex.resolveWatchlistItems(rawItems, "show", showLibraryId);
+    const [movieItems, showItems] = await Promise.all([
+      plex.resolveWatchlistItems(rawItems, "movie", movieLibraryId),
+      plex.resolveWatchlistItems(rawItems, "show", showLibraryId)
+    ]);
     const fetched: ResolvedWatchlistItem[] = [...movieItems, ...showItems].sort((a, b) => a.title.localeCompare(b.title));
 
     if (selfPlexUuid) {
@@ -1051,29 +1058,36 @@ export class HubarrServices {
       });
     }
 
-    for (const [index, friend] of friends.entries()) {
-      this.updateRunProgressSummary(runId, "full", friend, index + 1, friends.length);
-      const rssDateMap = rssMaps
-        ? (friend.isSelf ? rssMaps.self : (rssMaps.byAuthor.get(friend.plexUserId) ?? new Map()))
-        : undefined;
-      try {
-        await this.syncUser(friend, runId, rssDateMap);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        this.logger.error("Friend sync failed during full sync — continuing with remaining users", {
-          userId: friend.id,
-          displayName: friend.displayName,
-          message
-        });
-        this.db.markUserSyncResult(friend.id, message);
-        this.db.addSyncRunItem(runId, "sync.user", "error", {
-          userId: friend.id,
-          displayName: friend.displayName,
-          message
-        }, friend.id);
-        failures.push(`${friend.displayName}: ${message}`);
-      }
-    }
+    const limit = pLimit(5);
+    let completed = 0;
+
+    await Promise.all(friends.map((friend) =>
+      limit(async () => {
+        const rssDateMap = rssMaps
+          ? (friend.isSelf ? rssMaps.self : (rssMaps.byAuthor.get(friend.plexUserId) ?? new Map()))
+          : undefined;
+        try {
+          await this.syncUser(friend, runId, rssDateMap);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.error("Friend sync failed during full sync — continuing with remaining users", {
+            userId: friend.id,
+            displayName: friend.displayName,
+            message
+          });
+          this.db.markUserSyncResult(friend.id, message);
+          this.db.addSyncRunItem(runId, "sync.user", "error", {
+            userId: friend.id,
+            displayName: friend.displayName,
+            message
+          }, friend.id);
+          failures.push(`${friend.displayName}: ${message}`);
+        } finally {
+          completed++;
+          this.updateRunProgressSummary(runId, "full", completed, friends.length);
+        }
+      })
+    ));
 
     if (failures.length > 0) {
       const summary = `Full sync finished: ${friends.length - failures.length}/${friends.length} users succeeded.`;
@@ -1187,27 +1201,34 @@ export class HubarrServices {
 
     this.logger.info("Collection sync started", { userCount: friends.length });
 
-    for (const [index, friend] of friends.entries()) {
-      this.updateRunProgressSummary(runId, "publish", friend, index + 1, friends.length);
-      try {
-        await this.publishUserCollections(friend, this.db.getWatchlistItems(friend.id), runId, plex);
-        this.db.markUserSyncResult(friend.id, null);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        this.logger.error("Collection sync failed for user — continuing with remaining users", {
-          userId: friend.id,
-          displayName: friend.displayName,
-          message
-        });
-        this.db.markUserSyncResult(friend.id, message);
-        this.db.addSyncRunItem(runId, "collection.publish", "error", {
-          userId: friend.id,
-          displayName: friend.displayName,
-          message
-        }, friend.id);
-        failures.push(`${friend.displayName}: ${message}`);
-      }
-    }
+    const publishLimit = pLimit(5);
+    let publishCompleted = 0;
+
+    await Promise.all(friends.map((friend) =>
+      publishLimit(async () => {
+        try {
+          await this.publishUserCollections(friend, this.db.getWatchlistItems(friend.id), runId, plex);
+          this.db.markUserSyncResult(friend.id, null);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.error("Collection sync failed for user — continuing with remaining users", {
+            userId: friend.id,
+            displayName: friend.displayName,
+            message
+          });
+          this.db.markUserSyncResult(friend.id, message);
+          this.db.addSyncRunItem(runId, "collection.publish", "error", {
+            userId: friend.id,
+            displayName: friend.displayName,
+            message
+          }, friend.id);
+          failures.push(`${friend.displayName}: ${message}`);
+        } finally {
+          publishCompleted++;
+          this.updateRunProgressSummary(runId, "publish", publishCompleted, friends.length);
+        }
+      })
+    ));
 
     await this.applyIsolationFilters(friends, runId);
 

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -324,8 +324,9 @@ export class HubarrServices {
         const onboardingLimit = pLimit(5);
         await Promise.all(trackedUsers.map((user) =>
           onboardingLimit(async () => {
+            const syncPromise = this.syncUser(user, runId);
             try {
-              await withTimeout(this.syncUser(user, runId), 60_000, `User sync for ${user.displayName}`);
+              await withTimeout(syncPromise, 60_000, `User sync for ${user.displayName}`);
               succeeded++;
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
@@ -341,6 +342,10 @@ export class HubarrServices {
                 message
               }, user.id);
             } finally {
+              // withTimeout() only rejects the wrapper promise. Always wait for
+              // the underlying sync to settle before advancing onboarding so a
+              // timed-out user sync cannot keep mutating state in Phase 3.
+              await syncPromise.catch(() => {});
               onboardingCompleted++;
               emit("graphql-sync", "running", `Syncing watchlists (${onboardingCompleted}/${total})...`, { progress: onboardingCompleted, total });
             }

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1216,7 +1216,7 @@ export class HubarrServices {
 
     this.logger.info("Collection sync started", { userCount: friends.length });
 
-    const publishLimit = pLimit(5);
+    const publishLimit = pLimit(3);
     let publishCompleted = 0;
 
     await Promise.all(friends.map((friend) =>

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -822,7 +822,7 @@ export class HubarrServices {
               });
             }
           } catch (err) {
-            this.logger.warn({ plexItemId: item.plexItemId, thumb: item.thumb, err }, "Failed to cache poster image; skipping");
+            this.logger.warn("Failed to cache poster image; skipping", { plexItemId: item.plexItemId, thumb: item.thumb, err });
           }
         })
       ));

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -822,7 +822,7 @@ export class HubarrServices {
               });
             }
           } catch (err) {
-            logger.warn({ plexItemId: item.plexItemId, thumb: item.thumb, err }, "Failed to cache poster image; skipping");
+            this.logger.warn({ plexItemId: item.plexItemId, thumb: item.thumb, err }, "Failed to cache poster image; skipping");
           }
         })
       ));

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -321,7 +321,7 @@ export class HubarrServices {
         let onboardingCompleted = 0;
         const failures: string[] = [];
 
-        const onboardingLimit = pLimit(5);
+        const onboardingLimit = pLimit(3);
         await Promise.all(trackedUsers.map((user) =>
           onboardingLimit(async () => {
             const syncPromise = this.syncUser(user, runId);
@@ -1073,7 +1073,7 @@ export class HubarrServices {
       });
     }
 
-    const limit = pLimit(5);
+    const limit = pLimit(3);
     let completed = 0;
 
     await Promise.all(friends.map((friend) =>

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -806,19 +806,23 @@ export class HubarrServices {
       const imageLimit = pLimit(5);
       await Promise.all(mergedWithDates.map((item) =>
         imageLimit(async () => {
-          if (!item.thumb) return;
-          if (item.thumb.startsWith("/")) {
-            await this.imageCache.ensurePosterCached(item.plexItemId, {
-              type: "plex-path",
-              value: item.thumb,
-              serverUrl: plexSettings.serverUrl,
-              token: plexSettings.token
-            });
-          } else if (item.thumb.startsWith("https://")) {
-            await this.imageCache.ensurePosterCached(item.plexItemId, {
-              type: "public-url",
-              value: item.thumb
-            });
+          try {
+            if (!item.thumb) return;
+            if (item.thumb.startsWith("/")) {
+              await this.imageCache.ensurePosterCached(item.plexItemId, {
+                type: "plex-path",
+                value: item.thumb,
+                serverUrl: plexSettings.serverUrl,
+                token: plexSettings.token
+              });
+            } else if (item.thumb.startsWith("https://")) {
+              await this.imageCache.ensurePosterCached(item.plexItemId, {
+                type: "public-url",
+                value: item.thumb
+              });
+            }
+          } catch (err) {
+            logger.warn({ plexItemId: item.plexItemId, thumb: item.thumb, err }, "Failed to cache poster image; skipping");
           }
         })
       ));

--- a/tests/server/identifiers.test.ts
+++ b/tests/server/identifiers.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTestDatabase } from "./test-db.js";
+
+test("batchUpsertMediaItemIdentifiers seeds canonical, discover, and guid lookups for all items", () => {
+  const { db, cleanup } = createTestDatabase();
+
+  try {
+    db.upsertUsers([
+      { plexUserId: "plex-user-1", username: "alice", displayName: "Alice", avatarUrl: null }
+    ]);
+
+    const [alice] = db.listUsers();
+    db.upsertUserIdentifierAlias(alice.id, "plex-user-1");
+
+    db.batchUpsertMediaItemIdentifiers([
+      {
+        plexItemId: "movie-a",
+        type: "movie",
+        discoverKey: "/library/metadata/101",
+        guids: ["imdb://tt1234567", "tmdb://101"]
+      },
+      {
+        plexItemId: "show-a",
+        type: "show",
+        discoverKey: "/library/metadata/202",
+        guids: ["tvdb://202", "plex://show/202"]
+      }
+    ]);
+
+    db.upsertActivityCacheEntries([
+      {
+        plexItemId: "imdb://tt1234567",
+        plexUserId: "plex-user-1",
+        watchlistedAt: "2026-04-10T12:00:00.000Z"
+      },
+      {
+        plexItemId: "tvdb://202",
+        plexUserId: "plex-user-1",
+        watchlistedAt: "2026-04-11T12:00:00.000Z"
+      }
+    ]);
+
+    const dates = db.getActivityCacheDatesForUser(alice.id);
+
+    assert.equal(dates.get("movie-a"), "2026-04-10T12:00:00.000Z");
+    assert.equal(dates.get("/library/metadata/101"), "2026-04-10T12:00:00.000Z");
+    assert.equal(dates.get("imdb://tt1234567"), "2026-04-10T12:00:00.000Z");
+    assert.equal(dates.get("tmdb://101"), "2026-04-10T12:00:00.000Z");
+
+    assert.equal(dates.get("show-a"), "2026-04-11T12:00:00.000Z");
+    assert.equal(dates.get("/library/metadata/202"), "2026-04-11T12:00:00.000Z");
+    assert.equal(dates.get("tvdb://202"), "2026-04-11T12:00:00.000Z");
+    assert.equal(dates.get("plex://show/202"), "2026-04-11T12:00:00.000Z");
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/server/watchlist-grouping.test.ts
+++ b/tests/server/watchlist-grouping.test.ts
@@ -117,3 +117,139 @@ test("getWatchlistGrouped does not merge movie and show entries that share provi
     cleanup();
   }
 });
+
+test("getWatchlistGrouped counts merged duplicates once in user facets and totals", () => {
+  const { db, cleanup } = createTestDatabase();
+
+  try {
+    db.upsertUsers([
+      { plexUserId: "plex-user-1", username: "alice", displayName: "Alice", avatarUrl: null }
+    ]);
+
+    const [alice] = db.listUsers();
+    db.updateUser(alice.id, { enabled: true });
+
+    db.upsertWatchlistItem(alice.id, {
+      plexItemId: "movie-a",
+      title: "Duplicate Merge",
+      type: "movie",
+      year: 2024,
+      releaseDate: "2024-01-01",
+      thumb: null,
+      guids: ["imdb://tt2222222"],
+      discoverKey: "movie-a",
+      source: "graphql",
+      addedAt: "2026-04-12T10:00:00.000Z",
+      matchedRatingKey: null
+    });
+    db.upsertWatchlistItem(alice.id, {
+      plexItemId: "movie-b",
+      title: "Duplicate Merge",
+      type: "movie",
+      year: 2024,
+      releaseDate: "2024-01-01",
+      thumb: null,
+      guids: ["imdb://tt2222222"],
+      discoverKey: "movie-b",
+      source: "graphql",
+      addedAt: "2026-04-12T10:05:00.000Z",
+      matchedRatingKey: null
+    });
+
+    const watchlist = db.getWatchlistGrouped({ page: 1, pageSize: 20 });
+
+    assert.equal(watchlist.total, 1);
+    assert.equal(watchlist.facets.allUsersCount, 1);
+    assert.equal(watchlist.facets.users[0]?.count, 1);
+    assert.equal(watchlist.items[0]?.userCount, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("getWatchlistGrouped uses deterministic item and user ordering for pagination", () => {
+  const { db, cleanup } = createTestDatabase();
+
+  try {
+    db.upsertUsers([
+      { plexUserId: "plex-user-2", username: "bob", displayName: "Bob", avatarUrl: null },
+      { plexUserId: "plex-user-1", username: "alice", displayName: "Alice", avatarUrl: null }
+    ]);
+
+    const users = db.listUsers();
+    const alice = users.find((user) => user.username === "alice");
+    const bob = users.find((user) => user.username === "bob");
+    assert.ok(alice);
+    assert.ok(bob);
+
+    db.updateUser(alice.id, { enabled: true });
+    db.updateUser(bob.id, { enabled: true });
+
+    db.upsertWatchlistItem(bob.id, {
+      plexItemId: "z-item",
+      title: "Same Time",
+      type: "movie",
+      year: 2024,
+      releaseDate: "2024-01-01",
+      thumb: null,
+      guids: ["imdb://tt9000001"],
+      discoverKey: "z-item",
+      source: "graphql",
+      addedAt: "2026-04-12T10:00:00.000Z",
+      matchedRatingKey: null
+    });
+    db.upsertWatchlistItem(alice.id, {
+      plexItemId: "a-item",
+      title: "Same Time",
+      type: "movie",
+      year: 2024,
+      releaseDate: "2024-01-01",
+      thumb: null,
+      guids: ["imdb://tt9000002"],
+      discoverKey: "a-item",
+      source: "graphql",
+      addedAt: "2026-04-12T10:00:00.000Z",
+      matchedRatingKey: null
+    });
+
+    db.upsertWatchlistItem(bob.id, {
+      plexItemId: "merge-a",
+      title: "Merged Users",
+      type: "movie",
+      year: 2023,
+      releaseDate: "2023-01-01",
+      thumb: null,
+      guids: ["imdb://tt9000003"],
+      discoverKey: "merge-a",
+      source: "graphql",
+      addedAt: "2026-04-11T10:00:00.000Z",
+      matchedRatingKey: null
+    });
+    db.upsertWatchlistItem(alice.id, {
+      plexItemId: "merge-b",
+      title: "Merged Users",
+      type: "movie",
+      year: 2023,
+      releaseDate: "2023-01-01",
+      thumb: null,
+      guids: ["imdb://tt9000003"],
+      discoverKey: "merge-b",
+      source: "graphql",
+      addedAt: "2026-04-11T10:00:00.000Z",
+      matchedRatingKey: null
+    });
+
+    const watchlist = db.getWatchlistGrouped({ page: 1, pageSize: 20, sortBy: "added-desc" });
+
+    assert.deepEqual(
+      watchlist.items.map((item) => item.plexItemId),
+      ["a-item", "z-item", "merge-a"]
+    );
+    assert.deepEqual(
+      watchlist.items[2]?.users.map((user) => user.userId),
+      [Math.min(alice.id, bob.id), Math.max(alice.id, bob.id)]
+    );
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Addresses the bottlenecks identified in #92. A 40-user full sync was taking ~10 minutes due to sequential I/O throughout the pipeline. These changes parallelise the user loop, per-item enrichment, and image caching with `p-limit`; replace an N+1 activity cache query pattern with a single bulk lookup per user; and reduce unnecessary DB write and read overhead.

## Changes

**`src/server/services.ts`**
- Full sync user loop (`runFullSync`) now runs up to 5 users concurrently via `p-limit` instead of one at a time
- Publish pass (`runPublishPass`) parallelised the same way
- Onboarding preload watchlist loop also parallelised; per-user SSE progress messages replaced with a count-based message (`Syncing watchlists (N/total)...`) since multiple users run simultaneously
- `updateRunProgressSummary` signature changed to take `completed: number, total: number` instead of a `UserRecord` — summary now reads "syncing watchlists (N/total users)" rather than naming a single user
- `syncUser`: movies and shows now resolved with `Promise.all` instead of sequentially
- `syncUser`: activity cache lookup replaced — one bulk query per user via `getActivityCacheDatesForUser()` instead of one DB query per watchlist item (~3,000 queries → ~40 per 40-user sync)
- `syncUser`: identifier pre-registration wrapped in a single transaction via `batchUpsertMediaItemIdentifiers()` instead of per-item auto-commits
- `syncUser`: image cache loop parallelised with `p-limit(5)`
- `runPlexAvailabilityScan`: user map and per-user watchlist snapshots built once before the library loop, eliminating O(users × libraries) `find()` calls and DB queries

**`src/server/integrations/plex.ts`**
- `resolveWatchlistItems`: per-item enrichment (discover fetch + library search) parallelised with `p-limit(10)` — a 100-item watchlist now runs up to 10 items in flight instead of 200 sequential HTTP calls

**`src/server/db/identifiers.ts`**
- `getActivityCacheDatesForUser()`: new bulk query that fetches all activity cache dates for a user in one go, returning a `Map<string, string>` keyed by normalised identifier value
- `batchUpsertMediaItemIdentifiers()`: wraps the per-item upsert loop in a single transaction

**`src/server/db/index.ts`**
- Exposes `getActivityCacheDatesForUser()` and `batchUpsertMediaItemIdentifiers()`

**`src/server/db/watchlist.ts`**
- `replaceWatchlistItems`: removed redundant `upsertMediaItemIdentifiers` call — `syncUser` pre-registers all identifiers before calling this function, so the second write was always a no-op
- `getWatchlistGrouped`: `mediaType` filter pushed into the SQL `WHERE` clause (safe because the GUID merge is type-scoped); removed the `ORDER BY` that was being discarded by the TypeScript re-sort after the merge; simplified `allUsersCount` now that mediaType is pre-filtered

**`package.json` / `package-lock.json`**
- Added `p-limit` dependency

## Test plan

- [x] Trigger a full sync with multiple users and confirm it completes significantly faster than before — log output should show users starting concurrently rather than strictly sequentially
- [x] Confirm sync run history shows correct success/failure counts after a full sync
- [x] Confirm onboarding preload progress bar advances and completes correctly for a fresh setup
- [x] Open the watchlist page filtered by movie type and confirm only movies are shown
- [x] Open the watchlist page filtered by show type and confirm only shows are shown
- [x] Trigger a manual single-user sync and confirm it still completes and the history entry is correct
- [x] Confirm poster images load correctly after a sync (image cache parallelism)
- [x] Confirm `addedAt` dates are populated correctly for items that exist in the activity cache (bulk lookup parity with the old per-item query)

Closes #92

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a concurrency helper dependency and simplified progress reporting to aggregate completions.

* **Performance**
  * Adaptive bounded parallelism for user/item work, batched identifier writes, bulk activity-date queries, and concurrent poster caching for faster, more resilient runs.

* **Reliability**
  * Improved rate-limit/backoff handling for external calls and better error reporting when endpoints fail.

* **Bug Fixes**
  * Improved duplicate merging/counting, deterministic ordering, and more stable poster selection for grouped watchlist items.

* **Tests**
  * New tests for identifier batch upserts and deterministic watchlist grouping/merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->