### PR TITLE
feat: add Test Connection button for Plex in settings and onboarding

### DIFF
--- a/src/client/components/FormControls.tsx
+++ b/src/client/components/FormControls.tsx
@@ -183,10 +183,12 @@ export function SaveBar({
   }
 
   return (
-    <div className="flex items-center gap-3 pt-2">
+    <div className="flex items-center justify-between gap-3 pt-2 border-t border-outline-variant/15">
+      <div className="flex items-center gap-3">
+        {success && <span className="text-success text-sm">Saved</span>}
+        {error && <span className="text-error text-sm">{error}</span>}
+      </div>
       {saveButton}
-      {success && <span className="text-success text-sm">Saved</span>}
-      {error && <span className="text-error text-sm">{error}</span>}
     </div>
   );
 }

--- a/src/client/components/PlexConfigForm.tsx
+++ b/src/client/components/PlexConfigForm.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from "react";
-import { ChevronRight, RefreshCw } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 import { apiGet, apiPost } from "../lib/api";
 import type { PlexConfigPayload, PlexConnectionOption, PlexLibrary, PlexSettingsView } from "../../shared/types";
-import { Field, SaveBar, SectionCard, SelectInput, TextInput, ToggleField } from "./FormControls";
+import { Field, SectionCard, SelectInput, TextInput, ToggleField } from "./FormControls";
 
 interface PlexConfigResponse {
   plex: PlexSettingsView | null;
@@ -12,12 +12,14 @@ interface PlexConfigResponse {
 export default function PlexConfigForm({
   initialConfig,
   saveUrl,
+  testUrl,
   onSaved,
   onBack,
   saveLabel = "Save Plex"
 }: {
   initialConfig: PlexSettingsView | null;
   saveUrl: string;
+  testUrl: string;
   onSaved?: (result: PlexConfigResponse) => void | Promise<void>;
   onBack?: () => void;
   saveLabel?: string;
@@ -34,6 +36,8 @@ export default function PlexConfigForm({
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
 
   const groupedServers = useMemo(() => {
     return availableServers.map((option) => ({
@@ -42,6 +46,12 @@ export default function PlexConfigForm({
       option
     }));
   }, [availableServers]);
+
+  function buildPayload(): PlexConfigPayload {
+    return selectedServerUri && selectedMachineIdentifier
+      ? { mode: "preset", serverUrl: selectedServerUri, machineIdentifier: selectedMachineIdentifier }
+      : { mode: "manual", hostname, port: Number(port), useSsl };
+  }
 
   function switchToManual() {
     setSelectedServerUri("");
@@ -61,26 +71,33 @@ export default function PlexConfigForm({
     }
   }
 
+  async function testConnection() {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await apiPost<{ ok: boolean; serverUrl?: string; libraryCount?: number; error?: string }>(
+        testUrl,
+        buildPayload()
+      );
+      if (result.ok) {
+        const count = result.libraryCount ?? 0;
+        setTestResult({ ok: true, message: `Test Succeeded — ${count} ${count === 1 ? "library" : "libraries"} found` });
+      } else {
+        setTestResult({ ok: false, message: result.error ?? "Connection failed" });
+      }
+    } catch (caught) {
+      setTestResult({ ok: false, message: caught instanceof Error ? caught.message : String(caught) });
+    } finally {
+      setTesting(false);
+    }
+  }
+
   async function save() {
     setSaving(true);
     setSuccess(false);
     setError(null);
     try {
-      const payload: PlexConfigPayload =
-        selectedServerUri && selectedMachineIdentifier
-          ? {
-              mode: "preset",
-              serverUrl: selectedServerUri,
-              machineIdentifier: selectedMachineIdentifier
-            }
-          : {
-              mode: "manual",
-              hostname,
-              port: Number(port),
-              useSsl
-            };
-
-      const result = await apiPost<PlexConfigResponse>(saveUrl, payload);
+      const result = await apiPost<PlexConfigResponse>(saveUrl, buildPayload());
       setSuccess(true);
       await onSaved?.(result);
     } catch (caught) {
@@ -89,6 +106,8 @@ export default function PlexConfigForm({
       setSaving(false);
     }
   }
+
+  const hasHostname = Boolean(hostname);
 
   return (
     <SectionCard
@@ -167,21 +186,46 @@ export default function PlexConfigForm({
         setUseSsl(value);
       }} />
 
-      <SaveBar
-        saving={saving}
-        success={success}
-        error={error}
-        onSave={() => void save()}
-        onBack={onBack}
-        label={saveLabel}
-      />
-
-      {success && onSaved && (
-        <div className="text-xs text-on-surface-variant flex items-center gap-1">
-          <ChevronRight size={12} />
-          Plex configuration saved successfully.
+      <div className="flex items-center justify-between gap-3 pt-2 border-t border-outline-variant/15">
+        <div className="flex items-center gap-3 flex-wrap">
+          {onBack && (
+            <button
+              type="button"
+              onClick={onBack}
+              className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+            >
+              <ChevronLeft size={15} />
+              Back
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => void testConnection()}
+            disabled={testing || (!selectedServerUri && !hasHostname)}
+            className="bg-surface-container-high hover:bg-surface-bright disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+          >
+            {testing ? "Testing..." : "Test Connection"}
+          </button>
+          {testResult && (
+            <span className={`text-xs font-medium ${testResult.ok ? "text-success" : "text-error"}`}>
+              {testResult.message}
+            </span>
+          )}
         </div>
-      )}
+        <div className="flex items-center gap-3">
+          {success && <span className="text-success text-sm">Saved</span>}
+          {error && <span className="text-error text-sm">{error}</span>}
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => void save()}
+            className="flex items-center gap-2 bg-primary hover:bg-primary-dim disabled:opacity-50 text-on-primary text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
+          >
+            {saving ? "Saving..." : saveLabel}
+            {!saving && <ChevronRight size={15} />}
+          </button>
+        </div>
+      </div>
     </SectionCard>
   );
 }

--- a/src/client/components/PlexConfigForm.tsx
+++ b/src/client/components/PlexConfigForm.tsx
@@ -47,10 +47,15 @@ export default function PlexConfigForm({
     }));
   }, [availableServers]);
 
+  const trimmedHostname = hostname.trim();
+  const parsedPort = parseInt(port, 10);
+  const portValid = Number.isInteger(parsedPort) && parsedPort >= 1 && parsedPort <= 65535;
+  const manualConfigValid = trimmedHostname.length > 0 && portValid;
+
   function buildPayload(): PlexConfigPayload {
     return selectedServerUri && selectedMachineIdentifier
       ? { mode: "preset", serverUrl: selectedServerUri, machineIdentifier: selectedMachineIdentifier }
-      : { mode: "manual", hostname, port: Number(port), useSsl };
+      : { mode: "manual", hostname: trimmedHostname, port: parsedPort, useSsl };
   }
 
   function switchToManual() {
@@ -72,20 +77,25 @@ export default function PlexConfigForm({
   }
 
   async function testConnection() {
+    const payload = buildPayload();
+    console.debug("Plex connection test started", { testUrl, payload });
     setTesting(true);
     setTestResult(null);
     try {
       const result = await apiPost<{ ok: boolean; serverUrl?: string; libraryCount?: number; error?: string }>(
         testUrl,
-        buildPayload()
+        payload
       );
       if (result.ok) {
+        console.debug("Plex connection test succeeded", { ok: true, serverUrl: result.serverUrl, libraryCount: result.libraryCount });
         const count = result.libraryCount ?? 0;
         setTestResult({ ok: true, message: `Test Succeeded — ${count} ${count === 1 ? "library" : "libraries"} found` });
       } else {
+        console.warn("Plex connection test returned non-ok", { ok: false, error: result.error });
         setTestResult({ ok: false, message: result.error ?? "Connection failed" });
       }
     } catch (caught) {
+      console.warn("Plex connection test threw", { error: caught instanceof Error ? caught.message : String(caught) });
       setTestResult({ ok: false, message: caught instanceof Error ? caught.message : String(caught) });
     } finally {
       setTesting(false);
@@ -106,8 +116,6 @@ export default function PlexConfigForm({
       setSaving(false);
     }
   }
-
-  const hasHostname = Boolean(hostname);
 
   return (
     <SectionCard
@@ -201,7 +209,7 @@ export default function PlexConfigForm({
           <button
             type="button"
             onClick={() => void testConnection()}
-            disabled={testing || (!selectedServerUri && !hasHostname)}
+            disabled={testing || (!selectedServerUri && !manualConfigValid)}
             className="bg-surface-container-high hover:bg-surface-bright disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
           >
             {testing ? "Testing..." : "Test Connection"}

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -136,6 +136,7 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
           <PlexConfigForm
             initialConfig={setupStatus?.plex ?? null}
             saveUrl="/api/setup/plex/save"
+            testUrl="/api/setup/plex/test"
             saveLabel="Continue to Collections"
             onBack={() => setStep("general")}
             onSaved={async () => {

--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -106,6 +106,7 @@ export default function Settings() {
             <PlexConfigForm
               initialConfig={settings.plex}
               saveUrl="/api/settings/plex/save"
+              testUrl="/api/settings/plex/test"
               saveLabel="Save Plex"
               onSaved={async () => {
                 await loadSettings();
@@ -289,7 +290,7 @@ function GeneralTab({
           </div>
 
           <div className="pt-1">
-            <SaveBar saving={saving} success={success} error={error} onSave={() => void save()} />
+            <SaveBar saving={saving} success={success} error={error} onSave={() => void save()} label="Save General" />
           </div>
         </div>
       </div>

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -204,6 +204,23 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     };
   }
 
+  async function handlePlexConnectionTest(payload: PlexConfigPayload, res: Response) {
+    const owner = db.getPlexOwner();
+    if (!owner) {
+      res.status(400).json({ ok: false, error: "No Plex account configured. Please sign in with Plex first." });
+      return;
+    }
+    try {
+      const input = buildPlexInputFromPayload(owner.plexToken, payload);
+      const result = await services.validatePlexSettings(input);
+      logger.info("Plex connection test succeeded", { serverUrl: input.serverUrl, libraryCount: result.libraries.length });
+      res.json({ ok: true, serverUrl: input.serverUrl, libraryCount: result.libraries.length });
+    } catch (err) {
+      logger.warn("Plex connection test failed", { error: err instanceof Error ? err.message : String(err) });
+      res.status(400).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
   async function validateAndSavePlexConfiguration(payload: PlexConfigPayload) {
     const owner = db.getPlexOwner();
     if (!owner) {
@@ -417,20 +434,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   /** Test Plex connectivity during onboarding with the provided configuration without saving */
   app.post("/api/setup/plex/test", requireAuth, async (req, res) => {
-    const owner = db.getPlexOwner();
-    if (!owner) {
-      res.status(400).json({ ok: false, error: "No Plex account configured. Please sign in with Plex first." });
-      return;
-    }
-    try {
-      const input = buildPlexInputFromPayload(owner.plexToken, req.body as PlexConfigPayload);
-      const result = await services.validatePlexSettings(input);
-      logger.info("Plex connection test succeeded (setup)", { serverUrl: input.serverUrl, libraryCount: result.libraries.length });
-      res.json({ ok: true, serverUrl: input.serverUrl, libraryCount: result.libraries.length });
-    } catch (err) {
-      logger.warn("Plex connection test failed (setup)", { error: err instanceof Error ? err.message : String(err) });
-      res.status(400).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
-    }
+    await handlePlexConnectionTest(req.body as PlexConfigPayload, res);
   });
 
   app.get("/api/setup/status", requireAuth, (_req, res) => {
@@ -920,20 +924,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
 
   /** Test Plex connectivity with the provided configuration without saving */
   app.post("/api/settings/plex/test", requireAuth, async (req, res) => {
-    const owner = db.getPlexOwner();
-    if (!owner) {
-      res.status(400).json({ ok: false, error: "No Plex account configured. Please sign in with Plex first." });
-      return;
-    }
-    try {
-      const input = buildPlexInputFromPayload(owner.plexToken, req.body as PlexConfigPayload);
-      const result = await services.validatePlexSettings(input);
-      logger.info("Plex connection test succeeded", { serverUrl: input.serverUrl, libraryCount: result.libraries.length });
-      res.json({ ok: true, serverUrl: input.serverUrl, libraryCount: result.libraries.length });
-    } catch (err) {
-      logger.warn("Plex connection test failed", { error: err instanceof Error ? err.message : String(err) });
-      res.status(400).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
-    }
+    await handlePlexConnectionTest(req.body as PlexConfigPayload, res);
   });
 
   app.use("/api/settings/logs", logsRateLimiter);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -415,6 +415,24 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     }
   });
 
+  /** Test Plex connectivity during onboarding with the provided configuration without saving */
+  app.post("/api/setup/plex/test", requireAuth, async (req, res) => {
+    const owner = db.getPlexOwner();
+    if (!owner) {
+      res.status(400).json({ ok: false, error: "No Plex account configured. Please sign in with Plex first." });
+      return;
+    }
+    try {
+      const input = buildPlexInputFromPayload(owner.plexToken, req.body as PlexConfigPayload);
+      const result = await services.validatePlexSettings(input);
+      logger.info("Plex connection test succeeded (setup)", { serverUrl: input.serverUrl, libraryCount: result.libraries.length });
+      res.json({ ok: true, serverUrl: input.serverUrl, libraryCount: result.libraries.length });
+    } catch (err) {
+      logger.warn("Plex connection test failed (setup)", { error: err instanceof Error ? err.message : String(err) });
+      res.status(400).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
   app.get("/api/setup/status", requireAuth, (_req, res) => {
     const appSettings = db.getAppSettings();
     const payload: SetupStatusResponse = {
@@ -897,6 +915,24 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     } catch (error) {
       logger.warn("Plex settings save failed", { error: error instanceof Error ? error.message : String(error) });
       res.status(400).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  /** Test Plex connectivity with the provided configuration without saving */
+  app.post("/api/settings/plex/test", requireAuth, async (req, res) => {
+    const owner = db.getPlexOwner();
+    if (!owner) {
+      res.status(400).json({ ok: false, error: "No Plex account configured. Please sign in with Plex first." });
+      return;
+    }
+    try {
+      const input = buildPlexInputFromPayload(owner.plexToken, req.body as PlexConfigPayload);
+      const result = await services.validatePlexSettings(input);
+      logger.info("Plex connection test succeeded", { serverUrl: input.serverUrl, libraryCount: result.libraries.length });
+      res.json({ ok: true, serverUrl: input.serverUrl, libraryCount: result.libraries.length });
+    } catch (err) {
+      logger.warn("Plex connection test failed", { error: err instanceof Error ? err.message : String(err) });
+      res.status(400).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
   });
 


### PR DESCRIPTION
## Summary

Implements a Test Connection button for Plex, in both the settings page and onboarding flow (issue #108). The button validates that the configured Plex server can be reached and returns the library count on success, without saving any changes. The UX is consistent with the existing Seerr test connection button.

Also takes the opportunity to align the bottom action bar layout across all settings tabs — General, Collections, and Plex now all push their save button to the far right, matching the Seerr tab. The General save button is also renamed to "Save General" for consistency.

Closes #108

## Changes

- **`src/server/app.ts`** — Added `POST /api/settings/plex/test` and `POST /api/setup/plex/test` endpoints. Both accept the same `PlexConfigPayload` used by the save endpoints, use the stored Plex owner token, call `services.validatePlexSettings()`, and return `{ ok, serverUrl, libraryCount }` or `{ ok: false, error }`.

- **`src/client/components/PlexConfigForm.tsx`** — Added `testUrl` prop, `testing`/`testResult` state, and a `testConnection()` function. Replaced the previous `SaveBar` + separate test row with a single Seerr-style bottom bar: Test Connection on the left, Save on the right. Back button (onboarding only) appears in the left group. `ChevronLeft` imported to support the inline Back button.

- **`src/client/components/FormControls.tsx`** — Updated the no-`onBack` variant of `SaveBar` to use `justify-between` with the save button on the right and success/error messages on the left, matching the Seerr tab style. Added the `border-t` separator.

- **`src/client/pages/Settings.tsx`** — Added `label="Save General"` to the `GeneralTab` save bar, and added `testUrl="/api/settings/plex/test"` to the Plex tab's `PlexConfigForm`.

- **`src/client/pages/Onboarding.tsx`** — Added `testUrl="/api/setup/plex/test"` to the onboarding `PlexConfigForm`.

## Test plan

- [x] Open Settings → Plex tab. Enter a valid server hostname/port (or select from the server list). Click **Test Connection** — confirm it shows `Test Succeeded — N libraries found`.
- [x] On the same tab, enter an invalid hostname. Click **Test Connection** — confirm it shows an error message in red.
- [x] Open Settings → General tab. Confirm the save button reads **Save General** and sits on the far right of the bottom bar.
- [x] Open Settings → Collections tab. Confirm the save button sits on the far right of the bottom bar.
- [x] Go through onboarding to the Plex step. Confirm the **Test Connection** button appears to the left of **Continue to Collections**, with **← Back** to the left of the test button.
- [x] Confirm the Seerr tab bottom bar is visually unchanged.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Test Connection" button to Plex configuration, allowing users to verify server connectivity before saving settings.

* **UI Improvements**
  * Reorganized save confirmation layout for enhanced visual clarity and better message placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->