### PR TITLE
fix: stop deleting Seerr service account when disabling service account usage

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1328,30 +1328,15 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       }
 
       if (!body.useServiceAccount) {
-        const baseUrl = patch.baseUrl ?? current.baseUrl;
-        const apiKey = patch.apiKey ?? current.apiKey;
-
-        if (current.useServiceAccount && current.serviceAccountSeerrUserId !== null) {
-          if (!baseUrl || !apiKey) {
-            res.status(400).json({ error: "Base URL and API key are required to disable service account mode cleanly." });
-            return;
-          }
-
-          try {
-            const seerr = services.buildSeerrIntegration(baseUrl, apiKey);
-            await seerr.deleteServiceAccount();
-            logger.info("Seerr service account deleted on settings save", {
-              seerrUserId: current.serviceAccountSeerrUserId
-            });
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            logger.error("Failed to delete Seerr service account", { message });
-            res.status(400).json({ error: `Could not delete Seerr service account: ${message}` });
-            return;
-          }
+        // Disabling service account mode — stop using the account but do not delete it from Seerr.
+        // Deleting causes Seerr user IDs to increment each time the option is toggled, which is
+        // surprising and hard to recover from. The account will be found and reused by email if
+        // the option is enabled again later.
+        if (current.useServiceAccount) {
+          logger.info("Seerr service account usage disabled — account retained in Seerr", {
+            seerrUserId: current.serviceAccountSeerrUserId
+          });
         }
-
-        // Disabling service account mode — clear the stored user ID after cleanup
         patch.serviceAccountSeerrUserId = null;
       }
     }

--- a/src/server/integrations/seerr.ts
+++ b/src/server/integrations/seerr.ts
@@ -326,25 +326,6 @@ export class SeerrIntegration {
     });
   }
 
-  /**
-   * Delete the Hubarr service account from Seerr if it exists.
-   * This is used when service account mode is disabled in Hubarr settings.
-   */
-  async deleteServiceAccount(users: SeerrUser[] = []): Promise<void> {
-    const seerrUsers = users.length > 0 ? users : await this.getUsers();
-    const existing = seerrUsers.find(
-      (u) => u.email.toLowerCase() === SEERR_SERVICE_ACCOUNT_EMAIL.toLowerCase()
-    );
-
-    if (!existing) {
-      this.logger.info("Seerr service account delete skipped — account not found");
-      return;
-    }
-
-    await this.delete(`/user/${existing.id}`);
-    this.logger.info("Seerr service account deleted", { seerrUserId: existing.id });
-  }
-
   // ---------------------------------------------------------------------------
   // Media status inspection
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When the **Use service account** option is unchecked in Seerr settings, Hubarr previously deleted the service account from Seerr. This caused Seerr user IDs to increment every time the option was toggled on and off, eventually leaving orphaned account slots and confusing users. This PR removes the deletion behaviour — disabling the option now simply stops Hubarr from using the account, leaving it intact in Seerr.

When the option is re-enabled, the existing `createOrReconcileServiceAccount()` function already searches for the account by email (`hubarr@hubarr.local`) and reuses it if found, so no additional changes are needed for the "re-enable" path.

## Changes

- **`src/server/app.ts`** — Removed the block in `PATCH /api/settings/seerr` that called `deleteServiceAccount()` when `useServiceAccount` was set to `false`. Replaced with an informational log line confirming the account was retained. The `serviceAccountSeerrUserId` is still cleared from the DB (so it isn't mistakenly referenced while the option is off), and will be repopulated from the actual Seerr account when the option is re-enabled.

- **`src/server/integrations/seerr.ts`** — Removed the `deleteServiceAccount()` method entirely, as it is no longer called anywhere.

## Test plan

- [x] Enable Seerr integration and check **Use service account** — confirm the Hubarr service account is created in Seerr.
- [x] Uncheck **Use service account** and save — confirm the account **still exists** in Seerr (was not deleted).
- [x] Re-check **Use service account** and save — confirm Hubarr reuses the existing Seerr account (same user ID, no new account created).
- [x] Toggle the option multiple times and confirm the Seerr user list does not accumulate extra accounts.

Closes #113

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service accounts are now preserved when disabling service account mode in Seerr, rather than being deleted. This allows seamless re-enablement without requiring reconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->