### PR TITLE
fix: align collectionNameOverride field name between frontend and backend

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -552,7 +552,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       const body = req.body as Record<string, unknown>;
       const allowedUserPatchFields = new Set([
         "enabled",
-        "collectionName",
+        "collectionNameOverride",
         "movieLibraryId",
         "showLibraryId",
         "visibilityOverride",
@@ -621,12 +621,12 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         }
         updatePayload.displayNameOverride = body.displayNameOverride as string | null;
       }
-      if ("collectionName" in body) {
-        if (body.collectionName !== null && typeof body.collectionName !== "string") {
-          res.status(400).json({ error: "collectionName must be a string or null." });
+      if ("collectionNameOverride" in body) {
+        if (body.collectionNameOverride !== null && typeof body.collectionNameOverride !== "string") {
+          res.status(400).json({ error: "collectionNameOverride must be a string or null." });
           return;
         }
-        updatePayload.collectionNameOverride = body.collectionName as string | null;
+        updatePayload.collectionNameOverride = body.collectionNameOverride as string | null;
       }
       if ("collectionSortOrderOverride" in body) {
         updatePayload.collectionSortOrderOverride = (body.collectionSortOrderOverride ?? null) as CollectionSortOrder | null;


### PR DESCRIPTION
## Summary

Saving a collection name override was failing with `Unsupported fields: collectionNameOverride` because the backend's PATCH `/api/users/:id` allowlist used the alias `collectionName` while the frontend (and every other override field) used `collectionNameOverride`. The two sides never matched, so every save attempt was rejected.

## Changes

**[src/server/app.ts](src/server/app.ts)**
- Renamed `"collectionName"` to `"collectionNameOverride"` in the `allowedUserPatchFields` set
- Updated the handler branch from `"collectionName" in body` to `"collectionNameOverride" in body`, removing the intermediate alias mapping that was no longer needed

## Test plan

- [x] Open a user edit modal and set a collection name override value, then save — confirm it saves without an error
- [x] Clear the collection name override (set to empty / null) and save — confirm it clears correctly
- [x] Confirm other user override fields (display name, visibility, sort order) still save correctly

Closes #112

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced user update request handling with improved parameter validation and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->