### PR TITLE
chore: remove legacy fallback and compatibility code paths

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -842,12 +842,9 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         patch.collectionNamePattern = body.collections.collectionNamePattern;
       }
       if (body.collections.collectionSortOrder !== undefined) {
-        // Accept new date-* values and normalize legacy year-* values on ingest.
-        const legacyMap: Record<string, string> = { "year-desc": "date-desc", "year-asc": "date-asc" };
-        const normalized = legacyMap[body.collections.collectionSortOrder] ?? body.collections.collectionSortOrder;
         const valid: CollectionSortOrder[] = ["date-desc", "date-asc", "title", "watchlist-date-desc", "watchlist-date-asc"];
-        if (valid.includes(normalized as CollectionSortOrder)) {
-          patch.collectionSortOrder = normalized as CollectionSortOrder;
+        if (valid.includes(body.collections.collectionSortOrder as CollectionSortOrder)) {
+          patch.collectionSortOrder = body.collections.collectionSortOrder as CollectionSortOrder;
         }
       }
       if ("movieLibraryId" in body.collections) {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -845,6 +845,10 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         const valid: CollectionSortOrder[] = ["date-desc", "date-asc", "title", "watchlist-date-desc", "watchlist-date-asc"];
         if (valid.includes(body.collections.collectionSortOrder as CollectionSortOrder)) {
           patch.collectionSortOrder = body.collections.collectionSortOrder as CollectionSortOrder;
+        } else {
+          logger.warn("Invalid collectionSortOrder value rejected", { value: body.collections.collectionSortOrder, allowed: valid });
+          res.status(400).json({ error: "Invalid collectionSortOrder.", allowed: valid });
+          return;
         }
       }
       if ("movieLibraryId" in body.collections) {

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -49,7 +49,7 @@ export class HubarrDatabase {
     // to prevent stale rows left in a `running` state during startup.
     syncRepo.reconcileStaleRuns(this.db, logger);
     settingsRepo.seedDefaultSettings(this.db);
-    this.sessionSecret = settingsRepo.resolveSessionSecret(this.db, config.dataDir);
+    this.sessionSecret = settingsRepo.resolveSessionSecret(this.db);
   }
 
   getSessionSecret(): string {

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -6,32 +6,6 @@ interface Migration {
   up(db: Database.Database): void;
 }
 
-const v1Tables = [
-  "settings",
-  "users",
-  "watchlist_cache",
-  "plex_collections",
-  "sync_runs",
-  "sync_run_items",
-  "job_run_state",
-  "sessions"
-] as const;
-
-function tableExists(db: Database.Database, name: string): boolean {
-  const row = db
-    .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
-    .get(name) as { 1: number } | undefined;
-
-  return Boolean(row);
-}
-
-function inferSchemaVersion(db: Database.Database): number {
-  if (v1Tables.every((table) => tableExists(db, table))) {
-    return 1;
-  }
-
-  return 0;
-}
 
 function normalizeIdentifierValue(value: string): string {
   return value.trim().toLowerCase();
@@ -534,15 +508,6 @@ const migrations: Migration[] = [
 
 export function runMigrations(db: Database.Database, logger?: Logger): void {
   let currentVersion = db.pragma("user_version", { simple: true }) as number;
-
-  if (currentVersion === 0) {
-    const inferredVersion = inferSchemaVersion(db);
-    if (inferredVersion > 0) {
-      db.pragma(`user_version = ${inferredVersion}`);
-      currentVersion = inferredVersion;
-      logger?.info("Database schema version inferred from existing tables", { version: currentVersion });
-    }
-  }
 
   const latestVersion = migrations[migrations.length - 1]?.version ?? 0;
   if (currentVersion >= latestVersion) {

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -1,6 +1,4 @@
 import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
 import type Database from "better-sqlite3";
 import type {
   AppSettings,
@@ -39,16 +37,6 @@ export const defaultAppSettings: AppSettings = {
   onboardingComplete: false
 };
 
-/**
- * Normalize legacy collection sort order values to the current date-based names.
- * Existing installs may have "year-desc" or "year-asc" stored in settings.
- */
-function normalizeSortOrder(value: string): AppSettings["collectionSortOrder"] {
-  if (value === "year-desc") return "date-desc";
-  if (value === "year-asc") return "date-asc";
-  if (value === "date-desc" || value === "date-asc" || value === "title" || value === "watchlist-date-desc" || value === "watchlist-date-asc") return value;
-  return "date-desc";
-}
 
 export function getSetting<T>(db: Database.Database, key: SettingKey): T | null {
   const row = db.prepare("SELECT value FROM settings WHERE key = ?").get(key) as
@@ -73,31 +61,13 @@ export function seedDefaultSettings(db: Database.Database): void {
   }
 }
 
-/**
- * Resolve the session signing secret from the database.
- *
- * On the first run after migrating from the file-based approach, any existing
- * .session_secret file is read into the database and then deleted so that
- * existing sessions remain valid. If no secret exists anywhere a new one is
- * generated and persisted.
- */
-export function resolveSessionSecret(db: Database.Database, dataDir: string): string {
+export function resolveSessionSecret(db: Database.Database): string {
   const stored = getSetting<string>(db, "session_secret");
   if (stored) {
     return stored;
   }
 
-  // One-time migration: pull the value out of the legacy file if it exists.
-  const legacyFile = path.join(dataDir, ".session_secret");
-  let secret: string;
-  try {
-    secret = fs.readFileSync(legacyFile, "utf8").trim();
-    fs.unlinkSync(legacyFile);
-  } catch {
-    // File didn't exist — generate a fresh secret.
-    secret = crypto.randomBytes(48).toString("hex");
-  }
-
+  const secret = crypto.randomBytes(48).toString("hex");
   setSetting(db, "session_secret", secret);
   return secret;
 }
@@ -119,18 +89,10 @@ export function getBootstrapStatus(db: Database.Database, hasActiveSession: bool
       appSettings.defaultShowLibraryId
   );
 
-  // Backwards-compat: existing installs that were fully configured before the
-  // onboardingComplete flag was introduced won't have the field in stored
-  // settings. For these we derive onboardingComplete from configurationValid so
-  // they aren't forced through the wizard again.
-  const stored = getSetting<AppSettings>(db, "app");
-  const hasFlag = stored !== null && "onboardingComplete" in stored;
-  const onboardingComplete = hasFlag ? appSettings.onboardingComplete : configurationValid;
-
   return {
     hasOwner: Boolean(getSetting<PlexOwnerRecord>(db, "admin")),
     configurationValid,
-    onboardingComplete,
+    onboardingComplete: appSettings.onboardingComplete,
     hasActiveSession
   };
 }
@@ -231,12 +193,7 @@ export function deleteAllSessions(db: Database.Database): void {
 
 export function getAppSettings(db: Database.Database): AppSettings {
   const stored = getSetting<AppSettings>(db, "app");
-  const merged = { ...defaultAppSettings, ...stored };
-  // Normalize on every read so existing installs that stored the old "year-desc" /
-  // "year-asc" values automatically upgrade to "date-desc" / "date-asc" without
-  // requiring a schema migration or a manual settings save.
-  merged.collectionSortOrder = normalizeSortOrder(merged.collectionSortOrder);
-  return merged;
+  return { ...defaultAppSettings, ...stored };
 }
 
 export function updateAppSettings(db: Database.Database, patch: Partial<AppSettings>): AppSettings {

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -373,12 +373,10 @@ export function getWatchlistItems(db: Database.Database, userId?: number): Watch
       const parsed = JSON.parse(rawPayload) as Partial<WatchlistItem>;
       return {
         ...row,
-        // guids and releaseDate are stored only in raw_payload — they are wide/variable-length
-        // arrays not needed for SQL filtering. discoverKey is now a dedicated column but
-        // we fall back to raw_payload for any rows written before migration v7.
+        // guids and releaseDate are stored only in raw_payload — wide/variable-length data not needed for SQL filtering.
         guids: Array.isArray(parsed.guids) ? parsed.guids : undefined,
-        discoverKey: row.discoverKey ?? (typeof parsed.discoverKey === "string" ? parsed.discoverKey : undefined),
-        releaseDate: typeof parsed.releaseDate === "string" ? parsed.releaseDate : (row.releaseDate ?? null)
+        discoverKey: row.discoverKey,
+        releaseDate: typeof parsed.releaseDate === "string" ? parsed.releaseDate : null
       };
     } catch {
       return row;

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -455,26 +455,6 @@ export class PlexIntegration {
     return url;
   }
 
-  private normalizeGuids(guids: unknown): string[] {
-    if (!Array.isArray(guids)) {
-      return [];
-    }
-
-    return guids
-      .map((guid) => {
-        if (typeof guid === "string") {
-          return guid;
-        }
-        if (guid && typeof guid === "object" && "id" in guid && typeof guid.id === "string") {
-          return guid.id;
-        }
-        return null;
-      })
-      .filter((guid): guid is string => Boolean(guid))
-      .map((guid) => guid.toLowerCase().trim())
-      .filter(Boolean);
-  }
-
   private normalizeAddedAt(value: unknown): string {
     if (typeof value === "number" && Number.isFinite(value)) {
       return new Date(value > 10_000_000_000 ? value : value * 1000).toISOString();


### PR DESCRIPTION
## Summary

Removes transitional fallback and compatibility code that was introduced during earlier migrations but no longer provides value — either because the migration has been completed on all instances, or because the project is early enough to safely assume a clean slate. The change reduces complexity and makes the codebase easier to follow.

Closes #118

## Changes

- **`src/server/db/settings.ts`** — Removed the `normalizeSortOrder()` function and its call in `getAppSettings()` (legacy `year-desc`/`year-asc` → `date-*` translation). Removed the `onboardingComplete` backwards-compat derivation in `getBootstrapStatus()` — the flag is now read directly from stored settings. Removed the one-time `.session_secret` file → database migration block from `resolveSessionSecret()`, along with the now-unused `fs` and `path` imports and the `dataDir` parameter.
- **`src/server/app.ts`** — Removed the `legacyMap` that normalised legacy sort order values on ingest to the PATCH `/api/settings` handler; the allowlist check now operates directly on the incoming value.
- **`src/server/db/index.ts`** — Updated the `resolveSessionSecret` call site to drop the now-removed `dataDir` argument.
- **`src/server/db/watchlist.ts`** — Removed the `discoverKey` raw_payload fallback for pre-migration-v7 rows (migration v7 backfills the column for all existing rows). Replaced `row.releaseDate ?? null` with plain `null` — `releaseDate` is not a database column and `row.releaseDate` was always `undefined`.
- **`src/server/db/migrations.ts`** — Removed `v1Tables`, `tableExists()`, `inferSchemaVersion()`, and the `currentVersion === 0` inference block in `runMigrations()`. Any database opened by the migration runner already has `user_version` stamped.
- **`src/server/integrations/plex.ts`** — Deleted the unused private `normalizeGuids()` method. It handled two GUID shapes but was never called — all active GUID normalisation uses inline `.map()` expressions directly.

## Test plan

- [ ] Start the app fresh — confirm it boots without errors and settings load correctly
- [ ] Open Settings → Collections, change the sort order, save, and reload — confirm the saved value is applied correctly
- [ ] Verify onboarding wizard does not re-appear for a fully configured instance
- [ ] Confirm session persists across a server restart (session secret is read from DB as expected)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecated Features**
  * Legacy collection sort order values (year-*) are no longer accepted; use current date-based options.

* **Behavior Changes**
  * Settings updates now reject unsupported sort order values with an error instead of remapping them.
  * Some watchlist and integration inputs may no longer be coerced from legacy formats; data will rely on current stored fields.

* **Internal Improvements**
  * Removed legacy migration and normalization fallbacks to simplify initialization and settings handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->