### PR TITLE
fix: use stable username-based labels and label-first collection lookup

### DIFF
--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1296,13 +1296,32 @@ export class PlexIntegration {
     const collections = await this.getCollections(libraryId);
     const label = this.createCollectionLabel(username);
 
-    // Fetch all collection labels in parallel so we can check for both title
-    // matches and label matches in one pass without serialising N round-trips.
-    const withLabels = await Promise.all(
+    // Fetch all collection labels in parallel. Use allSettled so a single
+    // failing label fetch (network blip, permission issue) is logged and skipped
+    // rather than aborting the entire reconciliation.
+    const settled = await Promise.allSettled(
       collections.map(async (c) => ({ ...c, labels: await this.getCollectionLabels(c.ratingKey) }))
     );
+    const withLabels = settled
+      .map((result, i) => {
+        if (result.status === "fulfilled") return result.value;
+        this.logger.warn("Failed to fetch labels for collection, skipping in reconciliation", {
+          ratingKey: collections[i].ratingKey,
+          title: collections[i].title,
+          error: result.reason instanceof Error ? result.reason.message : String(result.reason)
+        });
+        return null;
+      })
+      .filter((c): c is { ratingKey: string; title: string; labels: string[] } => c !== null);
 
-    const byTitle = withLabels.find((c) => c.title === title);
+    // Only accept a title match that already carries this user's label or has no
+    // hubarr:* label at all — this avoids accidentally claiming another user's
+    // same-named collection.
+    const byTitle = withLabels.find(
+      (c) => c.title === title &&
+             (c.labels.some((l) => l.toLowerCase() === label.toLowerCase()) ||
+              !c.labels.some((l) => l.toLowerCase().startsWith("hubarr:")))
+    );
     // Label matches on collections other than the title match are duplicates to reconcile.
     const labelMatches = withLabels.filter(
       (c) => c.ratingKey !== byTitle?.ratingKey &&

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1282,6 +1282,7 @@ export class PlexIntegration {
   }
 
   async updateCollectionTitle(ratingKey: string, title: string): Promise<void> {
+    this.logger.info("Updating Plex collection title", { ratingKey, title });
     const params = new URLSearchParams({
       type: "18",
       id: ratingKey,
@@ -1293,38 +1294,38 @@ export class PlexIntegration {
 
   async ensureCollection(title: string, username: string, mediaType: MediaType, libraryId: string) {
     const collections = await this.getCollections(libraryId);
-
-    // Fast path: collection already has the expected title
-    const byTitle = collections.find((c) => c.title === title);
-    if (byTitle) {
-      return byTitle.ratingKey;
-    }
-
-    // Label-first: scan all collections for the stable hubarr label for this user.
-    // This finds collections that exist under an old/different name and renames the
-    // canonical one rather than creating a duplicate. Any additional matches are genuine
-    // duplicates and are deleted.
     const label = this.createCollectionLabel(username);
-    const labelMatches: Array<{ ratingKey: string; title: string }> = [];
-    for (const collection of collections) {
-      const labels = await this.getCollectionLabels(collection.ratingKey);
-      if (labels.some((l) => l.toLowerCase() === label.toLowerCase())) {
-        labelMatches.push(collection);
-      }
-    }
 
-    if (labelMatches.length === 0) {
+    // Fetch all collection labels in parallel so we can check for both title
+    // matches and label matches in one pass without serialising N round-trips.
+    const withLabels = await Promise.all(
+      collections.map(async (c) => ({ ...c, labels: await this.getCollectionLabels(c.ratingKey) }))
+    );
+
+    const byTitle = withLabels.find((c) => c.title === title);
+    // Label matches on collections other than the title match are duplicates to reconcile.
+    const labelMatches = withLabels.filter(
+      (c) => c.ratingKey !== byTitle?.ratingKey &&
+             c.labels.some((l) => l.toLowerCase() === label.toLowerCase())
+    );
+
+    // Canonical: title match wins; otherwise first label match.
+    const canonical = byTitle ?? labelMatches[0];
+    const extras = byTitle ? labelMatches : labelMatches.slice(1);
+
+    if (!canonical) {
       return this.createCollection(title, mediaType, libraryId);
     }
 
-    const [canonical, ...extras] = labelMatches;
-    this.logger.info("Found existing collection by label, renaming to current expected title", {
-      ratingKey: canonical.ratingKey,
-      oldTitle: canonical.title,
-      newTitle: title,
-      label
-    });
-    await this.updateCollectionTitle(canonical.ratingKey, title);
+    if (canonical.title !== title) {
+      this.logger.info("Found existing collection by label, renaming to current expected title", {
+        ratingKey: canonical.ratingKey,
+        oldTitle: canonical.title,
+        newTitle: title,
+        label
+      });
+      await this.updateCollectionTitle(canonical.ratingKey, title);
+    }
 
     if (extras.length > 0) {
       this.logger.warn("Found duplicate Hubarr-labelled collections for user, removing extras", {

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1301,24 +1301,43 @@ export class PlexIntegration {
     }
 
     // Label-first: scan all collections for the stable hubarr label for this user.
-    // This finds a collection that exists under an old/different name and renames it
-    // rather than creating a duplicate.
+    // This finds collections that exist under an old/different name and renames the
+    // canonical one rather than creating a duplicate. Any additional matches are genuine
+    // duplicates and are deleted.
     const label = this.createCollectionLabel(username);
+    const labelMatches: Array<{ ratingKey: string; title: string }> = [];
     for (const collection of collections) {
       const labels = await this.getCollectionLabels(collection.ratingKey);
       if (labels.some((l) => l.toLowerCase() === label.toLowerCase())) {
-        this.logger.info("Found existing collection by label, renaming to current expected title", {
-          ratingKey: collection.ratingKey,
-          oldTitle: collection.title,
-          newTitle: title,
-          label
-        });
-        await this.updateCollectionTitle(collection.ratingKey, title);
-        return collection.ratingKey;
+        labelMatches.push(collection);
       }
     }
 
-    return this.createCollection(title, mediaType, libraryId);
+    if (labelMatches.length === 0) {
+      return this.createCollection(title, mediaType, libraryId);
+    }
+
+    const [canonical, ...extras] = labelMatches;
+    this.logger.info("Found existing collection by label, renaming to current expected title", {
+      ratingKey: canonical.ratingKey,
+      oldTitle: canonical.title,
+      newTitle: title,
+      label
+    });
+    await this.updateCollectionTitle(canonical.ratingKey, title);
+
+    if (extras.length > 0) {
+      this.logger.warn("Found duplicate Hubarr-labelled collections for user, removing extras", {
+        canonicalRatingKey: canonical.ratingKey,
+        duplicates: extras.map((c) => ({ ratingKey: c.ratingKey, title: c.title })),
+        label
+      });
+      for (const extra of extras) {
+        await this.deleteCollection(extra.ratingKey);
+      }
+    }
+
+    return canonical.ratingKey;
   }
 
   async deleteCollection(collectionRatingKey: string): Promise<void> {

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1281,11 +1281,43 @@ export class PlexIntegration {
     return { staleKeys };
   }
 
-  async ensureCollection(title: string, mediaType: MediaType, libraryId: string) {
-    const existing = (await this.getCollections(libraryId)).find((collection) => collection.title === title);
-    if (existing) {
-      return existing.ratingKey;
+  async updateCollectionTitle(ratingKey: string, title: string): Promise<void> {
+    const params = new URLSearchParams({
+      type: "18",
+      id: ratingKey,
+      title: title,
+      "title.locked": "1"
+    });
+    await this.requestServer(`/library/metadata/${ratingKey}?${params.toString()}`, { method: "PUT" });
+  }
+
+  async ensureCollection(title: string, username: string, mediaType: MediaType, libraryId: string) {
+    const collections = await this.getCollections(libraryId);
+
+    // Fast path: collection already has the expected title
+    const byTitle = collections.find((c) => c.title === title);
+    if (byTitle) {
+      return byTitle.ratingKey;
     }
+
+    // Label-first: scan all collections for the stable hubarr label for this user.
+    // This finds a collection that exists under an old/different name and renames it
+    // rather than creating a duplicate.
+    const label = this.createCollectionLabel(username);
+    for (const collection of collections) {
+      const labels = await this.getCollectionLabels(collection.ratingKey);
+      if (labels.some((l) => l.toLowerCase() === label.toLowerCase())) {
+        this.logger.info("Found existing collection by label, renaming to current expected title", {
+          ratingKey: collection.ratingKey,
+          oldTitle: collection.title,
+          newTitle: title,
+          label
+        });
+        await this.updateCollectionTitle(collection.ratingKey, title);
+        return collection.ratingKey;
+      }
+    }
+
     return this.createCollection(title, mediaType, libraryId);
   }
 
@@ -1866,7 +1898,7 @@ export class PlexIntegration {
     const sharedUsers = await this.getSharedUsers();
 
     // Build one label per user (same label applies to both movie and TV collections)
-    const allLabels = enabledUsers.map((u) => this.createCollectionLabel(u.displayName));
+    const allLabels = enabledUsers.map((u) => this.createCollectionLabel(u.username));
 
     // Index enabled users by their Plex username for matching with shared users.
     // The XML invitedId and GraphQL plexUserId are different ID formats, but
@@ -1892,7 +1924,7 @@ export class PlexIntegration {
 
       // Labels to exclude: all labels EXCEPT this user's own
       const excludedLabels = matchedUser
-        ? allLabels.filter((l) => l !== this.createCollectionLabel(matchedUser.displayName))
+        ? allLabels.filter((l) => l !== this.createCollectionLabel(matchedUser.username))
         : allLabels;
 
       // Strip old Hubarr labels then re-apply the current set

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1159,7 +1159,7 @@ export class HubarrServices {
         collectionName,
         matchedItems: matchedRatingKeys.length
       });
-      const collectionRatingKey = await plex.ensureCollection(collectionName, mediaType, libraryId);
+      const collectionRatingKey = await plex.ensureCollection(collectionName, friend.username, mediaType, libraryId);
       this.logger.info("Collection resolved", {
         userId: friend.id,
         mediaType,
@@ -1218,7 +1218,7 @@ export class HubarrServices {
         matchedItems: cleanedKeys.length
       });
 
-      const labelName = plex.createCollectionLabel(friend.displayName);
+      const labelName = plex.createCollectionLabel(friend.username);
       await plex.applyLabelToCollection(collectionRatingKey, labelName);
       this.logger.info("Collection label applied", {
         userId: friend.id,


### PR DESCRIPTION
## Summary

Fixes a bug where Hubarr would create duplicate Plex collections when display names changed or a fresh setup was run without the same display name overrides. The root cause was two compounding issues: collection labels used the mutable `displayName` (which reflects any override) instead of the stable Plex `username`, and collection lookup only searched by title rather than by label.

With this fix, each user's Hubarr label is permanently tied to their Plex username. When `ensureCollection` runs, it first checks by title (fast path for the normal case), then scans all collections in the library for the user's stable label. If it finds a match under an old or different name it renames the collection rather than creating a duplicate. Isolation filters follow the same change and are now keyed to `username` too.

Closes #114

## Changes

- **`src/server/integrations/plex.ts`**
  - `ensureCollection` now accepts `username` and performs label-first lookup after the title check fails. Found collections with a mismatched title are renamed to the current expected name before being returned.
  - New `updateCollectionTitle` helper to rename a Plex collection via the metadata API.
  - `syncIsolationFilters` now generates labels from `u.username` instead of `u.displayName` at both the allLabels build and the per-user exclusion filter.
  - `createCollectionLabel` is unchanged — it still normalises any string passed to it; callers now pass `username`.

- **`src/server/services.ts`**
  - `publishUserCollections`: passes `friend.username` to both `ensureCollection` and `createCollectionLabel`.

## Test plan

- [x] Open Settings → Users, set a display name override for a user, trigger a sync. Confirm the existing collection is renamed in Plex to the new name rather than a second collection being created.
- [x] Delete the Hubarr config, run onboarding fresh. Confirm Hubarr finds and reconciles the existing (now username-labelled) collections rather than creating duplicates.
- [x] Confirm isolation filters still work: each shared Plex user should only see their own watchlist collection, not others'.
- [x] Confirm the Plex collection label is now `hubarr:{plex-username}-watchlist` rather than `hubarr:{display-name-override}-watchlist`.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Plex collections by reconciling and consolidating per-user collections; extras are removed and the canonical collection is renamed and locked to the expected title.
  * Made label reads more resilient by skipping failed label fetches instead of aborting reconciliation.
  * Fixed isolation label logic to use each user's account identifier (username) and updated exclusion handling accordingly.
* **New Features**
  * Creates a collection when no suitable canonical collection exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->