### PR TITLE
refactor: rename setupComplete to configurationValid

### DIFF
--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -113,7 +113,7 @@ export function resolveSessionSecret(db: Database.Database, dataDir: string): st
 export function getBootstrapStatus(db: Database.Database, hasActiveSession: boolean): BootstrapStatus {
   const plexSettings = getSetting<PlexSettingsInput>(db, "plex");
   const appSettings = getAppSettings(db);
-  const setupComplete = Boolean(
+  const configurationValid = Boolean(
     plexSettings?.serverUrl &&
       appSettings.defaultMovieLibraryId &&
       appSettings.defaultShowLibraryId
@@ -121,15 +121,15 @@ export function getBootstrapStatus(db: Database.Database, hasActiveSession: bool
 
   // Backwards-compat: existing installs that were fully configured before the
   // onboardingComplete flag was introduced won't have the field in stored
-  // settings. For these we derive onboardingComplete from setupComplete so
+  // settings. For these we derive onboardingComplete from configurationValid so
   // they aren't forced through the wizard again.
   const stored = getSetting<AppSettings>(db, "app");
   const hasFlag = stored !== null && "onboardingComplete" in stored;
-  const onboardingComplete = hasFlag ? appSettings.onboardingComplete : setupComplete;
+  const onboardingComplete = hasFlag ? appSettings.onboardingComplete : configurationValid;
 
   return {
     hasOwner: Boolean(getSetting<PlexOwnerRecord>(db, "admin")),
-    setupComplete,
+    configurationValid,
     onboardingComplete,
     hasActiveSession
   };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,7 +23,7 @@ const appSettings = db.getAppSettings();
  */
 function isSetupReady(): boolean {
   const bootstrap = db.getBootstrapStatus(false);
-  return bootstrap.onboardingComplete && bootstrap.setupComplete;
+  return bootstrap.onboardingComplete && bootstrap.configurationValid;
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,7 +3,7 @@ export type MediaType = "movie" | "show";
 
 export interface BootstrapStatus {
   hasOwner: boolean;
-  setupComplete: boolean;
+  configurationValid: boolean;
   onboardingComplete: boolean;
   hasActiveSession: boolean;
 }


### PR DESCRIPTION
## Summary

Addresses the naming ambiguity raised in issue #95. The two bootstrap flags now have clearly distinct names:

- `onboardingComplete` — persisted in the database; set once the onboarding wizard is formally finished by the user.
- `configurationValid` — computed dynamically on every bootstrap call; true when Plex URL, default movie library ID, and default show library ID are all present in the stored config. Can become false if the live config drifts (e.g. settings are cleared), independent of whether the wizard was completed.

The old name `setupComplete` read as "setup is done," which overlapped with `onboardingComplete` in a reviewer's mental model. The new name makes it immediately clear this is a live validity check on the configuration, not a wizard-completion marker.

## Changes

- **`src/shared/types.ts`** — renamed `setupComplete` field to `configurationValid` in the `BootstrapStatus` interface.
- **`src/server/db/settings.ts`** — renamed the local variable, updated the backward-compat comment, and updated the return object key in `getBootstrapStatus()`.
- **`src/server/index.ts`** — updated `isSetupReady()` to read `bootstrap.configurationValid`.

No client code and no tests referenced `setupComplete`, so the blast radius is limited to these three files.

## Test plan

- [x] `npm run build` completes without type errors.
- [x] `GET /api/bootstrap` response body contains `configurationValid` (not `setupComplete`).
- [x] On a fully configured instance, the dashboard loads and background jobs continue to run normally.
- [x] On a fresh install, the app routes to `/onboarding` as expected.

Closes #95

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration status field naming across the application for improved consistency. The bootstrap status indicator has been renamed to better reflect its purpose in tracking system readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->