### PR TITLE
feat: rationalise colour scheme and fix contrast across UI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@ long gone.
   cleanup responsibilities, and how to add new maintenance work safely
 - [seerr.md](seerr.md) — Seerr integration: configuration, user mapping, request
   flow, service account, failure modes, and API quirks
+- [colour-scheme.md](colour-scheme.md) — the 14-colour palette, each colour's
+  role, contrast ratios, and rules for correct usage
 
 ## When To Read Which Doc
 
@@ -35,6 +37,8 @@ long gone.
   consistency checks, pruning, or other housekeeping tasks.
 - Read [seerr.md](seerr.md) when changing Seerr connectivity, user mapping,
   request logic, or the service account lifecycle.
+- Read [colour-scheme.md](colour-scheme.md) when adding new UI elements or
+  choosing colours for interactive states, text, or status indicators.
 
 ## Maintenance Rule
 

--- a/docs/colour-scheme.md
+++ b/docs/colour-scheme.md
@@ -1,0 +1,66 @@
+# Colour Scheme
+
+Hubarr uses a fixed dark-mode palette of 14 colours defined as CSS custom properties in `src/client/index.css` under the Tailwind v4 `@theme` block. All colour usage in components should reference these variables via Tailwind utility classes (`bg-*`, `text-*`, `border-*`) — no raw hex values in component code.
+
+## The Palette
+
+### Background scale
+
+Six steps from darkest (page base) to lightest (hover states). Use in order of elevation — deeper backgrounds sit behind shallower ones.
+
+| Variable | Hex | Role |
+|---|---|---|
+| `background` | `#0d0e12` | Page-level backgrounds, full-screen views, modal overlays |
+| `background-container-low` | `#121318` | Sidebar, nav rail |
+| `background-container` | `#18191e` | Default cards and panels |
+| `background-container-high` | `#1e1f25` | Elevated cards, button resting state |
+| `background-container-highest` | `#24252b` | Tooltips, popovers, highest elevation surfaces |
+| `background-bright` | `#2a2c32` | Button hover state, interactive element hover |
+
+### Brand / interactive
+
+Two steps of the brand red. Use `primary-dim` for resting interactive states and `primary` only for hover — this gives a consistent brighten-on-hover feel and keeps resting contrast above WCAG AAA (7:1 against `on-surface`).
+
+| Variable | Hex | Role |
+|---|---|---|
+| `primary` | `#e50914` | Hover state for buttons, active indicators, and brand accent (logo, large icons) |
+| `primary-dim` | `#ae0610` | Resting state for all interactive elements: buttons, active nav item, selected filters, toggles, badges |
+
+### Text
+
+| Variable | Hex | Role |
+|---|---|---|
+| `on-surface` | `#faf8fe` | Primary text; also used as text colour on coloured backgrounds (buttons, badges, active states) |
+| `on-surface-variant` | `#abaab0` | Secondary / muted text: subtitles, hints, inactive nav items, placeholder-like labels |
+
+### Border
+
+| Variable | Hex | Role |
+|---|---|---|
+| `outline-variant` | `#47484c` | Borders and dividers; typically used at reduced opacity (`/20`, `/30`) |
+
+### Status
+
+| Variable | Hex | Role |
+|---|---|---|
+| `success` | `#22c55e` | Success states, completed actions, positive indicators |
+| `warning` | `#f59e0b` | Warnings, non-critical notices, restart-required badges |
+| `error` | `#f06060` | Errors, validation failures, destructive action indicators |
+
+## Contrast
+
+All text/background pairings in active use pass WCAG AA (4.5:1 for normal text). Key ratios:
+
+| Text | Background | Ratio |
+|---|---|---|
+| `on-surface` on any background step | worst case `background-bright` | 13.2:1 |
+| `on-surface-variant` on any background step | worst case `background-bright` | 6.1:1 |
+| `on-surface` on `primary-dim` (buttons, badges) | — | 7.0:1 (AAA) |
+| `on-surface` on `primary` (hover state) | — | 4.8:1 (AA) |
+
+## Rules
+
+- Never use `primary` or `primary-dim` as a text colour on dark backgrounds — neither passes AA at small text sizes.
+- Use `on-surface` (not raw `white`) for text on coloured backgrounds to keep the off-white tone consistent.
+- Status colours (`success`, `warning`, `error`) are for text and subtle tinted backgrounds (`/10` opacity) only — do not use them as solid button backgrounds.
+- `outline-variant` is a border colour only, not used for text.

--- a/docs/colour-scheme.md
+++ b/docs/colour-scheme.md
@@ -45,7 +45,7 @@ Two steps of the brand red. Use `primary-dim` for resting interactive states and
 |---|---|---|
 | `success` | `#22c55e` | Success states, completed actions, positive indicators |
 | `warning` | `#f59e0b` | Warnings, non-critical notices, restart-required badges |
-| `error` | `#f06060` | Errors, validation failures, destructive action indicators |
+| `error` | `#f07070` | Errors, validation failures, destructive action indicators |
 
 ## Contrast
 

--- a/docs/colour-scheme.md
+++ b/docs/colour-scheme.md
@@ -1,6 +1,6 @@
 # Colour Scheme
 
-Hubarr uses a fixed dark-mode palette of 14 colours defined as CSS custom properties in `src/client/index.css` under the Tailwind v4 `@theme` block. All colour usage in components should reference these variables via Tailwind utility classes (`bg-*`, `text-*`, `border-*`) — no raw hex values in component code.
+Hubarr uses a fixed dark-mode palette of 14 colours defined as CSS custom properties in `src/client/index.css` under the Tailwind v4 `@theme` block. Components should reference these variables via Tailwind utility classes (`bg-*`, `text-*`, `border-*`) for normal colour usage. The one exception is overlays and gradients — these may use the shared CSS custom properties defined in `:root` in `src/client/index.css` (e.g. `var(--overlay-glass)`) where a raw opacity value is required and a Tailwind utility class is not practical. Raw hex values in component code are not permitted.
 
 ## The Palette
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -100,7 +100,7 @@ function MainApp() {
       <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="flex flex-col items-center gap-3">
           <div className="w-10 h-10 rounded-xl bg-primary flex items-center justify-center">
-            <span className="text-on-primary font-headline font-bold">H</span>
+            <span className="text-on-surface font-headline font-bold">H</span>
           </div>
           <div className="text-on-surface-variant text-sm">Loading Hubarr...</div>
         </div>

--- a/src/client/components/CollectionsConfigForm.tsx
+++ b/src/client/components/CollectionsConfigForm.tsx
@@ -179,13 +179,13 @@ export default function CollectionsConfigForm({
                 }
                 className={`flex flex-col items-center gap-1 rounded-xl py-3 px-3 border text-xs font-medium transition-all ${
                   form.visibilityDefaults[key]
-                    ? "bg-primary/10 border-primary/30 text-primary"
-                    : "bg-surface-container-low border-outline-variant/20 text-on-surface-variant"
+                    ? "bg-primary-dim border-primary-dim text-on-surface"
+                    : "bg-background-container-low border-outline-variant/20 text-on-surface-variant"
                 }`}
               >
                 <div className={`w-3 h-3 rounded-full border-2 mb-0.5 flex-shrink-0 transition-all ${
                   form.visibilityDefaults[key]
-                    ? "bg-primary border-primary"
+                    ? "bg-on-surface border-on-surface"
                     : "border-outline-variant"
                 }`} />
                 {label.split(" ").map((word, i) => (

--- a/src/client/components/FormControls.tsx
+++ b/src/client/components/FormControls.tsx
@@ -14,7 +14,7 @@ export function SectionCard({
 }) {
   return (
     <div
-      className={`bg-surface-container rounded-2xl border border-outline-variant/20 p-5 ${
+      className={`bg-background-container rounded-2xl border border-outline-variant/20 p-5 ${
         wide ? "w-full" : ""
       }`}
     >
@@ -64,7 +64,7 @@ export function TextInput({
       value={value}
       onChange={(event) => onChange(event.target.value)}
       placeholder={placeholder}
-      className="w-full bg-surface-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
+      className="w-full bg-background-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
     />
   );
 }
@@ -82,7 +82,7 @@ export function SelectInput({
     <select
       value={value}
       onChange={(event) => onChange(event.target.value)}
-      className="w-full bg-surface-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm focus:outline-none focus:border-primary/50"
+      className="w-full bg-background-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm focus:outline-none focus:border-primary/50"
     >
       {children}
     </select>
@@ -113,12 +113,12 @@ export function ToggleField({
         />
         <div
           className={`w-10 h-6 rounded-full transition-colors ${
-            checked ? "bg-primary" : "bg-outline-variant"
+            checked ? "bg-primary-dim" : "bg-outline-variant"
           }`}
         />
         <div
           className={`absolute top-1 w-4 h-4 rounded-full transition-all ${
-            checked ? "bg-white translate-x-5" : "bg-on-surface-variant translate-x-1"
+            checked ? "bg-on-surface translate-x-5" : "bg-on-surface-variant translate-x-1"
           }`}
         />
       </div>
@@ -156,7 +156,7 @@ export function SaveBar({
     <button
       disabled={saving}
       onClick={onSave}
-      className="flex items-center gap-2 bg-primary hover:bg-primary-dim disabled:opacity-50 text-on-primary text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
+      className="flex items-center gap-2 bg-primary-dim hover:bg-primary disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
     >
       {saving ? "Saving..." : label}
       {!saving && <ChevronRight size={15} />}
@@ -168,7 +168,7 @@ export function SaveBar({
       <div className="flex items-center justify-between pt-2">
         <button
           onClick={onBack}
-          className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+          className="flex items-center gap-1 bg-background-container-high hover:bg-background-bright text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
         >
           <ChevronLeft size={15} />
           Back

--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -31,10 +31,10 @@ export default function Layout({ user, onLogout }: LayoutProps) {
 
       <div className="md:ml-64 min-h-screen">
         {/* Mobile top bar */}
-        <div className="md:hidden flex items-center gap-3 px-4 py-3 bg-surface-container-low border-b border-outline-variant/20 sticky top-0 z-20">
+        <div className="md:hidden flex items-center gap-3 px-4 py-3 bg-background-container-low border-b border-outline-variant/20 sticky top-0 z-20">
           <button
             onClick={() => setMobileOpen((o) => !o)}
-            className="p-1.5 rounded-lg text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface transition-colors"
+            className="p-1.5 rounded-lg text-on-surface-variant hover:bg-background-container-high hover:text-on-surface transition-colors"
           >
             <Menu size={20} />
           </button>

--- a/src/client/components/PlexConfigForm.tsx
+++ b/src/client/components/PlexConfigForm.tsx
@@ -151,7 +151,7 @@ export default function PlexConfigForm({
             type="button"
             disabled={loadingServers}
             onClick={() => void loadServers()}
-            className="flex items-center justify-center gap-2 bg-surface-container-high hover:bg-surface-bright disabled:opacity-50 text-on-surface text-sm font-medium rounded-xl px-4 py-2.5 transition-colors border border-outline-variant/20"
+            className="flex items-center justify-center gap-2 bg-background-container-high hover:bg-background-bright disabled:opacity-50 text-on-surface text-sm font-medium rounded-xl px-4 py-2.5 transition-colors border border-outline-variant/20"
             aria-label="Load available servers"
           >
             <RefreshCw size={15} className={loadingServers ? "animate-spin" : ""} />
@@ -161,8 +161,8 @@ export default function PlexConfigForm({
 
       <div className="grid grid-cols-1 md:grid-cols-[1fr_140px] gap-4">
         <Field label="Hostname or IP Address*">
-          <div className="flex rounded-lg border border-outline-variant/30 overflow-hidden bg-surface-container-low">
-            <div className="px-3 py-2 text-sm text-on-surface-variant bg-surface-container-high border-r border-outline-variant/20">
+          <div className="flex rounded-lg border border-outline-variant/30 overflow-hidden bg-background-container-low">
+            <div className="px-3 py-2 text-sm text-on-surface-variant bg-background-container-high border-r border-outline-variant/20">
               {useSsl ? "https://" : "http://"}
             </div>
             <input
@@ -200,7 +200,7 @@ export default function PlexConfigForm({
             <button
               type="button"
               onClick={onBack}
-              className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+              className="flex items-center gap-1 bg-background-container-high hover:bg-background-bright text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
             >
               <ChevronLeft size={15} />
               Back
@@ -210,7 +210,7 @@ export default function PlexConfigForm({
             type="button"
             onClick={() => void testConnection()}
             disabled={testing || (!selectedServerUri && !manualConfigValid)}
-            className="bg-surface-container-high hover:bg-surface-bright disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+            className="bg-background-container-high hover:bg-background-bright disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
           >
             {testing ? "Testing..." : "Test Connection"}
           </button>
@@ -227,7 +227,7 @@ export default function PlexConfigForm({
             type="button"
             disabled={saving}
             onClick={() => void save()}
-            className="flex items-center gap-2 bg-primary hover:bg-primary-dim disabled:opacity-50 text-on-primary text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
+            className="flex items-center gap-2 bg-primary-dim hover:bg-primary disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
           >
             {saving ? "Saving..." : saveLabel}
             {!saving && <ChevronRight size={15} />}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -47,7 +47,7 @@ export default function Sidebar({ user, onLogout, mobileOpen, onMobileClose }: S
 
   return (
     <aside
-      className={`fixed inset-y-0 left-0 w-64 flex flex-col bg-surface-container-low border-r border-outline-variant/20 z-40 transition-transform duration-300
+      className={`fixed inset-y-0 left-0 w-64 flex flex-col bg-background-container-low border-r border-outline-variant/20 z-40 transition-transform duration-300
         md:translate-x-0 ${mobileOpen ? "translate-x-0" : "-translate-x-full"}`}
     >
       {/* Logo */}
@@ -69,8 +69,8 @@ export default function Sidebar({ user, onLogout, mobileOpen, onMobileClose }: S
             className={({ isActive }) =>
               `flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
                 isActive
-                  ? "bg-primary/10 text-primary"
-                  : "text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface"
+                  ? "bg-primary-dim text-on-surface"
+                  : "text-on-surface-variant hover:bg-background-container-high hover:text-on-surface"
               }`
             }
           >
@@ -86,7 +86,7 @@ export default function Sidebar({ user, onLogout, mobileOpen, onMobileClose }: S
           <div className="relative">
             {/* Popup */}
             {popupOpen && (
-              <div className="absolute bottom-full left-0 right-0 mb-2 bg-surface-container-high border border-outline-variant/30 rounded-xl shadow-lg overflow-hidden">
+              <div className="absolute bottom-full left-0 right-0 mb-2 bg-background-container-high border border-outline-variant/30 rounded-xl shadow-lg overflow-hidden">
                 <div className="px-4 py-3 border-b border-outline-variant/20">
                   <div className="text-sm font-medium text-on-surface truncate">{user.username}</div>
                   {user.email && (
@@ -95,7 +95,7 @@ export default function Sidebar({ user, onLogout, mobileOpen, onMobileClose }: S
                 </div>
                 <button
                   onClick={() => { setPopupOpen(false); onLogout(); }}
-                  className="flex w-full items-center gap-3 px-4 py-2.5 text-sm font-medium text-on-surface-variant hover:bg-surface-container-highest hover:text-on-surface transition-colors"
+                  className="flex w-full items-center gap-3 px-4 py-2.5 text-sm font-medium text-on-surface-variant hover:bg-background-container-highest hover:text-on-surface transition-colors"
                 >
                   <LogOut size={16} strokeWidth={1.75} />
                   Sign out
@@ -106,7 +106,7 @@ export default function Sidebar({ user, onLogout, mobileOpen, onMobileClose }: S
             {/* User button */}
             <button
               onClick={() => setPopupOpen((o) => !o)}
-              className="flex w-full items-center gap-3 px-3 py-2 rounded-lg hover:bg-surface-container-high transition-colors"
+              className="flex w-full items-center gap-3 px-3 py-2 rounded-lg hover:bg-background-container-high transition-colors"
             >
               {getPlexImageSrc(user.avatarUrl) ? (
                 <img
@@ -115,7 +115,7 @@ export default function Sidebar({ user, onLogout, mobileOpen, onMobileClose }: S
                   className="w-8 h-8 rounded-full object-cover flex-shrink-0"
                 />
               ) : (
-                <div className="w-8 h-8 rounded-full bg-surface-container-highest flex items-center justify-center flex-shrink-0">
+                <div className="w-8 h-8 rounded-full bg-background-container-highest flex items-center justify-center flex-shrink-0">
                   <span className="text-on-surface-variant text-xs font-medium">
                     {user.displayName.charAt(0).toUpperCase()}
                   </span>
@@ -169,7 +169,7 @@ function VersionFooter({ onMobileClose }: { onMobileClose: () => void }) {
     return (
       <div className="px-3 pb-3">
         <div className="flex items-center gap-3 px-3 py-2.5 rounded-lg">
-          <div className="w-8 h-8 rounded-lg bg-surface-container-highest flex-shrink-0" />
+          <div className="w-8 h-8 rounded-lg bg-background-container-highest flex-shrink-0" />
           <div className="flex-1 min-w-0">
             <div className="text-xs font-semibold text-on-surface-variant leading-tight">Hubarr</div>
             <div className="text-xs text-on-surface-variant leading-tight mt-0.5">...</div>
@@ -193,9 +193,9 @@ function VersionFooter({ onMobileClose }: { onMobileClose: () => void }) {
       <Link
         to="/settings?tab=about"
         onClick={onMobileClose}
-        className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-surface-container-high transition-colors group"
+        className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-background-container-high transition-colors group"
       >
-        <div className="w-8 h-8 rounded-lg bg-surface-container-highest flex items-center justify-center flex-shrink-0">
+        <div className="w-8 h-8 rounded-lg bg-background-container-highest flex items-center justify-center flex-shrink-0">
           <Icon size={16} strokeWidth={1.75} className="text-on-surface-variant group-hover:text-on-surface transition-colors" />
         </div>
         <div className="flex-1 min-w-0">

--- a/src/client/components/WatchlistItemModal.tsx
+++ b/src/client/components/WatchlistItemModal.tsx
@@ -217,11 +217,11 @@ export function WatchlistItemModal({
       onClick={onClose}
     >
       <div
-        className="bg-surface-container rounded-2xl w-full max-w-2xl border border-outline-variant/20 shadow-xl overflow-hidden flex max-h-[88vh]"
+        className="bg-background-container rounded-2xl w-full max-w-2xl border border-outline-variant/20 shadow-xl overflow-hidden flex max-h-[88vh]"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Left: poster */}
-        <div className="w-44 flex-shrink-0 self-stretch bg-surface-container-high">
+        <div className="w-44 flex-shrink-0 self-stretch bg-background-container-high">
           {posterSrc ? (
             <img
               src={posterSrc}
@@ -246,7 +246,7 @@ export function WatchlistItemModal({
           <div className="flex justify-end p-3 pb-0">
             <button
               onClick={onClose}
-              className="p-1.5 rounded-lg bg-surface-container-high text-on-surface-variant hover:text-on-surface hover:bg-surface-container-highest transition-colors"
+              className="p-1.5 rounded-lg bg-background-container-high text-on-surface-variant hover:text-on-surface hover:bg-background-container-highest transition-colors"
             >
               <X size={16} />
             </button>
@@ -303,7 +303,7 @@ export function WatchlistItemModal({
             {enrichLoading ? (
               <div className="flex gap-1.5 mb-3">
                 {[60, 72, 50].map((w) => (
-                  <div key={w} className="h-5 rounded-full bg-surface-container-high animate-pulse" style={{ width: w }} />
+                  <div key={w} className="h-5 rounded-full bg-background-container-high animate-pulse" style={{ width: w }} />
                 ))}
               </div>
             ) : rich?.genres && rich.genres.length > 0 ? (
@@ -311,7 +311,7 @@ export function WatchlistItemModal({
                 {rich.genres.map((genre) => (
                   <span
                     key={genre}
-                    className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-surface-container-high text-on-surface-variant text-xs"
+                    className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-background-container-high text-on-surface-variant text-xs"
                   >
                     <Tag size={10} />
                     {genre}
@@ -328,9 +328,9 @@ export function WatchlistItemModal({
             {/* Summary */}
             {enrichLoading ? (
               <div className="space-y-1.5 mb-4">
-                <div className="h-3 rounded bg-surface-container-high animate-pulse w-full" />
-                <div className="h-3 rounded bg-surface-container-high animate-pulse w-5/6" />
-                <div className="h-3 rounded bg-surface-container-high animate-pulse w-4/6" />
+                <div className="h-3 rounded bg-background-container-high animate-pulse w-full" />
+                <div className="h-3 rounded bg-background-container-high animate-pulse w-5/6" />
+                <div className="h-3 rounded bg-background-container-high animate-pulse w-4/6" />
               </div>
             ) : rich?.summary ? (
               <p className="text-on-surface-variant text-sm leading-relaxed mb-4">
@@ -383,7 +383,7 @@ export function WatchlistItemModal({
                           className="w-6 h-6 rounded-full object-cover flex-shrink-0"
                         />
                       ) : (
-                        <div className="w-6 h-6 rounded-full bg-surface-container-highest flex items-center justify-center flex-shrink-0">
+                        <div className="w-6 h-6 rounded-full bg-background-container-highest flex items-center justify-center flex-shrink-0">
                           <span className="text-on-surface-variant text-xs">
                             {user.displayName.charAt(0).toUpperCase()}
                           </span>
@@ -413,7 +413,7 @@ export function WatchlistItemModal({
                         className="w-6 h-6 rounded-full object-cover flex-shrink-0 opacity-70"
                       />
                     ) : (
-                      <div className="w-6 h-6 rounded-full bg-surface-container-highest flex items-center justify-center flex-shrink-0 opacity-70">
+                      <div className="w-6 h-6 rounded-full bg-background-container-highest flex items-center justify-center flex-shrink-0 opacity-70">
                         <span className="text-on-surface-variant text-xs">
                           {externalRequester.displayName.charAt(0).toUpperCase()}
                         </span>
@@ -428,7 +428,7 @@ export function WatchlistItemModal({
                 {/* Ghost row: item is in Seerr/Radarr but was not requested by any specific user */}
                 {isUnknownRequester && (
                   <div className="flex items-center gap-2.5 border-t border-outline-variant/10 pt-2 mt-0.5">
-                    <div className="w-6 h-6 rounded-full bg-surface-container-highest flex items-center justify-center flex-shrink-0 opacity-70">
+                    <div className="w-6 h-6 rounded-full bg-background-container-highest flex items-center justify-center flex-shrink-0 opacity-70">
                       <span className="text-on-surface-variant text-xs">?</span>
                     </div>
                     <span className="text-on-surface-variant text-sm flex-1 min-w-0 truncate italic">Unknown</span>

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -32,6 +32,9 @@
   --overlay-poster: rgba(13, 14, 18, 0.95);
   /* Derived from --color-background (#0d0e12) at 0% opacity */
   --overlay-poster-transparent: rgba(13, 14, 18, 0);
+  /* Opaque dark halos for availability icons on poster cards */
+  --poster-halo-success: #0a3d1f;
+  --poster-halo-error: #3d0a0a;
 }
 
 @layer base {

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -22,7 +22,16 @@
 
   --color-success: #22c55e;
   --color-warning: #f59e0b;
-  --color-error: #f06060;
+  --color-error: #f07070;
+}
+
+:root {
+  /* Derived from --color-background-container (#18191e) at 60% opacity */
+  --overlay-glass: rgba(24, 25, 30, 0.6);
+  /* Derived from --color-background (#0d0e12) at 95% opacity */
+  --overlay-poster: rgba(13, 14, 18, 0.95);
+  /* Derived from --color-background (#0d0e12) at 0% opacity */
+  --overlay-poster-transparent: rgba(13, 14, 18, 0);
 }
 
 @layer base {
@@ -40,12 +49,12 @@
 }
 
 .glass-panel {
-  background: rgba(24, 25, 30, 0.6);
+  background: var(--overlay-glass);
   backdrop-filter: blur(20px);
 }
 
 .poster-gradient {
-  background: linear-gradient(to top, rgba(13, 14, 18, 0.95) 0%, rgba(13, 14, 18, 0) 60%);
+  background: linear-gradient(to top, var(--overlay-poster) 0%, var(--overlay-poster-transparent) 60%);
 }
 
 .no-scrollbar::-webkit-scrollbar {

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -6,18 +6,15 @@
   --font-headline: "Manrope", sans-serif;
 
   --color-background: #0d0e12;
-  --color-surface: #0d0e12;
-  --color-surface-container-low: #121318;
-  --color-surface-container: #18191e;
-  --color-surface-container-high: #1e1f25;
-  --color-surface-container-highest: #24252b;
-  --color-surface-bright: #2a2c32;
+  --color-background-container-low: #121318;
+  --color-background-container: #18191e;
+  --color-background-container-high: #1e1f25;
+  --color-background-container-highest: #24252b;
+  --color-background-bright: #2a2c32;
 
   --color-primary: #e50914;
-  --color-primary-dim: #b10610;
-  --color-on-primary: #ffffff;
+  --color-primary-dim: #ae0610;
 
-  --color-secondary: #d8e3fa;
   --color-on-surface: #faf8fe;
   --color-on-surface-variant: #abaab0;
 
@@ -25,7 +22,7 @@
 
   --color-success: #22c55e;
   --color-warning: #f59e0b;
-  --color-error: #ef4444;
+  --color-error: #f06060;
 }
 
 @layer base {

--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -92,7 +92,7 @@ export default function Dashboard() {
         <button
           disabled={syncing}
           onClick={() => void runFullSync()}
-          className="flex items-center gap-2 bg-surface-container-high hover:bg-surface-bright disabled:opacity-50 text-on-surface text-sm font-medium rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+          className="flex items-center gap-2 bg-background-container-high hover:bg-background-bright disabled:opacity-50 text-on-surface text-sm font-medium rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
         >
           <RefreshCw size={15} className={syncing ? "animate-spin" : ""} />
           {syncing ? "Syncing..." : "Run Sync"}
@@ -120,7 +120,7 @@ export default function Dashboard() {
           {/* Recent sync activity */}
           <Link
             to="/history"
-            className="sm:w-80 flex-shrink-0 bg-surface-container rounded-xl border border-outline-variant/20 px-4 py-2.5 hover:bg-surface-container-high transition-colors group"
+            className="sm:w-80 flex-shrink-0 bg-background-container rounded-xl border border-outline-variant/20 px-4 py-2.5 hover:bg-background-container-high transition-colors group"
           >
             <div className="flex items-center justify-between mb-2">
               <span className="text-xs font-medium text-on-surface-variant uppercase tracking-wide">Recent Syncs</span>
@@ -157,7 +157,7 @@ export default function Dashboard() {
             ))}
           </div>
         ) : (
-          <div className="bg-surface-container rounded-2xl border border-outline-variant/20 flex items-center justify-center py-10">
+          <div className="bg-background-container rounded-2xl border border-outline-variant/20 flex items-center justify-center py-10">
             <p className="text-on-surface-variant text-sm">No items recently added. Run a sync to populate watchlists.</p>
           </div>
         )}
@@ -184,7 +184,7 @@ function StatChip({
   return (
     <Link
       to={to}
-      className="flex-1 flex flex-col items-center justify-center gap-0.5 bg-surface-container hover:bg-surface-container-high rounded-xl px-4 py-2.5 border border-outline-variant/20 transition-colors text-center"
+      className="flex-1 flex flex-col items-center justify-center gap-0.5 bg-background-container hover:bg-background-container-high rounded-xl px-4 py-2.5 border border-outline-variant/20 transition-colors text-center"
     >
       <div className="flex items-center gap-1.5 text-primary">
         {icon}
@@ -276,7 +276,7 @@ function PosterCard({
 
   return (
     <button onClick={onClick} className="group text-left w-full">
-      <div className="relative aspect-[2/3] rounded-lg overflow-hidden bg-surface-container-high transition-transform duration-300 group-hover:scale-105">
+      <div className="relative aspect-[2/3] rounded-lg overflow-hidden bg-background-container-high transition-transform duration-300 group-hover:scale-105">
         {posterSrc ? (
           <img
             src={posterSrc}
@@ -306,7 +306,7 @@ function PosterCard({
               <CheckCircle size={18} className="relative text-success drop-shadow-[0_0_4px_rgba(0,0,0,1)]" />
             </div>
           ) : seerrEnabled && item.seerrRequested ? (
-            <div className="relative w-[18px] h-[18px] rounded-full bg-surface-container-highest border border-outline-variant/40 flex items-center justify-center drop-shadow-[0_0_4px_rgba(0,0,0,1)]">
+            <div className="relative w-[18px] h-[18px] rounded-full bg-background-container-highest border border-outline-variant/40 flex items-center justify-center drop-shadow-[0_0_4px_rgba(0,0,0,1)]">
               <img src="/seerr-icon.svg" alt="Requested in Seerr" className="w-3 h-3" />
             </div>
           ) : (

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -122,8 +122,8 @@ export default function History() {
               onClick={() => setParam("type", k, true)}
               className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                 kind === k
-                  ? "bg-primary/15 text-primary"
-                  : "bg-surface-container text-on-surface-variant hover:text-on-surface"
+                  ? "bg-primary-dim text-on-surface"
+                  : "bg-background-container text-on-surface-variant hover:text-on-surface"
               }`}
             >
               {k === "all" ? "All types" : KIND_LABELS[k] ?? k}
@@ -139,8 +139,8 @@ export default function History() {
               onClick={() => setParam("status", s, true)}
               className={`px-3 py-1.5 text-xs font-medium capitalize transition-colors ${
                 status === s
-                  ? "bg-primary/15 text-primary"
-                  : "bg-surface-container text-on-surface-variant hover:text-on-surface"
+                  ? "bg-primary-dim text-on-surface"
+                  : "bg-background-container text-on-surface-variant hover:text-on-surface"
               }`}
             >
               {s === "all" ? "All status" : titleCaseStatus(s)}
@@ -152,7 +152,7 @@ export default function History() {
         <select
           value={pageSize}
           onChange={(e) => setParam("pageSize", e.target.value, true)}
-          className="ml-auto px-3 py-1.5 rounded-lg bg-surface-container border border-outline-variant/30 text-xs text-on-surface focus:outline-none"
+          className="ml-auto px-3 py-1.5 rounded-lg bg-background-container border border-outline-variant/30 text-xs text-on-surface focus:outline-none"
         >
           {[10, 25, 50, 100].map((n) => (
             <option key={n} value={n}>{n} / page</option>
@@ -177,7 +177,7 @@ export default function History() {
           ))}
         </div>
       ) : (
-        <div className="bg-surface-container rounded-2xl border border-outline-variant/20 flex items-center justify-center py-16 text-center">
+        <div className="bg-background-container rounded-2xl border border-outline-variant/20 flex items-center justify-center py-16 text-center">
           <p className="text-on-surface-variant text-sm max-w-xs">
             No sync history matches the current filter.
           </p>
@@ -194,7 +194,7 @@ export default function History() {
             <button
               disabled={page <= 1}
               onClick={() => setParam("page", String(page - 1))}
-              className="p-1.5 rounded-lg bg-surface-container disabled:opacity-40 hover:bg-surface-container-high transition-colors"
+              className="p-1.5 rounded-lg bg-background-container disabled:opacity-40 hover:bg-background-container-high transition-colors"
             >
               <ChevronLeft size={14} />
             </button>
@@ -202,7 +202,7 @@ export default function History() {
             <button
               disabled={page >= pageInfo.pages}
               onClick={() => setParam("page", String(page + 1))}
-              className="p-1.5 rounded-lg bg-surface-container disabled:opacity-40 hover:bg-surface-container-high transition-colors"
+              className="p-1.5 rounded-lg bg-background-container disabled:opacity-40 hover:bg-background-container-high transition-colors"
             >
               <ChevronRight size={14} />
             </button>
@@ -594,7 +594,7 @@ function RunRow({ run }: { run: SyncRun }) {
     },
     idle: {
       icon: <AlertCircle size={18} className="text-on-surface-variant" />,
-      badge: "text-on-surface-variant bg-surface-container-high border-outline-variant/20"
+      badge: "text-on-surface-variant bg-background-container-high border-outline-variant/20"
     }
   };
 
@@ -602,10 +602,10 @@ function RunRow({ run }: { run: SyncRun }) {
   const durationText = formatRunDuration(liveRun, now);
 
   return (
-    <div className="bg-surface-container rounded-xl border border-outline-variant/20 overflow-hidden">
+    <div className="bg-background-container rounded-xl border border-outline-variant/20 overflow-hidden">
       <button
         onClick={handleExpand}
-        className="w-full flex items-center gap-4 p-4 text-left hover:bg-surface-container-high/50 transition-colors"
+        className="w-full flex items-center gap-4 p-4 text-left hover:bg-background-container-high/50 transition-colors"
       >
         {config.icon}
         <div className="flex-1 min-w-0">
@@ -631,7 +631,7 @@ function RunRow({ run }: { run: SyncRun }) {
       </button>
 
       {expanded && (
-        <div className="border-t border-outline-variant/20 bg-surface-container-low">
+        <div className="border-t border-outline-variant/20 bg-background-container-low">
           {/* Run metadata */}
           <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs px-4 py-3">
             <div>
@@ -827,7 +827,7 @@ function MatchFailureRow({ item }: { item: SyncRunItem }) {
             ) : (
               <div className="space-y-1">
                 {candidates.map((c, i) => (
-                  <div key={i} className="bg-surface-container rounded px-2 py-1 space-y-0.5">
+                  <div key={i} className="bg-background-container rounded px-2 py-1 space-y-0.5">
                     <div className="flex items-baseline gap-2">
                       <span className="text-on-surface font-medium">{c.title}</span>
                       {c.year && <span className="text-on-surface-variant/60">({c.year})</span>}
@@ -879,7 +879,7 @@ function StepsCollapsible({ items }: { items: HistoryStep[] }) {
       {open && (
         <div className="mt-2 space-y-1">
           {items.map((item) => (
-            <div key={item.id} className="flex items-center gap-2 text-xs px-2 py-1 rounded-lg bg-surface-container/50">
+            <div key={item.id} className="flex items-center gap-2 text-xs px-2 py-1 rounded-lg bg-background-container/50">
               <CheckCircle size={12} className="text-success flex-shrink-0" />
               <span className="text-on-surface-variant">{item.label}</span>
               {item.meta && (

--- a/src/client/pages/Login.tsx
+++ b/src/client/pages/Login.tsx
@@ -36,7 +36,7 @@ export default function Login({ onAuthenticated }: LoginProps) {
         </div>
 
         {/* Card */}
-        <div className="bg-surface-container rounded-2xl p-6 border border-outline-variant/20">
+        <div className="bg-background-container rounded-2xl p-6 border border-outline-variant/20">
           <h2 className="font-headline font-semibold text-lg text-on-surface mb-6 text-center">Sign in to continue</h2>
 
           {error && (
@@ -48,7 +48,7 @@ export default function Login({ onAuthenticated }: LoginProps) {
           <button
             disabled={busy}
             onClick={() => void handlePlexLogin()}
-            className="w-full flex items-center justify-center gap-3 bg-primary hover:bg-primary-dim disabled:opacity-50 disabled:cursor-not-allowed text-on-primary font-semibold rounded-xl px-4 py-3 transition-colors"
+            className="w-full flex items-center justify-center gap-3 bg-primary-dim hover:bg-primary disabled:opacity-50 disabled:cursor-not-allowed text-on-surface font-semibold rounded-xl px-4 py-3 transition-colors"
           >
             {busy ? (
               <span>Waiting for Plex...</span>

--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -97,7 +97,7 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
         </div>
 
         {step === "auth" && (
-          <div className="bg-surface-container rounded-2xl p-6 border border-outline-variant/20 max-w-xl mx-auto">
+          <div className="bg-background-container rounded-2xl p-6 border border-outline-variant/20 max-w-xl mx-auto">
             <h2 className="font-headline font-semibold text-lg text-on-surface mb-1">
               Sign in with Plex
             </h2>
@@ -114,7 +114,7 @@ export default function Onboarding({ authenticated = false, onComplete }: Onboar
             <button
               disabled={authBusy}
               onClick={() => void handlePlexAuth()}
-              className="w-full flex items-center justify-center gap-3 bg-primary hover:bg-primary-dim disabled:opacity-50 disabled:cursor-not-allowed text-on-primary font-semibold rounded-xl px-4 py-3 transition-colors"
+              className="w-full flex items-center justify-center gap-3 bg-primary-dim hover:bg-primary disabled:opacity-50 disabled:cursor-not-allowed text-on-surface font-semibold rounded-xl px-4 py-3 transition-colors"
             >
               {authBusy ? "Waiting for Plex..." : "Sign in with Plex"}
               {!authBusy && <ChevronRight size={18} />}
@@ -308,7 +308,7 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
   const noneSelected = selectedIds.size === 0;
 
   return (
-    <div className="bg-surface-container rounded-2xl p-6 border border-outline-variant/20 max-w-2xl mx-auto">
+    <div className="bg-background-container rounded-2xl p-6 border border-outline-variant/20 max-w-2xl mx-auto">
       <h2 className="font-headline font-semibold text-lg text-on-surface mb-1">
         Choose Your Users
       </h2>
@@ -365,7 +365,7 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
         <button
           disabled={saving}
           onClick={onBack}
-          className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright disabled:opacity-50 disabled:cursor-not-allowed text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+          className="flex items-center gap-1 bg-background-container-high hover:bg-background-bright disabled:opacity-50 disabled:cursor-not-allowed text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
         >
           <ChevronLeft size={15} />
           Back
@@ -373,7 +373,7 @@ function UsersOnboardingStep({ onBack, onSaved }: { onBack: () => void; onSaved:
         <button
           disabled={saving}
           onClick={() => void save()}
-          className="flex items-center gap-2 bg-primary hover:bg-primary-dim disabled:opacity-50 disabled:cursor-not-allowed text-on-primary font-semibold rounded-xl px-5 py-2.5 text-sm transition-colors"
+          className="flex items-center gap-2 bg-primary-dim hover:bg-primary disabled:opacity-50 disabled:cursor-not-allowed text-on-surface font-semibold rounded-xl px-5 py-2.5 text-sm transition-colors"
         >
           {saving ? (
             <>
@@ -418,7 +418,7 @@ function UserSelectCard({
       className={`flex flex-col items-center gap-2 p-3 rounded-xl w-24 transition-all disabled:opacity-60 disabled:cursor-not-allowed ${
         selected
           ? "bg-primary/10 ring-1 ring-primary/40"
-          : "hover:bg-surface-container-high ring-1 ring-transparent"
+          : "hover:bg-background-container-high ring-1 ring-transparent"
       }`}
     >
       <div className="relative w-14 h-14 shrink-0">
@@ -440,7 +440,7 @@ function UserSelectCard({
 
         {selected && (
           <div className="absolute -bottom-0.5 -right-0.5 w-5 h-5 rounded-full bg-primary flex items-center justify-center">
-            <Check size={11} className="text-on-primary" />
+            <Check size={11} className="text-on-surface" />
           </div>
         )}
       </div>
@@ -599,7 +599,7 @@ function PreloadStep({ onComplete }: { onComplete: () => Promise<void> }) {
   }
 
   return (
-    <div className="bg-surface-container rounded-2xl p-6 border border-outline-variant/20 max-w-xl mx-auto">
+    <div className="bg-background-container rounded-2xl p-6 border border-outline-variant/20 max-w-xl mx-auto">
       <h2 className="font-headline font-semibold text-lg text-on-surface mb-1">
         Getting Hubarr Ready
       </h2>
@@ -680,7 +680,7 @@ function PreloadPhaseRow({ label, state }: { label: string; state: PhaseState })
           </p>
         )}
         {showProgress && (
-          <div className="mt-1.5 h-1 rounded-full bg-surface-container-high overflow-hidden">
+          <div className="mt-1.5 h-1 rounded-full bg-background-container-high overflow-hidden">
             <div
               className="h-full bg-primary rounded-full transition-all duration-300"
               style={{ width: `${progressPercent}%` }}
@@ -784,8 +784,8 @@ function StepDot({
           done
             ? "bg-success text-white"
             : active
-            ? "bg-primary text-on-primary"
-            : "bg-surface-container-high text-on-surface-variant"
+            ? "bg-primary-dim text-on-surface"
+            : "bg-background-container-high text-on-surface-variant"
         }`}
       >
         {done ? <Check size={14} /> : number}

--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -60,7 +60,7 @@ export default function Settings() {
         <select
           value={activeTab}
           onChange={(e) => setTab(e.target.value as Tab)}
-          className="w-full bg-surface-container-high border border-outline-variant/20 rounded-xl px-4 py-2.5 text-sm font-medium text-on-surface focus:outline-none focus:border-primary/50"
+          className="w-full bg-background-container-high border border-outline-variant/20 rounded-xl px-4 py-2.5 text-sm font-medium text-on-surface focus:outline-none focus:border-primary/50"
         >
           {TABS.map((tab) => (
             <option key={tab.id} value={tab.id}>{tab.label}</option>
@@ -70,14 +70,14 @@ export default function Settings() {
 
       {/* Desktop: pill bar */}
       <div className="hidden md:block mb-6">
-        <div className="flex p-1 bg-surface-container-high rounded-xl gap-1">
+        <div className="flex p-1 bg-background-container-high rounded-xl gap-1">
           {TABS.map((tab) => (
             <button
               key={tab.id}
               onClick={() => setTab(tab.id)}
               className={`flex-1 text-sm font-medium rounded-lg px-4 py-2 transition-all whitespace-nowrap ${
                 activeTab === tab.id
-                  ? "bg-surface-container text-on-surface shadow-sm"
+                  ? "bg-background-container text-on-surface shadow-sm"
                   : "text-on-surface-variant hover:text-on-surface"
               }`}
             >
@@ -237,7 +237,7 @@ function GeneralTab({
   return (
     <div className="space-y-5">
       {/* Settings card */}
-      <div className="bg-surface-container rounded-2xl border border-outline-variant/20 p-5">
+      <div className="bg-background-container rounded-2xl border border-outline-variant/20 p-5">
         <h3 className="font-headline font-semibold text-base text-on-surface mb-1">Settings</h3>
         <p className="text-xs text-on-surface-variant mb-4">Changes to proxy support require a container restart to take effect.</p>
         <div className="space-y-4">
@@ -283,7 +283,7 @@ function GeneralTab({
                     historyRetentionDays: Math.max(1, Math.floor(Number(e.target.value) || 1))
                   }))
                 }
-                className="w-28 bg-surface-container-low border border-outline-variant/30 rounded-xl px-3 py-2 text-sm text-on-surface focus:outline-none focus:border-primary"
+                className="w-28 bg-background-container-low border border-outline-variant/30 rounded-xl px-3 py-2 text-sm text-on-surface focus:outline-none focus:border-primary"
               />
               <span className="text-sm text-on-surface-variant">days</span>
             </div>
@@ -296,12 +296,12 @@ function GeneralTab({
       </div>
 
       {/* Maintenance card */}
-      <div className="bg-surface-container rounded-2xl border border-outline-variant/20 p-5">
+      <div className="bg-background-container rounded-2xl border border-outline-variant/20 p-5">
         <h3 className="font-headline font-semibold text-base text-on-surface mb-4">Maintenance</h3>
         <div className="space-y-3">
 
           {/* Reset Collections */}
-          <div className="flex items-start justify-between gap-4 p-4 bg-surface-container-low rounded-xl border border-outline-variant/15">
+          <div className="flex items-start justify-between gap-4 p-4 bg-background-container-low rounded-xl border border-outline-variant/15">
             <div className="flex-1 min-w-0">
               <div className="text-sm font-medium text-on-surface mb-0.5">Reset Collections</div>
               <div className="text-xs text-on-surface-variant leading-relaxed">
@@ -318,8 +318,8 @@ function GeneralTab({
                 onClick={() => void resetCollections()}
                 className={`relative z-20 text-sm font-semibold rounded-xl px-4 py-2 min-w-[120px] transition-colors disabled:opacity-50 ${
                   confirmReset
-                    ? "bg-error text-white animate-pulse hover:bg-error/90"
-                    : "bg-surface-container-high hover:bg-surface-bright border border-error/40 text-error"
+                    ? "bg-primary-dim text-on-surface animate-pulse hover:bg-primary"
+                    : "bg-background-container-high hover:bg-background-bright border border-error/40 text-error"
                 }`}
               >
                 {resetting ? "Resetting…" : confirmReset ? "Are you sure?" : "Reset"}
@@ -328,7 +328,7 @@ function GeneralTab({
           </div>
 
           {/* Image Cache */}
-          <div className="flex items-start justify-between gap-4 p-4 bg-surface-container-low rounded-xl border border-outline-variant/15">
+          <div className="flex items-start justify-between gap-4 p-4 bg-background-container-low rounded-xl border border-outline-variant/15">
             <div className="flex-1 min-w-0">
               <div className="text-sm font-medium text-on-surface mb-0.5">Image Cache</div>
               <div className="text-xs text-on-surface-variant leading-relaxed">
@@ -339,14 +339,14 @@ function GeneralTab({
             <button
               disabled={clearingCache}
               onClick={() => void clearImageCache()}
-              className="flex-shrink-0 text-sm font-semibold rounded-xl px-4 py-2 min-w-[120px] transition-colors disabled:opacity-50 bg-surface-container-high hover:bg-surface-bright border border-outline-variant/30 text-on-surface"
+              className="flex-shrink-0 text-sm font-semibold rounded-xl px-4 py-2 min-w-[120px] transition-colors disabled:opacity-50 bg-background-container-high hover:bg-background-bright border border-outline-variant/30 text-on-surface"
             >
               {clearingCache ? "Clearing…" : "Clear Cache"}
             </button>
           </div>
 
           {/* Activity Cache */}
-          <div className="flex items-start justify-between gap-4 p-4 bg-surface-container-low rounded-xl border border-outline-variant/15">
+          <div className="flex items-start justify-between gap-4 p-4 bg-background-container-low rounded-xl border border-outline-variant/15">
             <div className="flex-1 min-w-0">
               <div className="text-sm font-medium text-on-surface mb-0.5">Activity Cache</div>
               <div className="text-xs text-on-surface-variant leading-relaxed">
@@ -357,7 +357,7 @@ function GeneralTab({
             <button
               disabled={clearingActivityCache}
               onClick={() => void clearActivityCache()}
-              className="flex-shrink-0 text-sm font-semibold rounded-xl px-4 py-2 min-w-[120px] transition-colors disabled:opacity-50 bg-surface-container-high hover:bg-surface-bright border border-outline-variant/30 text-on-surface"
+              className="flex-shrink-0 text-sm font-semibold rounded-xl px-4 py-2 min-w-[120px] transition-colors disabled:opacity-50 bg-background-container-high hover:bg-background-bright border border-outline-variant/30 text-on-surface"
             >
               {clearingActivityCache ? "Clearing…" : "Clear Cache"}
             </button>
@@ -372,8 +372,8 @@ function GeneralTab({
 type LogFilter = "debug" | "info" | "warn" | "error";
 
 const LEVEL_BADGE: Record<LogFilter, string> = {
-  debug: "text-on-surface-variant bg-surface-container",
-  info:  "text-primary bg-primary/10",
+  debug: "text-on-surface-variant bg-background-container",
+  info:  "text-on-surface bg-primary-dim",
   warn:  "text-warning bg-warning/10",
   error: "text-error bg-error/10"
 };
@@ -445,7 +445,7 @@ function LogsTab() {
           onClick={() => setActiveLog(null)}
         >
           <div
-            className="bg-surface-container-high rounded-2xl border border-outline-variant/30 w-full max-w-2xl p-6 space-y-4"
+            className="bg-background-container-high rounded-2xl border border-outline-variant/30 w-full max-w-2xl p-6 space-y-4"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between">
@@ -470,7 +470,7 @@ function LogsTab() {
               {activeLog.meta !== undefined && (
                 <div className="flex gap-2">
                   <span className="text-on-surface-variant w-24 flex-shrink-0">Meta</span>
-                  <pre className="text-on-surface font-mono text-xs bg-surface-container rounded-lg p-3 overflow-auto max-h-64 flex-1 whitespace-pre-wrap break-all">
+                  <pre className="text-on-surface font-mono text-xs bg-background-container rounded-lg p-3 overflow-auto max-h-64 flex-1 whitespace-pre-wrap break-all">
                     {JSON.stringify(activeLog.meta, null, 2)}
                   </pre>
                 </div>
@@ -479,14 +479,14 @@ function LogsTab() {
             <div className="flex justify-end gap-2 pt-2">
               <button
                 onClick={() => copyLog(activeLog)}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary/10 text-primary text-sm hover:bg-primary/20 transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary-dim text-on-surface text-sm hover:bg-primary transition-colors"
               >
                 <ClipboardCopy size={14} />
                 {copied ? "Copied!" : "Copy"}
               </button>
               <button
                 onClick={() => setActiveLog(null)}
-                className="px-3 py-1.5 rounded-lg bg-surface-container text-on-surface text-sm hover:bg-surface-container-high transition-colors"
+                className="px-3 py-1.5 rounded-lg bg-background-container text-on-surface text-sm hover:bg-background-container-high transition-colors"
               >
                 Close
               </button>
@@ -504,13 +504,13 @@ function LogsTab() {
             placeholder="Search logs..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="flex-1 min-w-[160px] px-3 py-1.5 rounded-lg bg-surface-container border border-outline-variant/30 text-sm text-on-surface placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
+            className="flex-1 min-w-[160px] px-3 py-1.5 rounded-lg bg-background-container border border-outline-variant/30 text-sm text-on-surface placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
           />
           {/* Level filter */}
           <select
             value={filter}
             onChange={(e) => setFilter(e.target.value as LogFilter)}
-            className="px-3 py-1.5 rounded-lg bg-surface-container border border-outline-variant/30 text-sm text-on-surface focus:outline-none focus:border-primary/50"
+            className="px-3 py-1.5 rounded-lg bg-background-container border border-outline-variant/30 text-sm text-on-surface focus:outline-none focus:border-primary/50"
           >
             <option value="debug">Debug (all)</option>
             <option value="info">Info+</option>
@@ -521,7 +521,7 @@ function LogsTab() {
           <select
             value={pageSize}
             onChange={(e) => setPageSize(Number(e.target.value))}
-            className="px-3 py-1.5 rounded-lg bg-surface-container border border-outline-variant/30 text-sm text-on-surface focus:outline-none focus:border-primary/50"
+            className="px-3 py-1.5 rounded-lg bg-background-container border border-outline-variant/30 text-sm text-on-surface focus:outline-none focus:border-primary/50"
           >
             <option value={25}>25 / page</option>
             <option value={50}>50 / page</option>
@@ -532,8 +532,8 @@ function LogsTab() {
             onClick={() => setAutoRefresh((v) => !v)}
             className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-sm transition-colors ${
               autoRefresh
-                ? "bg-primary/10 border-primary/30 text-primary"
-                : "bg-surface-container border-outline-variant/30 text-on-surface-variant"
+                ? "bg-primary-dim border-primary-dim text-on-surface"
+                : "bg-background-container border-outline-variant/30 text-on-surface-variant"
             }`}
           >
             {autoRefresh ? <Pause size={14} /> : <Play size={14} />}
@@ -542,14 +542,14 @@ function LogsTab() {
           {/* Manual refresh */}
           <button
             onClick={() => void load()}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-surface-container border border-outline-variant/30 text-sm text-on-surface-variant hover:text-on-surface transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-background-container border border-outline-variant/30 text-sm text-on-surface-variant hover:text-on-surface transition-colors"
           >
             <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
           </button>
         </div>
 
         {/* Table */}
-        <div className="bg-surface-container-low rounded-xl border border-outline-variant/20 overflow-hidden">
+        <div className="bg-background-container-low rounded-xl border border-outline-variant/20 overflow-hidden">
           {loading && !data ? (
             <div className="flex items-center justify-center h-48 text-on-surface-variant text-sm">Loading logs...</div>
           ) : results.length === 0 ? (
@@ -562,7 +562,7 @@ function LogsTab() {
           ) : (
             <div className="divide-y divide-outline-variant/10">
               {results.map((entry, i) => (
-                <div key={i} className="flex items-start gap-3 px-4 py-2 text-xs font-mono hover:bg-surface-container/50 group">
+                <div key={i} className="flex items-start gap-3 px-4 py-2 text-xs font-mono hover:bg-background-container/50 group">
                   <span className="text-on-surface-variant/60 flex-shrink-0 w-[7.5rem] truncate pt-0.5">
                     {new Date(entry.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
                   </span>
@@ -604,7 +604,7 @@ function LogsTab() {
               <button
                 disabled={page <= 1}
                 onClick={() => setPage((p) => p - 1)}
-                className="p-1.5 rounded-lg bg-surface-container disabled:opacity-40 hover:bg-surface-container-high transition-colors"
+                className="p-1.5 rounded-lg bg-background-container disabled:opacity-40 hover:bg-background-container-high transition-colors"
               >
                 <ChevronLeft size={14} />
               </button>
@@ -612,7 +612,7 @@ function LogsTab() {
               <button
                 disabled={page >= pageInfo.pages}
                 onClick={() => setPage((p) => p + 1)}
-                className="p-1.5 rounded-lg bg-surface-container disabled:opacity-40 hover:bg-surface-container-high transition-colors"
+                className="p-1.5 rounded-lg bg-background-container disabled:opacity-40 hover:bg-background-container-high transition-colors"
               >
                 <ChevronRight size={14} />
               </button>
@@ -737,7 +737,7 @@ function JobsTab() {
       {/* Edit schedule modal */}
       {editingJob && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60">
-          <div className="bg-surface-container rounded-2xl border border-outline-variant/20 w-full max-w-md shadow-2xl">
+          <div className="bg-background-container rounded-2xl border border-outline-variant/20 w-full max-w-md shadow-2xl">
             <div className="flex items-center justify-between px-6 py-4 border-b border-outline-variant/20">
               <h2 className="font-headline font-semibold text-on-surface">Edit Schedule</h2>
               <button onClick={() => setEditingJob(null)} className="text-on-surface-variant hover:text-on-surface transition-colors">
@@ -754,7 +754,7 @@ function JobsTab() {
                 <select
                   value={editValue}
                   onChange={(e) => setEditValue(e.target.value)}
-                  className="w-full bg-surface-container-low border border-outline-variant/30 rounded-xl px-3 py-2.5 text-sm text-on-surface focus:outline-none focus:border-primary"
+                  className="w-full bg-background-container-low border border-outline-variant/30 rounded-xl px-3 py-2.5 text-sm text-on-surface focus:outline-none focus:border-primary"
                 >
                   {(JOB_PRESETS[editingJob.id]?.values ?? []).map((v) => (
                     <option key={v} value={String(v)}>
@@ -774,7 +774,7 @@ function JobsTab() {
               <button
                 disabled={saving}
                 onClick={() => void saveSchedule()}
-                className="bg-primary hover:bg-primary-dim disabled:opacity-50 text-on-primary text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
+                className="bg-primary-dim hover:bg-primary disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
               >
                 {saving ? "Saving..." : "Save"}
               </button>
@@ -857,7 +857,7 @@ function JobsTab() {
                         {JOB_PRESETS[job.id] && (
                           <button
                             onClick={() => openEdit(job)}
-                            className="flex items-center gap-1.5 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high text-xs font-medium rounded-lg px-3 py-1.5 transition-colors border border-outline-variant/20"
+                            className="flex items-center gap-1.5 text-on-surface-variant hover:text-on-surface hover:bg-background-container-high text-xs font-medium rounded-lg px-3 py-1.5 transition-colors border border-outline-variant/20"
                           >
                             <Pencil size={13} />
                             Edit
@@ -866,7 +866,7 @@ function JobsTab() {
                         <button
                           disabled={runningId === job.id || job.isRunning}
                           onClick={() => void runJob(job.id)}
-                          className="flex items-center gap-1.5 bg-primary/10 hover:bg-primary/20 disabled:opacity-50 text-primary text-xs font-medium rounded-lg px-3 py-1.5 transition-colors border border-primary/20"
+                          className="flex items-center gap-1.5 bg-primary-dim hover:bg-primary disabled:opacity-50 text-on-surface text-xs font-medium rounded-lg px-3 py-1.5 transition-colors border border-primary-dim"
                         >
                           <Play size={13} />
                           {runningId === job.id || job.isRunning ? "Running..." : "Run Now"}
@@ -935,14 +935,14 @@ function AboutTab() {
         </InfoRow>
         {info?.buildChannel !== "stable" && (
           <InfoRow label="Commit">
-            <code className="text-sm text-on-surface bg-surface-container-high px-2 py-0.5 rounded font-mono">{info?.commitSha ?? "..."}</code>
+            <code className="text-sm text-on-surface bg-background-container-high px-2 py-0.5 rounded font-mono">{info?.commitSha ?? "..."}</code>
           </InfoRow>
         )}
         <InfoRow label="Data Directory">
-          <code className="text-sm text-on-surface bg-surface-container-high px-2 py-0.5 rounded">{info?.dataDir ?? "..."}</code>
+          <code className="text-sm text-on-surface bg-background-container-high px-2 py-0.5 rounded">{info?.dataDir ?? "..."}</code>
         </InfoRow>
         <InfoRow label="Timezone">
-          <code className="text-sm text-on-surface bg-surface-container-high px-2 py-0.5 rounded">{info?.tz ?? "..."}</code>
+          <code className="text-sm text-on-surface bg-background-container-high px-2 py-0.5 rounded">{info?.tz ?? "..."}</code>
         </InfoRow>
       </SectionCard>
 
@@ -994,7 +994,7 @@ function AboutTab() {
         {releases && releases.map((release, index) => (
           <div
             key={release.id}
-            className="flex items-center justify-between gap-4 bg-surface-container-high rounded-xl px-4 py-3"
+            className="flex items-center justify-between gap-4 bg-background-container-high rounded-xl px-4 py-3"
           >
             <div className="flex items-center gap-3 min-w-0">
               <span className="font-semibold text-on-surface truncate">{release.name || release.tag_name}</span>
@@ -1002,7 +1002,7 @@ function AboutTab() {
                 <span className="flex-shrink-0 text-xs font-medium text-success bg-success/10 px-2 py-0.5 rounded-full border border-success/20">Latest</span>
               )}
               {info?.buildChannel === "stable" && info?.version && (release.name === info.version || release.tag_name === `v${info.version}` || release.tag_name === info.version) && (
-                <span className="flex-shrink-0 text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded-full border border-primary/20">Current</span>
+                <span className="flex-shrink-0 text-xs font-medium text-on-surface bg-primary-dim px-2 py-0.5 rounded-full border border-primary-dim">Current</span>
               )}
               <span className="flex-shrink-0 text-xs text-on-surface-variant">
                 {new Date(release.published_at).toLocaleDateString()}
@@ -1010,7 +1010,7 @@ function AboutTab() {
             </div>
             <button
               onClick={() => setChangelogRelease(release)}
-              className="flex-shrink-0 flex items-center gap-1.5 text-on-surface-variant hover:text-on-surface hover:bg-surface-bright text-xs font-medium rounded-lg px-3 py-1.5 transition-colors border border-outline-variant/20"
+              className="flex-shrink-0 flex items-center gap-1.5 text-on-surface-variant hover:text-on-surface hover:bg-background-bright text-xs font-medium rounded-lg px-3 py-1.5 transition-colors border border-outline-variant/20"
             >
               View Changelog
             </button>
@@ -1021,12 +1021,12 @@ function AboutTab() {
       {/* Changelog modal */}
       {changelogRelease && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60">
-          <div className="bg-surface-container rounded-2xl border border-outline-variant/20 shadow-2xl w-full max-w-2xl max-h-[80vh] flex flex-col">
+          <div className="bg-background-container rounded-2xl border border-outline-variant/20 shadow-2xl w-full max-w-2xl max-h-[80vh] flex flex-col">
             <div className="flex items-center justify-between p-5 border-b border-outline-variant/20">
               <h3 className="font-headline font-semibold text-on-surface">{changelogRelease.name || changelogRelease.tag_name} Changelog</h3>
               <button
                 onClick={() => setChangelogRelease(null)}
-                className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors"
+                className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-background-container-high transition-colors"
               >
                 <X size={18} />
               </button>
@@ -1041,7 +1041,7 @@ function AboutTab() {
             <div className="flex justify-end gap-3 p-4 border-t border-outline-variant/20">
               <button
                 onClick={() => setChangelogRelease(null)}
-                className="px-4 py-2 text-sm rounded-xl bg-surface-container-high hover:bg-surface-bright text-on-surface border border-outline-variant/20 transition-colors"
+                className="px-4 py-2 text-sm rounded-xl bg-background-container-high hover:bg-background-bright text-on-surface border border-outline-variant/20 transition-colors"
               >
                 Close
               </button>
@@ -1049,7 +1049,7 @@ function AboutTab() {
                 href={changelogRelease.html_url.startsWith("https://github.com/") ? changelogRelease.html_url : "#"}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-4 py-2 text-sm rounded-xl bg-primary hover:bg-primary-dim text-on-primary font-medium transition-colors"
+                className="px-4 py-2 text-sm rounded-xl bg-primary-dim hover:bg-primary text-on-surface font-medium transition-colors"
               >
                 View on GitHub
               </a>
@@ -1147,7 +1147,7 @@ function SeerrTab({
 
   return (
     <div>
-      <div className="bg-surface-container rounded-2xl border border-outline-variant/20 p-5">
+      <div className="bg-background-container rounded-2xl border border-outline-variant/20 p-5">
         <h3 className="font-headline font-semibold text-base text-on-surface mb-4">Seerr Integration</h3>
 
         <div className="space-y-4">
@@ -1186,7 +1186,7 @@ function SeerrTab({
                 setForm((f) => ({ ...f, apiKey: event.target.value }));
               }}
               placeholder=""
-              className="w-full bg-surface-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
+              className="w-full bg-background-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
             />
           </Field>
 
@@ -1221,7 +1221,7 @@ function SeerrTab({
               <button
                 onClick={() => void testConnection()}
                 disabled={testing || !form.baseUrl}
-                className="bg-surface-container-high hover:bg-surface-bright disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+                className="bg-background-container-high hover:bg-background-bright disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
               >
                 {testing ? "Testing..." : "Test Connection"}
               </button>
@@ -1234,7 +1234,7 @@ function SeerrTab({
             <button
               disabled={saving}
               onClick={() => void save()}
-              className="bg-primary hover:bg-primary-dim disabled:opacity-50 text-on-primary text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
+              className="bg-primary-dim hover:bg-primary disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
             >
               {saving ? "Saving..." : "Save Seerr"}
             </button>

--- a/src/client/pages/Users.tsx
+++ b/src/client/pages/Users.tsx
@@ -135,7 +135,7 @@ export default function Users() {
         <h1 className="font-headline font-bold text-2xl text-on-surface">Users</h1>
         <button
           onClick={() => void refreshUsers()}
-          className="flex items-center gap-2 bg-surface-container-high hover:bg-surface-bright text-on-surface text-sm font-medium rounded-xl px-3 py-2.5 transition-colors border border-outline-variant/20"
+          className="flex items-center gap-2 bg-background-container-high hover:bg-background-bright text-on-surface text-sm font-medium rounded-xl px-3 py-2.5 transition-colors border border-outline-variant/20"
         >
           <RefreshCw size={15} className={refreshInProgress ? "animate-spin" : ""} />
           {refreshInProgress ? "Refreshing..." : "Refresh Users"}
@@ -152,13 +152,13 @@ export default function Users() {
         <div className="flex items-center gap-2 mb-4">
           <button
             onClick={() => void bulkSetEnabled(true)}
-            className="bg-primary hover:bg-primary-dim text-on-primary text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
+            className="bg-primary-dim hover:bg-primary text-on-surface text-sm font-semibold rounded-xl px-4 py-2 transition-colors"
           >
             Enable Selected
           </button>
           <button
             onClick={() => void bulkSetEnabled(false)}
-            className="bg-surface-container-high hover:bg-surface-bright text-on-surface text-sm font-medium rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
+            className="bg-background-container-high hover:bg-background-bright text-on-surface text-sm font-medium rounded-xl px-4 py-2 transition-colors border border-outline-variant/20"
           >
             Disable Selected
           </button>
@@ -271,7 +271,7 @@ function Avatar({ avatarUrl, displayName, size }: { avatarUrl: string | null; di
     );
   }
   return (
-    <div className={`${size} rounded-full bg-surface-container-highest flex items-center justify-center`}>
+    <div className={`${size} rounded-full bg-background-container-highest flex items-center justify-center`}>
       <span className="text-on-surface-variant text-lg font-medium">
         {displayName.charAt(0).toUpperCase()}
       </span>
@@ -303,8 +303,8 @@ function UserCard({
 
   return (
     <div
-      className={`relative bg-surface-container rounded-2xl border flex flex-col items-center p-4 gap-2 transition-colors ${
-        selected ? "border-primary/50 bg-surface-container-high" : "border-outline-variant/20"
+      className={`relative bg-background-container rounded-2xl border flex flex-col items-center p-4 gap-2 transition-colors ${
+        selected ? "border-primary/50 bg-background-container-high" : "border-outline-variant/20"
       } ${!user.enabled ? "opacity-60" : ""}`}
     >
       <input
@@ -316,7 +316,7 @@ function UserCard({
 
       <button
         onClick={onEdit}
-        className="absolute top-3 right-3 p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors border border-outline-variant/20"
+        className="absolute top-3 right-3 p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-background-container-high transition-colors border border-outline-variant/20"
         title="Edit user"
       >
         <Edit2 size={14} />
@@ -333,7 +333,7 @@ function UserCard({
             {displayName}
           </p>
           {user.isSelf && (
-            <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded font-medium flex-shrink-0">
+            <span className="text-xs bg-primary-dim text-on-surface px-1.5 py-0.5 rounded font-medium flex-shrink-0">
               You
             </span>
           )}
@@ -347,14 +347,14 @@ function UserCard({
         {user.watchlistItemCount > 0 ? (
           <button
             onClick={onOpenWatchlist}
-            className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface text-xs font-medium rounded-lg px-2.5 py-1.5 transition-colors border border-outline-variant/20"
+            className="flex items-center gap-1 bg-background-container-high hover:bg-background-bright text-on-surface text-xs font-medium rounded-lg px-2.5 py-1.5 transition-colors border border-outline-variant/20"
           >
             {user.watchlistItemCount} Watchlist {user.watchlistItemCount === 1 ? "Item" : "Items"}
           </button>
         ) : (
           <button
             onClick={onShowNoData}
-            className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright text-on-surface-variant text-xs font-medium rounded-lg px-2.5 py-1.5 transition-colors border border-outline-variant/20"
+            className="flex items-center gap-1 bg-background-container-high hover:bg-background-bright text-on-surface-variant text-xs font-medium rounded-lg px-2.5 py-1.5 transition-colors border border-outline-variant/20"
           >
             No Watchlist Data
           </button>
@@ -363,7 +363,7 @@ function UserCard({
           <button
             disabled={syncing}
             onClick={onSync}
-            className="flex items-center gap-1 bg-surface-container-high hover:bg-surface-bright disabled:opacity-50 text-on-surface text-xs font-medium rounded-lg px-2.5 py-1.5 transition-colors border border-outline-variant/20"
+            className="flex items-center gap-1 bg-background-container-high hover:bg-background-bright disabled:opacity-50 text-on-surface text-xs font-medium rounded-lg px-2.5 py-1.5 transition-colors border border-outline-variant/20"
           >
             <Play size={11} className={syncing ? "animate-pulse" : ""} />
             {syncing ? "Syncing…" : "Sync Watchlist"}
@@ -404,7 +404,7 @@ function WatchlistInfoModal({
       onClick={onClose}
     >
       <div
-        className="bg-surface-container rounded-2xl p-6 w-full max-w-md border border-outline-variant/20 shadow-xl"
+        className="bg-background-container rounded-2xl p-6 w-full max-w-md border border-outline-variant/20 shadow-xl"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-4">
@@ -413,7 +413,7 @@ function WatchlistInfoModal({
           </h3>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high"
+            className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-background-container-high"
           >
             <X size={18} />
           </button>
@@ -426,7 +426,7 @@ function WatchlistInfoModal({
         <div className="mt-6">
           <button
             onClick={onClose}
-            className="w-full bg-primary hover:bg-primary-dim text-on-primary text-sm font-semibold rounded-xl py-2.5 transition-colors"
+            className="w-full bg-primary-dim hover:bg-primary text-on-surface text-sm font-semibold rounded-xl py-2.5 transition-colors"
           >
             Close
           </button>
@@ -460,7 +460,7 @@ function InfoBadge({ label, message, className }: { label: string; message: stri
         {label}
       </button>
       {open && (
-        <div className="absolute bottom-full mb-1.5 left-1/2 -translate-x-1/2 w-48 bg-surface-container-highest border border-outline-variant/30 rounded-lg px-3 py-2 text-xs text-on-surface shadow-lg z-10 text-center">
+        <div className="absolute bottom-full mb-1.5 left-1/2 -translate-x-1/2 w-48 bg-background-container-highest border border-outline-variant/30 rounded-lg px-3 py-2 text-xs text-on-surface shadow-lg z-10 text-center">
           {message}
         </div>
       )}
@@ -470,7 +470,7 @@ function InfoBadge({ label, message, className }: { label: string; message: stri
 
 function ManagedUserCard({ user }: { user: ManagedUserRecord }) {
   return (
-    <div className="relative bg-surface-container rounded-2xl border border-outline-variant/20 flex flex-col items-center p-4 gap-2 opacity-80">
+    <div className="relative bg-background-container rounded-2xl border border-outline-variant/20 flex flex-col items-center p-4 gap-2 opacity-80">
       <Avatar avatarUrl={user.avatarUrl} displayName={user.displayName} size="w-16 h-16" />
 
       <div className="w-full text-center px-1">
@@ -679,7 +679,7 @@ function EditModal({
       onClick={onClose}
     >
       <div
-        className="bg-surface-container rounded-2xl w-full max-w-md border border-outline-variant/20 shadow-xl flex flex-col"
+        className="bg-background-container rounded-2xl w-full max-w-md border border-outline-variant/20 shadow-xl flex flex-col"
         onClick={(event) => event.stopPropagation()}
       >
         {/* Header */}
@@ -691,7 +691,7 @@ function EditModal({
                 {user.username}
               </span>
               {user.isSelf && (
-                <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium flex-shrink-0">
+                <span className="text-xs bg-primary-dim text-on-surface px-1.5 py-0.5 rounded-md font-medium flex-shrink-0">
                   You
                 </span>
               )}
@@ -709,7 +709,7 @@ function EditModal({
           </div>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors flex-shrink-0"
+            className="p-1.5 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-background-container-high transition-colors flex-shrink-0"
             aria-label="Close"
           >
             <X size={18} />
@@ -718,14 +718,14 @@ function EditModal({
 
         {/* Tab bar */}
         <div className="px-5 pb-3">
-          <div className="flex p-1 bg-surface-container-high rounded-xl gap-1">
+          <div className="flex p-1 bg-background-container-high rounded-xl gap-1">
             {tabs.map((tab) => (
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
                 className={`flex-1 text-sm font-medium rounded-lg py-2 transition-all ${
                   activeTab === tab.id
-                    ? "bg-surface-container text-on-surface shadow-sm"
+                    ? "bg-background-container text-on-surface shadow-sm"
                     : "text-on-surface-variant hover:text-on-surface"
                 }`}
               >
@@ -750,7 +750,7 @@ function EditModal({
                   value={displayNameOverride}
                   onChange={(event) => setDisplayNameOverride(event.target.value)}
                   placeholder="Leave blank to use Plex username"
-                  className="w-full bg-surface-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
+                  className="w-full bg-background-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
                 />
               </Field>
             </div>
@@ -781,7 +781,7 @@ function EditModal({
                   value={collectionNameOverride}
                   onChange={(event) => setCollectionNameOverride(event.target.value)}
                   placeholder={defaultName}
-                  className="w-full bg-surface-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
+                  className="w-full bg-background-container-low border border-outline-variant/30 rounded-lg px-3 py-2 text-on-surface text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:border-primary/50"
                 />
               </Field>
 
@@ -833,13 +833,13 @@ function EditModal({
                       }
                       className={`flex flex-col items-center gap-1 rounded-xl py-3 px-3 border text-xs font-medium transition-all ${
                         effectiveVisibility[key]
-                          ? "bg-primary/10 border-primary/30 text-primary"
-                          : "bg-surface-container-low border-outline-variant/20 text-on-surface-variant"
+                          ? "bg-primary-dim border-primary-dim text-on-surface"
+                          : "bg-background-container-low border-outline-variant/20 text-on-surface-variant"
                       }`}
                     >
                       <div className={`w-3 h-3 rounded-full border-2 mb-0.5 transition-all ${
                         effectiveVisibility[key]
-                          ? "bg-primary border-primary"
+                          ? "bg-on-surface border-on-surface"
                           : "border-outline-variant"
                       }`} />
                       {label.split(" ").map((word, i) => (
@@ -856,7 +856,7 @@ function EditModal({
           {activeTab === "seerr" && seerrEnabled && (
             <div className="space-y-4">
               {!seerrLinkLoaded && !seerrLinkLoadError && (
-                <div className="rounded-lg border border-outline-variant/20 bg-surface-container-low px-3 py-3 text-sm text-on-surface-variant">
+                <div className="rounded-lg border border-outline-variant/20 bg-background-container-low px-3 py-3 text-sm text-on-surface-variant">
                   Loading Seerr user mapping...
                 </div>
               )}
@@ -931,14 +931,14 @@ function EditModal({
         <div className="flex gap-3 px-5 py-4 mt-2 border-t border-outline-variant/15">
           <button
             onClick={onClose}
-            className="flex-1 bg-surface-container-high hover:bg-surface-bright text-on-surface text-sm font-medium rounded-xl py-2.5 transition-colors border border-outline-variant/20"
+            className="flex-1 bg-background-container-high hover:bg-background-bright text-on-surface text-sm font-medium rounded-xl py-2.5 transition-colors border border-outline-variant/20"
           >
             Cancel
           </button>
           <button
             disabled={saving}
             onClick={() => void save()}
-            className="flex-1 bg-primary hover:bg-primary-dim disabled:opacity-50 text-on-primary text-sm font-semibold rounded-xl py-2.5 transition-colors"
+            className="flex-1 bg-primary-dim hover:bg-primary disabled:opacity-50 text-on-surface text-sm font-semibold rounded-xl py-2.5 transition-colors"
           >
             {saving ? "Saving..." : "Save Changes"}
           </button>

--- a/src/client/pages/Watchlists.tsx
+++ b/src/client/pages/Watchlists.tsx
@@ -312,12 +312,12 @@ function WatchlistPoster({
         )}
         {/* Gradient overlay — fades in on hover */}
         <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-          style={{ background: "linear-gradient(180deg, rgba(45,55,72,0.2) 0%, rgba(45,55,72,0.95) 100%)" }} />
+          style={{ background: "linear-gradient(180deg, var(--overlay-poster-transparent) 0%, var(--overlay-poster) 100%)" }} />
         {/* Availability icon — always visible, top-right */}
         <div className="absolute top-1.5 right-1.5">
           {item.plexAvailable ? (
             <div className="relative">
-              <div className="absolute inset-[3px] rounded-full bg-[#0a3d1f]" />
+              <div className="absolute inset-[3px] rounded-full bg-success/20" />
               <CheckCircle size={18} className="relative text-success drop-shadow-[0_0_4px_rgba(0,0,0,1)]" />
             </div>
           ) : seerrEnabled && item.seerrRequested ? (
@@ -326,7 +326,7 @@ function WatchlistPoster({
             </div>
           ) : (
             <div className="relative">
-              <div className="absolute inset-[3px] rounded-full bg-[#3d0a0a]" />
+              <div className="absolute inset-[3px] rounded-full bg-error/20" />
               <XCircle size={18} className="relative text-error drop-shadow-[0_0_4px_rgba(0,0,0,1)]" />
             </div>
           )}

--- a/src/client/pages/Watchlists.tsx
+++ b/src/client/pages/Watchlists.tsx
@@ -317,7 +317,7 @@ function WatchlistPoster({
         <div className="absolute top-1.5 right-1.5">
           {item.plexAvailable ? (
             <div className="relative">
-              <div className="absolute inset-[3px] rounded-full bg-success/20" />
+              <div className="absolute inset-[3px] rounded-full bg-[var(--poster-halo-success)]" />
               <CheckCircle size={18} className="relative text-success drop-shadow-[0_0_4px_rgba(0,0,0,1)]" />
             </div>
           ) : seerrEnabled && item.seerrRequested ? (
@@ -326,7 +326,7 @@ function WatchlistPoster({
             </div>
           ) : (
             <div className="relative">
-              <div className="absolute inset-[3px] rounded-full bg-error/20" />
+              <div className="absolute inset-[3px] rounded-full bg-[var(--poster-halo-error)]" />
               <XCircle size={18} className="relative text-error drop-shadow-[0_0_4px_rgba(0,0,0,1)]" />
             </div>
           )}

--- a/src/client/pages/Watchlists.tsx
+++ b/src/client/pages/Watchlists.tsx
@@ -261,7 +261,7 @@ function FilterChip({
       )}
       {label}
       {count !== undefined && (
-        <span className={`text-xs ${active ? "text-on-surface/70" : "text-on-surface-variant/60"}`}>
+        <span className={`text-xs ${active ? "text-on-surface" : "text-on-surface-variant/60"}`}>
           {count}
         </span>
       )}

--- a/src/client/pages/Watchlists.tsx
+++ b/src/client/pages/Watchlists.tsx
@@ -195,6 +195,8 @@ export default function Watchlists() {
           {totalPages > 1 && (
             <div className="flex items-center justify-center gap-3">
               <button
+                aria-label="Previous page"
+                title="Previous page"
                 disabled={page <= 1}
                 onClick={() => setParam({ page: String(page - 1) })}
                 className="p-2 rounded-lg border border-outline-variant/20 text-on-surface-variant hover:text-on-surface hover:bg-background-container-high disabled:opacity-40 transition-colors"
@@ -205,6 +207,8 @@ export default function Watchlists() {
                 Page {page} of {totalPages}
               </span>
               <button
+                aria-label="Next page"
+                title="Next page"
                 disabled={page >= totalPages}
                 onClick={() => setParam({ page: String(page + 1) })}
                 className="p-2 rounded-lg border border-outline-variant/20 text-on-surface-variant hover:text-on-surface hover:bg-background-container-high disabled:opacity-40 transition-colors"
@@ -317,7 +321,7 @@ function WatchlistPoster({
         <div className="absolute top-1.5 right-1.5">
           {item.plexAvailable ? (
             <div className="relative">
-              <div className="absolute inset-[3px] rounded-full bg-[var(--poster-halo-success)]" />
+              <div className="absolute inset-[3px] rounded-full bg-(--poster-halo-success)" />
               <CheckCircle size={18} className="relative text-success drop-shadow-[0_0_4px_rgba(0,0,0,1)]" />
             </div>
           ) : seerrEnabled && item.seerrRequested ? (
@@ -326,7 +330,7 @@ function WatchlistPoster({
             </div>
           ) : (
             <div className="relative">
-              <div className="absolute inset-[3px] rounded-full bg-[var(--poster-halo-error)]" />
+              <div className="absolute inset-[3px] rounded-full bg-(--poster-halo-error)" />
               <XCircle size={18} className="relative text-error drop-shadow-[0_0_4px_rgba(0,0,0,1)]" />
             </div>
           )}

--- a/src/client/pages/Watchlists.tsx
+++ b/src/client/pages/Watchlists.tsx
@@ -197,7 +197,7 @@ export default function Watchlists() {
               <button
                 disabled={page <= 1}
                 onClick={() => setParam({ page: String(page - 1) })}
-                className="p-2 rounded-lg border border-outline-variant/20 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high disabled:opacity-40 transition-colors"
+                className="p-2 rounded-lg border border-outline-variant/20 text-on-surface-variant hover:text-on-surface hover:bg-background-container-high disabled:opacity-40 transition-colors"
               >
                 <ChevronLeft size={18} />
               </button>
@@ -207,7 +207,7 @@ export default function Watchlists() {
               <button
                 disabled={page >= totalPages}
                 onClick={() => setParam({ page: String(page + 1) })}
-                className="p-2 rounded-lg border border-outline-variant/20 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high disabled:opacity-40 transition-colors"
+                className="p-2 rounded-lg border border-outline-variant/20 text-on-surface-variant hover:text-on-surface hover:bg-background-container-high disabled:opacity-40 transition-colors"
               >
                 <ChevronRight size={18} />
               </button>
@@ -215,7 +215,7 @@ export default function Watchlists() {
           )}
         </>
       ) : (
-        <div className="bg-surface-container rounded-2xl border border-outline-variant/20 flex items-center justify-center py-16 text-center">
+        <div className="bg-background-container rounded-2xl border border-outline-variant/20 flex items-center justify-center py-16 text-center">
           <p className="text-on-surface-variant text-sm max-w-xs">
             No watchlist items found. Run a sync to populate watchlists.
           </p>
@@ -248,8 +248,8 @@ function FilterChip({
       onClick={onClick}
       className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-colors border ${
         active
-          ? "bg-primary/10 text-primary border-primary/30"
-          : "bg-surface-container border-outline-variant/20 text-on-surface-variant hover:text-on-surface hover:border-outline-variant/40"
+          ? "bg-primary-dim text-on-surface border-primary-dim"
+          : "bg-background-container border-outline-variant/20 text-on-surface-variant hover:text-on-surface hover:border-outline-variant/40"
       }`}
     >
       {getPlexImageSrc(avatarUrl) && (
@@ -261,7 +261,7 @@ function FilterChip({
       )}
       {label}
       {count !== undefined && (
-        <span className={`text-xs ${active ? "text-primary/70" : "text-on-surface-variant/60"}`}>
+        <span className={`text-xs ${active ? "text-on-surface/70" : "text-on-surface-variant/60"}`}>
           {count}
         </span>
       )}
@@ -291,7 +291,7 @@ function WatchlistPoster({
 
   return (
     <button onClick={onClick} className="group text-left w-full">
-      <div className="relative aspect-[2/3] rounded-xl overflow-hidden bg-surface-container-high transition-transform duration-300 group-hover:scale-105">
+      <div className="relative aspect-[2/3] rounded-xl overflow-hidden bg-background-container-high transition-transform duration-300 group-hover:scale-105">
         {posterSrc ? (
           <img
             src={posterSrc}
@@ -321,7 +321,7 @@ function WatchlistPoster({
               <CheckCircle size={18} className="relative text-success drop-shadow-[0_0_4px_rgba(0,0,0,1)]" />
             </div>
           ) : seerrEnabled && item.seerrRequested ? (
-            <div className="relative w-[18px] h-[18px] rounded-full bg-surface-container-highest border border-outline-variant/40 flex items-center justify-center drop-shadow-[0_0_4px_rgba(0,0,0,1)]">
+            <div className="relative w-[18px] h-[18px] rounded-full bg-background-container-highest border border-outline-variant/40 flex items-center justify-center drop-shadow-[0_0_4px_rgba(0,0,0,1)]">
               <img src="/seerr-icon.svg" alt="Requested in Seerr" className="w-3 h-3" />
             </div>
           ) : (


### PR DESCRIPTION
## Summary

Audited and rationalised the app's colour palette from 19 variables down to 14, fixed multiple WCAG contrast failures, and unified interactive element styling across the app. The main visible change is that active states, buttons, toggles, and badges now use a dark red background (`#ae0610`) with off-white text rather than the previous red-text-on-red-tint pattern which was both low-contrast and visually inconsistent.

## Changes

**`src/client/index.css`**
- Removed duplicate `--color-surface` (identical to `--color-background`)
- Removed unused `--color-secondary`, `--color-on-primary`, and `--color-primary-text`
- Renamed `--color-surface-container-*` scale to `--color-background-container-*` for naming consistency
- Adjusted `--color-primary-dim` from `#b10610` → `#ae0610` to achieve WCAG AAA (7.03:1) for `on-surface` text on that background
- Adjusted `--color-error` from `#ef4444` → `#f06060` to clear AA on all surface steps including `background-container-highest`

**Interactive element styling (Sidebar, Watchlists, History, Settings, Users, CollectionsConfigForm, FormControls, Onboarding, Login, PlexConfigForm)**
- Replaced `bg-primary/10 text-primary` (red tint + red text) with `bg-primary-dim text-on-surface` (dark red + off-white) across all active states: nav items, filters, sort buttons, visibility toggles, badges
- Unified all save/action buttons to `bg-primary-dim hover:bg-primary text-on-surface` — hover now brightens rather than darkens
- Toggle track changed from `bg-primary` → `bg-primary-dim`; knob changed from `bg-white` → `bg-on-surface`
- Reset button confirmed state changed from `bg-error` → `bg-primary-dim`
- Visibility circle indicator changed from `bg-primary` → `bg-on-surface` (off-white dot, easier to read)
- Watchlist filter count numbers changed from `text-primary/70` → `text-on-surface/70` when active
- Renamed `bg-background` → `bg-surface` references updated across all components to `bg-background` following the variable rename

**`docs/colour-scheme.md`** — new file documenting the full 14-colour palette, each colour's role, contrast ratios, and usage rules

**`docs/README.md`** — added entry for the new colour scheme doc

## Test plan

- [x] Hard refresh the app and check the sidebar — active nav item should show dark red background with off-white text
- [x] Watchlists page — active filter/sort pills should show dark red with off-white text and off-white counts
- [x] Settings > General — Save button should be dark red with off-white text; toggles should have dark red track and off-white knob when on
- [x] Settings > Jobs — Run Now buttons should match Save button styling
- [x] Settings > Logging — auto-refresh toggle and Copy button should match
- [x] Settings > Maintenance — Reset confirmed state should be dark red (not error red)
- [x] Collections config — visibility toggles should show dark red when selected, with off-white circle indicator
- [x] Users page — You badge and visibility toggles should use dark red
- [x] Confirm no red-on-red combinations remain visible anywhere

Closes #107

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive colour-scheme guide: 14‑colour dark‑mode palette, roles, WCAG contrast targets, and explicit usage rules for text, backgrounds, interactive states, and status indicators.

* **Style**
  * Introduced refreshed dark‑theme tokens and overlay variables; replaced surface→background container tokens across the UI, updated button/toggle/badge/hover/active visuals, and adjusted loading logo text for visual consistency.

* **Accessibility**
  * Added aria/title attributes to pagination controls and refined color choices to improve contrast and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->