### PR TITLE
fix: clear stale Plex matchedRatingKeys and harden collection publish

### DIFF
--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -217,6 +217,14 @@ export class HubarrDatabase {
     watchlistRepo.upsertWatchlistItem(this.db, userId, item);
   }
 
+  clearMatchedRatingKey(userId: number, plexItemId: string): void {
+    watchlistRepo.clearMatchedRatingKey(this.db, userId, plexItemId);
+  }
+
+  clearMatchedRatingKeyByValue(ratingKey: string): void {
+    watchlistRepo.clearMatchedRatingKeyByValue(this.db, ratingKey);
+  }
+
   upsertMediaItemIdentifiers(item: Pick<WatchlistItem, "plexItemId" | "type" | "guids" | "discoverKey">): void {
     identifiersRepo.upsertMediaItemIdentifiers(this.db, item);
   }

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -295,6 +295,22 @@ export function getWatchlistDiscoverKey(db: Database.Database, plexItemId: strin
   }
 }
 
+// Clears the matched_rating_key for a specific user's watchlist item.
+// Use this when a full scan confirms the item is no longer in the Plex library.
+export function clearMatchedRatingKey(db: Database.Database, userId: number, plexItemId: string): void {
+  db.prepare(
+    "UPDATE watchlist_cache SET matched_rating_key = NULL WHERE user_id = ? AND plex_item_id = ?"
+  ).run(userId, plexItemId);
+}
+
+// Clears matched_rating_key for every user whose item references the given ratingKey value.
+// Use this when collection publishing discovers a ratingKey is no longer valid in Plex.
+export function clearMatchedRatingKeyByValue(db: Database.Database, ratingKey: string): void {
+  db.prepare(
+    "UPDATE watchlist_cache SET matched_rating_key = NULL WHERE matched_rating_key = ?"
+  ).run(ratingKey);
+}
+
 export function upsertWatchlistItem(db: Database.Database, userId: number, item: WatchlistItem): void {
   const discoverKey = item.discoverKey ?? null;
   db.prepare(`

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -372,6 +372,14 @@ export class PlexIntegration {
     return JSON.parse(rawText) as T;
   }
 
+  // Returns true when a requestServer error indicates the specific item is
+  // missing or invalid in Plex (HTTP 400/404). Other status codes (401, 5xx,
+  // network failures) are transient and should not be treated as stale keys.
+  private isItemMissingError(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return /Plex server request failed: (400|404) /.test(msg);
+  }
+
   private async requestCommunity<T>(query: string, variables?: Record<string, unknown>) {
     const response = await fetch(COMMUNITY_API_URL, {
       method: "POST",
@@ -1168,6 +1176,7 @@ export class PlexIntegration {
               { method: "PUT" }
             );
           } catch (err) {
+            if (!this.isItemMissingError(err)) throw err;
             this.logger.warn("Skipping stale rating key during collection add", {
               collectionRatingKey,
               staleKey: key,
@@ -1303,6 +1312,7 @@ export class PlexIntegration {
         }
         lastPlacedKey = itemKey;
       } catch (err) {
+        if (!this.isItemMissingError(err)) throw err;
         this.logger.warn("Skipping stale rating key during collection reorder", {
           collectionRatingKey,
           staleKey: itemKey,

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1126,11 +1126,12 @@ export class PlexIntegration {
     return (response.MediaContainer?.Metadata || []).map((item) => item.ratingKey);
   }
 
-  async syncCollectionItems(collectionRatingKey: string, ratingKeys: string[]) {
+  async syncCollectionItems(collectionRatingKey: string, ratingKeys: string[]): Promise<{ staleKeys: Set<string> }> {
     const machineIdentifier = await this.getMachineIdentifier();
     const currentItems = await this.getCollectionItems(collectionRatingKey);
     const currentSet = new Set(currentItems);
     const desiredSet = new Set(ratingKeys);
+    const staleKeys = new Set<string>();
 
     const toAdd = ratingKeys.filter((key) => !currentSet.has(key));
     const toRemove = currentItems.filter((key) => !desiredSet.has(key));
@@ -1144,11 +1145,38 @@ export class PlexIntegration {
     });
 
     if (toAdd.length) {
-      const uri = `server://${machineIdentifier}/com.plexapp.plugins.library/library/metadata/${toAdd.join(",")}`;
-      await this.requestServer(
-        `/library/collections/${collectionRatingKey}/items?uri=${encodeURIComponent(uri)}`,
-        { method: "PUT" }
-      );
+      // Try adding all keys in one request. If Plex rejects the batch (e.g. a
+      // stale key causes a 400), fall back to per-key adds so we can isolate
+      // and skip whichever keys are no longer valid.
+      try {
+        const uri = `server://${machineIdentifier}/com.plexapp.plugins.library/library/metadata/${toAdd.join(",")}`;
+        await this.requestServer(
+          `/library/collections/${collectionRatingKey}/items?uri=${encodeURIComponent(uri)}`,
+          { method: "PUT" }
+        );
+      } catch (bulkErr) {
+        this.logger.warn("Bulk collection add failed, retrying per-key to isolate stale entries", {
+          collectionRatingKey,
+          toAdd: toAdd.length,
+          error: bulkErr instanceof Error ? bulkErr.message : String(bulkErr)
+        });
+        for (const key of toAdd) {
+          try {
+            const uri = `server://${machineIdentifier}/com.plexapp.plugins.library/library/metadata/${key}`;
+            await this.requestServer(
+              `/library/collections/${collectionRatingKey}/items?uri=${encodeURIComponent(uri)}`,
+              { method: "PUT" }
+            );
+          } catch (err) {
+            this.logger.warn("Skipping stale rating key during collection add", {
+              collectionRatingKey,
+              staleKey: key,
+              error: err instanceof Error ? err.message : String(err)
+            });
+            staleKeys.add(key);
+          }
+        }
+      }
     }
 
     for (const key of toRemove) {
@@ -1157,6 +1185,8 @@ export class PlexIntegration {
         { method: "DELETE" }
       );
     }
+
+    return { staleKeys };
   }
 
   async ensureCollection(title: string, mediaType: MediaType, libraryId: string) {
@@ -1240,8 +1270,10 @@ export class PlexIntegration {
    * Moves every item into position sequentially — simple and guaranteed correct.
    * Skips the whole operation if the collection is already in the desired order.
    */
-  async reorderCollectionItems(collectionRatingKey: string, orderedRatingKeys: string[]): Promise<void> {
-    if (orderedRatingKeys.length <= 1) return;
+  async reorderCollectionItems(collectionRatingKey: string, orderedRatingKeys: string[]): Promise<{ staleKeys: Set<string> }> {
+    const staleKeys = new Set<string>();
+
+    if (orderedRatingKeys.length <= 1) return { staleKeys };
 
     const currentOrder = await this.getCollectionItems(collectionRatingKey);
 
@@ -1249,24 +1281,38 @@ export class PlexIntegration {
       currentOrder.length === orderedRatingKeys.length &&
       currentOrder.every((key, i) => key === orderedRatingKeys[i])
     ) {
-      return; // already in correct order
+      return { staleKeys }; // already in correct order
     }
 
-    for (let i = 0; i < orderedRatingKeys.length; i++) {
-      const itemKey = orderedRatingKeys[i];
-      if (i === 0) {
-        await this.requestServer(
-          `/library/collections/${collectionRatingKey}/items/${itemKey}/move`,
-          { method: "PUT" }
-        );
-      } else {
-        const afterKey = orderedRatingKeys[i - 1];
-        await this.requestServer(
-          `/library/collections/${collectionRatingKey}/items/${itemKey}/move?after=${afterKey}`,
-          { method: "PUT" }
-        );
+    // Track the last successfully placed key so the anchor for subsequent moves
+    // stays valid even when stale keys are skipped mid-sequence.
+    let lastPlacedKey: string | null = null;
+
+    for (const itemKey of orderedRatingKeys) {
+      try {
+        if (lastPlacedKey === null) {
+          await this.requestServer(
+            `/library/collections/${collectionRatingKey}/items/${itemKey}/move`,
+            { method: "PUT" }
+          );
+        } else {
+          await this.requestServer(
+            `/library/collections/${collectionRatingKey}/items/${itemKey}/move?after=${lastPlacedKey}`,
+            { method: "PUT" }
+          );
+        }
+        lastPlacedKey = itemKey;
+      } catch (err) {
+        this.logger.warn("Skipping stale rating key during collection reorder", {
+          collectionRatingKey,
+          staleKey: itemKey,
+          error: err instanceof Error ? err.message : String(err)
+        });
+        staleKeys.add(itemKey);
       }
     }
+
+    return { staleKeys };
   }
 
   /**

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1136,11 +1136,17 @@ export class HubarrServices {
       const reorderKeys = syncStaleKeys.size > 0
         ? matchedRatingKeys.filter((k) => !syncStaleKeys.has(k))
         : matchedRatingKeys;
-      // Push explicit item positions for all custom-ordered modes. For title
-      // sort, Plex manages ordering so the moves are no-ops from the user's
-      // perspective, but the call still detects keys that are no longer valid
-      // in Plex via move failures (404).
-      const { staleKeys: reorderStaleKeys } = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys);
+      // For title sort (collectionSort=1) Plex ignores move calls, so skip the
+      // reorder and detect stale keys via a read-only collection fetch instead.
+      // For custom-order modes (date/watchlist-date, collectionSort=2) push
+      // explicit item positions which also catches stale keys via 404 failures.
+      let reorderStaleKeys: Set<string>;
+      if (effectiveSortOrder === "title") {
+        const liveKeys = new Set(await plex.getCollectionItems(collectionRatingKey));
+        reorderStaleKeys = new Set(reorderKeys.filter((k) => !liveKeys.has(k)));
+      } else {
+        ({ staleKeys: reorderStaleKeys } = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys));
+      }
       if (reorderStaleKeys.size > 0) {
         this.logger.warn("Clearing stale matched rating keys found during collection reorder", {
           userId: friend.id,

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -659,6 +659,9 @@ export class HubarrServices {
           : await plex.getAllLibraryItems(library.libraryId, library.mediaType);
 
       const guidToRatingKey = this.buildGuidToRatingKeyMap(libraryItems);
+      // Pre-build a set of all ratingKey values so items that lack GUIDs can
+      // still have their stored matchedRatingKey validated against the library.
+      const libraryRatingKeys = new Set(guidToRatingKey.values());
 
       // If Plex returned items but none had GUIDs, skip this library entirely.
       // GUIDs are the only reliable cross-reference between Plex library items
@@ -667,6 +670,12 @@ export class HubarrServices {
       // risk false positives. Skipping preserves all existing keys unchanged
       // until GUIDs become available on a future scan.
       if (libraryItems.length > 0 && guidToRatingKey.size === 0) {
+        this.logger.warn("Skipping library scan for missing GUIDs", {
+          libraryId: library.libraryId,
+          mediaType: library.mediaType,
+          mode: options.mode,
+          libraryItemCount: libraryItems.length
+        });
         continue;
       }
 
@@ -711,7 +720,26 @@ export class HubarrServices {
         let friendChanged = false;
 
         for (const item of watchlistItems) {
-          if (item.type !== library.mediaType || !item.guids?.length) {
+          if (item.type !== library.mediaType) {
+            continue;
+          }
+
+          if (!item.guids?.length) {
+            // No GUIDs — GUID-based matching and re-match detection are not
+            // possible, but we can still validate a stored matchedRatingKey by
+            // checking whether it appears anywhere in the current library.
+            if (item.matchedRatingKey && !libraryRatingKeys.has(item.matchedRatingKey) && options.mode === "full") {
+              this.db.clearMatchedRatingKey(friendId, item.plexItemId);
+              clearedCount++;
+              friendChanged = true;
+              this.logger.info("Clearing stale Plex match for item without GUIDs during full library scan", {
+                friendId,
+                displayName: friend.displayName,
+                title: item.title,
+                type: item.type,
+                staleRatingKey: item.matchedRatingKey
+              });
+            }
             continue;
           }
 
@@ -1103,22 +1131,19 @@ export class HubarrServices {
       const reorderKeys = syncStaleKeys.size > 0
         ? matchedRatingKeys.filter((k) => !syncStaleKeys.has(k))
         : matchedRatingKeys;
-      // Explicitly push item positions into Plex for all custom-ordered modes.
-      // Title sort uses Plex's native alphabetical sort (collectionSort=1) and
-      // doesn't need explicit reordering; all other modes use collectionSort=2.
-      let reorderStaleKeys = new Set<string>();
-      if (effectiveSortOrder !== "title") {
-        const reorderResult = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys);
-        reorderStaleKeys = reorderResult.staleKeys;
-        if (reorderStaleKeys.size > 0) {
-          this.logger.warn("Clearing stale matched rating keys found during collection reorder", {
-            userId: friend.id,
-            mediaType,
-            staleKeys: [...reorderStaleKeys]
-          });
-          for (const key of reorderStaleKeys) {
-            this.db.clearMatchedRatingKeyByValue(key);
-          }
+      // Push explicit item positions for all custom-ordered modes. For title
+      // sort, Plex manages ordering so the moves are no-ops from the user's
+      // perspective, but the call still detects keys that are no longer valid
+      // in Plex via move failures (404).
+      const { staleKeys: reorderStaleKeys } = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys);
+      if (reorderStaleKeys.size > 0) {
+        this.logger.warn("Clearing stale matched rating keys found during collection reorder", {
+          userId: friend.id,
+          mediaType,
+          staleKeys: [...reorderStaleKeys]
+        });
+        for (const key of reorderStaleKeys) {
+          this.db.clearMatchedRatingKeyByValue(key);
         }
       }
       // Build the cleaned key list that was actually published — excludes any

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -660,8 +660,12 @@ export class HubarrServices {
 
       const guidToRatingKey = this.buildGuidToRatingKeyMap(libraryItems);
 
-      // If Plex returned items but none had GUIDs, we can't do useful matching
-      // or stale-key detection — skip this library entirely.
+      // If Plex returned items but none had GUIDs, skip this library entirely.
+      // GUIDs are the only reliable cross-reference between Plex library items
+      // and stored watchlist rating keys. Without them, neither matching nor
+      // stale-key detection is safe — any attempt to clear or update keys would
+      // risk false positives. Skipping preserves all existing keys unchanged
+      // until GUIDs become available on a future scan.
       if (libraryItems.length > 0 && guidToRatingKey.size === 0) {
         continue;
       }

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -665,17 +665,14 @@ export class HubarrServices {
       // from the map values would produce false-positive stale clears.
       const libraryRatingKeys = new Set(libraryItems.map((item) => item.ratingKey));
 
-      // If Plex returned items but none had GUIDs, skip this library entirely.
-      // GUIDs are the only reliable cross-reference between Plex library items
-      // and stored watchlist rating keys. Without them, neither matching nor
-      // stale-key detection is safe — any attempt to clear or update keys would
-      // risk false positives. Skipping preserves all existing keys unchanged
-      // until GUIDs become available on a future scan.
+      // If Plex returned items but none had GUIDs, GUID-based matching and
+      // re-match detection are skipped (no cross-reference is possible).
+      // The library is still processed: libraryRatingKeys is populated from
+      // ratingKey values, so stored matchedRatingKey entries can still be
+      // validated against the library. Stale-key clearing only happens in
+      // 'full' mode; in 'recent' mode those branches are not reached.
       if (libraryItems.length > 0 && guidToRatingKey.size === 0) {
-        // No GUIDs on any library item — GUID-based matching is impossible, but
-        // libraryRatingKeys is still populated so stale-key validation below can
-        // run. Log the situation for operator visibility and fall through.
-        this.logger.warn("Library returned no GUIDs — skipping GUID-based matching, stale-key check will still run", {
+        this.logger.warn("Library returned no GUIDs — GUID-based matching skipped; stale-key validation runs for full scans only", {
           libraryId: library.libraryId,
           mediaType: library.mediaType,
           mode: options.mode,

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -659,7 +659,35 @@ export class HubarrServices {
           : await plex.getAllLibraryItems(library.libraryId, library.mediaType);
 
       const guidToRatingKey = this.buildGuidToRatingKeyMap(libraryItems);
-      if (guidToRatingKey.size === 0) {
+
+      // If Plex returned items but none had GUIDs, we can't do useful matching
+      // or stale-key detection — skip this library entirely.
+      if (libraryItems.length > 0 && guidToRatingKey.size === 0) {
+        continue;
+      }
+
+      // If a full scan returned zero library items, the library appears empty.
+      // Clear all stored matches for users in this library so they don't keep
+      // pointing at keys that no longer exist. Recent scans are skipped here —
+      // an empty "recently added" result just means nothing was added lately.
+      if (libraryItems.length === 0) {
+        if (options.mode === "full") {
+          for (const friendId of library.userIds) {
+            const watchlistItems = watchlistByUser.get(friendId) ?? [];
+            for (const item of watchlistItems) {
+              if (item.type !== library.mediaType || !item.matchedRatingKey) continue;
+              this.db.clearMatchedRatingKey(friendId, item.plexItemId);
+              clearedCount++;
+              this.logger.info("Clearing stale Plex match — library returned empty during full scan", {
+                friendId,
+                title: item.title,
+                type: item.type,
+                staleRatingKey: item.matchedRatingKey,
+                libraryId: library.libraryId
+              });
+            }
+          }
+        }
         continue;
       }
 

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -678,10 +678,12 @@ export class HubarrServices {
         if (options.mode === "full") {
           for (const friendId of library.userIds) {
             const watchlistItems = watchlistByUser.get(friendId) ?? [];
+            let friendChanged = false;
             for (const item of watchlistItems) {
               if (item.type !== library.mediaType || !item.matchedRatingKey) continue;
               this.db.clearMatchedRatingKey(friendId, item.plexItemId);
               clearedCount++;
+              friendChanged = true;
               this.logger.info("Clearing stale Plex match — library returned empty during full scan", {
                 friendId,
                 title: item.title,
@@ -689,6 +691,10 @@ export class HubarrServices {
                 staleRatingKey: item.matchedRatingKey,
                 libraryId: library.libraryId
               });
+            }
+            if (friendChanged) {
+              affectedUsers++;
+              this.db.markUserSyncResult(friendId, null);
             }
           }
         }
@@ -1100,8 +1106,10 @@ export class HubarrServices {
       // Explicitly push item positions into Plex for all custom-ordered modes.
       // Title sort uses Plex's native alphabetical sort (collectionSort=1) and
       // doesn't need explicit reordering; all other modes use collectionSort=2.
+      let reorderStaleKeys = new Set<string>();
       if (effectiveSortOrder !== "title") {
-        const { staleKeys: reorderStaleKeys } = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys);
+        const reorderResult = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys);
+        reorderStaleKeys = reorderResult.staleKeys;
         if (reorderStaleKeys.size > 0) {
           this.logger.warn("Clearing stale matched rating keys found during collection reorder", {
             userId: friend.id,
@@ -1113,11 +1121,16 @@ export class HubarrServices {
           }
         }
       }
+      // Build the cleaned key list that was actually published — excludes any
+      // stale keys discovered during sync or reorder.
+      const cleanedKeys = (syncStaleKeys.size > 0 || reorderStaleKeys.size > 0)
+        ? matchedRatingKeys.filter((k) => !syncStaleKeys.has(k) && !reorderStaleKeys.has(k))
+        : matchedRatingKeys;
       this.logger.info("Collection items synced", {
         userId: friend.id,
         mediaType,
         collectionRatingKey,
-        matchedItems: matchedRatingKeys.length
+        matchedItems: cleanedKeys.length
       });
 
       const labelName = plex.createCollectionLabel(friend.displayName);
@@ -1141,7 +1154,7 @@ export class HubarrServices {
         collectionRatingKey,
         hubIdentifier
       });
-      const hash = plex.hashRatingKeys(matchedRatingKeys);
+      const hash = plex.hashRatingKeys(cleanedKeys);
       this.db.upsertCollectionRecord(friend.id, mediaType, {
         collectionRatingKey,
         visibleName: collectionName,
@@ -1162,7 +1175,7 @@ export class HubarrServices {
             mediaType,
             collectionName,
             collectionRatingKey,
-            matchedItems: matchedRatingKeys.length
+            matchedItems: cleanedKeys.length
           },
           friend.id
         );

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -659,9 +659,11 @@ export class HubarrServices {
           : await plex.getAllLibraryItems(library.libraryId, library.mediaType);
 
       const guidToRatingKey = this.buildGuidToRatingKeyMap(libraryItems);
-      // Pre-build a set of all ratingKey values so items that lack GUIDs can
-      // still have their stored matchedRatingKey validated against the library.
-      const libraryRatingKeys = new Set(guidToRatingKey.values());
+      // Build from libraryItems directly (not guidToRatingKey.values()) so that
+      // library items without GUIDs still contribute their ratingKey. Items with
+      // empty guids won't appear in guidToRatingKey at all, so deriving the set
+      // from the map values would produce false-positive stale clears.
+      const libraryRatingKeys = new Set(libraryItems.map((item) => item.ratingKey));
 
       // If Plex returned items but none had GUIDs, skip this library entirely.
       // GUIDs are the only reliable cross-reference between Plex library items
@@ -670,13 +672,15 @@ export class HubarrServices {
       // risk false positives. Skipping preserves all existing keys unchanged
       // until GUIDs become available on a future scan.
       if (libraryItems.length > 0 && guidToRatingKey.size === 0) {
-        this.logger.warn("Skipping library scan for missing GUIDs", {
+        // No GUIDs on any library item — GUID-based matching is impossible, but
+        // libraryRatingKeys is still populated so stale-key validation below can
+        // run. Log the situation for operator visibility and fall through.
+        this.logger.warn("Library returned no GUIDs — skipping GUID-based matching, stale-key check will still run", {
           libraryId: library.libraryId,
           mediaType: library.mediaType,
           mode: options.mode,
           libraryItemCount: libraryItems.length
         });
-        continue;
       }
 
       // If a full scan returned zero library items, the library appears empty.
@@ -766,11 +770,15 @@ export class HubarrServices {
                 oldRatingKey: item.matchedRatingKey,
                 newRatingKey: match
               });
-            } else if (options.mode === "full") {
-              // Full scan covers the entire library; absence of the GUID means
+            } else if (options.mode === "full" && !libraryRatingKeys.has(item.matchedRatingKey)) {
+              // Full scan covers the entire library; the GUID is gone AND the
+              // stored ratingKey is no longer present in the library, confirming
               // the item was deleted. Clear the stale match so the watchlist row
-              // stays but the library link is severed. Recent scans are skipped
-              // here — the item may exist but simply wasn't recently added.
+              // stays but the library link is severed. The ratingKey guard
+              // prevents false-positive clears when GUIDs are temporarily
+              // missing but the item itself still exists. Recent scans are
+              // skipped here — the item may exist but simply wasn't recently
+              // added.
               this.db.clearMatchedRatingKey(friendId, item.plexItemId);
               clearedCount++;
               friendChanged = true;

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1148,9 +1148,11 @@ export class HubarrServices {
         ({ staleKeys: reorderStaleKeys } = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys));
       }
       if (reorderStaleKeys.size > 0) {
-        this.logger.warn("Clearing stale matched rating keys found during collection reorder", {
+        this.logger.warn("Clearing stale matched rating keys found during post-sync validation", {
           userId: friend.id,
           mediaType,
+          effectiveSortOrder,
+          reordered: effectiveSortOrder !== "title",
           staleKeys: [...reorderStaleKeys]
         });
         for (const key of reorderStaleKeys) {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -555,7 +555,23 @@ export class HubarrServices {
           if (incomingDate && incomingDate !== WATCHLIST_DATE_UNKNOWN_SENTINEL) return incomingDate;
           return WATCHLIST_DATE_UNKNOWN_SENTINEL;
         })(),
-        matchedRatingKey: item.matchedRatingKey ?? existing?.matchedRatingKey ?? null
+        // item.matchedRatingKey comes from resolveWatchlistItems which always
+        // sets it explicitly (string or null). Using !== undefined lets a null
+        // (meaning "not in library right now") clear a stale stored key, while
+        // undefined (not yet resolved) falls back to whatever is stored.
+        matchedRatingKey: (() => {
+          if (item.matchedRatingKey !== undefined) {
+            if (item.matchedRatingKey === null && existing?.matchedRatingKey) {
+              this.logger.info("Clearing stale Plex match for watchlist item", {
+                title: item.title,
+                type: item.type,
+                staleRatingKey: existing.matchedRatingKey
+              });
+            }
+            return item.matchedRatingKey;
+          }
+          return existing?.matchedRatingKey ?? null;
+        })()
       };
     });
   }
@@ -629,6 +645,7 @@ export class HubarrServices {
     const watchlistByUser = new Map(trackedUsers.map((u) => [u.id, this.db.getWatchlistItems(u.id)]));
 
     let matchedCount = 0;
+    let clearedCount = 0;
     let affectedUsers = 0;
 
     for (const library of libraries.values()) {
@@ -656,7 +673,7 @@ export class HubarrServices {
         let friendChanged = false;
 
         for (const item of watchlistItems) {
-          if (item.type !== library.mediaType || item.matchedRatingKey || !item.guids?.length) {
+          if (item.type !== library.mediaType || !item.guids?.length) {
             continue;
           }
 
@@ -664,6 +681,45 @@ export class HubarrServices {
             .map((guid) => guidToRatingKey.get(guid.toLowerCase()))
             .find((ratingKey): ratingKey is string => Boolean(ratingKey));
 
+          if (item.matchedRatingKey) {
+            // Item already has a stored match — verify it against the current library.
+            if (match === item.matchedRatingKey) {
+              continue; // Still valid, nothing to do
+            }
+            if (match) {
+              // Item was re-imported under a new ratingKey — update to the new one
+              this.db.upsertWatchlistItem(friendId, { ...item, matchedRatingKey: match });
+              matchedCount++;
+              friendChanged = true;
+              this.logger.info("Updated stale Plex match to new rating key during library scan", {
+                label: options.mode === "recent" ? "Plex Recently Added Scan" : "Plex Full Library Scan",
+                friendId,
+                displayName: friend.displayName,
+                title: item.title,
+                type: item.type,
+                oldRatingKey: item.matchedRatingKey,
+                newRatingKey: match
+              });
+            } else if (options.mode === "full") {
+              // Full scan covers the entire library; absence of the GUID means
+              // the item was deleted. Clear the stale match so the watchlist row
+              // stays but the library link is severed. Recent scans are skipped
+              // here — the item may exist but simply wasn't recently added.
+              this.db.clearMatchedRatingKey(friendId, item.plexItemId);
+              clearedCount++;
+              friendChanged = true;
+              this.logger.info("Clearing stale Plex match during full library scan", {
+                friendId,
+                displayName: friend.displayName,
+                title: item.title,
+                type: item.type,
+                staleRatingKey: item.matchedRatingKey
+              });
+            }
+            continue;
+          }
+
+          // No existing match — try to match against the current library
           if (!match) {
             continue;
           }
@@ -697,6 +753,7 @@ export class HubarrServices {
       mode: options.mode,
       since: options.since?.toISOString() ?? null,
       matchedCount,
+      clearedCount,
       affectedUsers
     });
 
@@ -992,12 +1049,37 @@ export class HubarrServices {
       });
       await plex.updateCollectionSortTitle(collectionRatingKey, `!10_${collectionName}`);
       await plex.updateCollectionContentSort(collectionRatingKey, effectiveSortOrder);
-      await plex.syncCollectionItems(collectionRatingKey, matchedRatingKeys);
+      const { staleKeys: syncStaleKeys } = await plex.syncCollectionItems(collectionRatingKey, matchedRatingKeys);
+      if (syncStaleKeys.size > 0) {
+        this.logger.warn("Clearing stale matched rating keys found during collection sync", {
+          userId: friend.id,
+          mediaType,
+          staleKeys: [...syncStaleKeys]
+        });
+        for (const key of syncStaleKeys) {
+          this.db.clearMatchedRatingKeyByValue(key);
+        }
+      }
+      // Exclude stale keys from reorder so move operations don't fail on items
+      // that were never successfully added to the collection.
+      const reorderKeys = syncStaleKeys.size > 0
+        ? matchedRatingKeys.filter((k) => !syncStaleKeys.has(k))
+        : matchedRatingKeys;
       // Explicitly push item positions into Plex for all custom-ordered modes.
       // Title sort uses Plex's native alphabetical sort (collectionSort=1) and
       // doesn't need explicit reordering; all other modes use collectionSort=2.
       if (effectiveSortOrder !== "title") {
-        await plex.reorderCollectionItems(collectionRatingKey, matchedRatingKeys);
+        const { staleKeys: reorderStaleKeys } = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys);
+        if (reorderStaleKeys.size > 0) {
+          this.logger.warn("Clearing stale matched rating keys found during collection reorder", {
+            userId: friend.id,
+            mediaType,
+            staleKeys: [...reorderStaleKeys]
+          });
+          for (const key of reorderStaleKeys) {
+            this.db.clearMatchedRatingKeyByValue(key);
+          }
+        }
       }
       this.logger.info("Collection items synced", {
         userId: friend.id,


### PR DESCRIPTION
## Summary

Fixes the stale `matchedRatingKey` bug described in #99. When a Plex library item is deleted or re-imported under a new ID, Hubarr was carrying forward the old key, causing collection publish to fail with a 400 from Plex when it tried to add items that no longer existed.

The fix tackles this at three levels: preventing stale keys from accumulating in the first place, making collection publish survive stale keys it encounters at runtime, and letting the full library scan actively repair stale state.

## Changes

**`src/server/db/watchlist.ts`**
- Added `clearMatchedRatingKey(db, userId, plexItemId)` — clears the match for a specific user's watchlist item (used by the scan when it confirms an item is gone)
- Added `clearMatchedRatingKeyByValue(db, ratingKey)` — clears across all users for a given ratingKey value (used by collection publish when it discovers a key is stale at runtime)
- Left `COALESCE` intact in `upsertWatchlistItem` — this protects against RSS upserts spuriously clearing a valid match if `searchLibraryItem` returns null (e.g. title mismatch or transient API error). Stale matches from RSS are cleaned up by the next full watchlist sync.

**`src/server/db/index.ts`**
- Exposed both new DB functions as `db.clearMatchedRatingKey()` and `db.clearMatchedRatingKeyByValue()`

**`src/server/services.ts` — `mergeFetchedWatchlistItems`**
- Changed `item.matchedRatingKey ?? existing?.matchedRatingKey ?? null` to a `!== undefined` check. `resolveWatchlistItems` always sets `matchedRatingKey` explicitly (string or `null`), so a `null` now correctly clears a stale stored key instead of falling back to it. If `item.matchedRatingKey` were `undefined` (not yet resolved), the existing stored value is preserved.
- Added a log line when a previously matched item transitions back to null.

**`src/server/services.ts` — `runPlexAvailabilityScan`**
- Scan now evaluates watchlist items that already have a `matchedRatingKey`, not just unmatched ones.
- During a **full** scan: if a stored key's GUIDs no longer appear in the library, the match is cleared via `clearMatchedRatingKey`. If the GUIDs resolve to a different key (re-import), the match is updated. Both cases log the change.
- During a **recent** scan: existing matched items are left alone — absence from "recently added" doesn't mean the item was deleted.
- Added `clearedCount` to the scan completion log.

**`src/server/integrations/plex.ts` — `syncCollectionItems`**
- Returns `{ staleKeys: Set<string> }` instead of `void`.
- Tries a bulk PUT first (fast path). If Plex rejects it, falls back to per-key adds, catching individual failures. Each failed key is added to the stale set and a warning is logged.

**`src/server/integrations/plex.ts` — `reorderCollectionItems`**
- Returns `{ staleKeys: Set<string> }` instead of `void`.
- Each move is now wrapped in try/catch. Failed moves are logged and the key is added to the stale set.
- Uses `lastPlacedKey` as the anchor for subsequent moves, so skipped stale keys don't break the ordering of the remaining valid items.

**`src/server/services.ts` — `publishCollectionForUser`**
- Consumes `staleKeys` from both `syncCollectionItems` and `reorderCollectionItems`.
- After sync: clears stale keys via `clearMatchedRatingKeyByValue` and filters them out of the list before passing it to reorder.
- After reorder: clears any additional stale keys found during move operations.

## Test plan

- [ ] Trigger a full sync with a user whose watchlist contains an item that has been deleted from Plex — confirm the log shows "Clearing stale Plex match" and that `matchedRatingKey` is null in the DB afterward
- [ ] Re-import the same title under a new Plex ID — confirm the next full sync or watchlist sync picks up the new key
- [ ] Simulate a stale key reaching collection publish (e.g. item deleted between sync and publish) — confirm the publish completes for all other items and logs a warning about the stale key rather than throwing
- [ ] Confirm RSS-sourced items do not have their valid `matchedRatingKey` cleared when a subsequent RSS pass fails to match them in the library

Closes #99

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit operations to clear watchlist matches by user/item or by rating-key value.
  * Collection syncs and reorders now report stale item keys.

* **Bug Fixes**
  * Skip missing/invalid items during collection syncs/reorders without failing the whole operation.
  * Full-mode scans clear stored matches for empty libraries.

* **Improvements**
  * Collections exclude and remove stale keys from publishes and reorders.
  * Merge and availability scans better handle items without external IDs and report cleared counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->