### PR TITLE
fix: harden watchlist query parsing

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -46,6 +46,19 @@ function parseCookies(rawCookie = "") {
     }, new Map());
 }
 
+function parsePositiveIntegerQuery(value: unknown): number | undefined {
+  if (typeof value !== "string" || value.trim() === "") {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
 function signedValue(secret: string, value: string) {
   return crypto.createHmac("sha256", secret).update(value).digest("hex");
 }
@@ -682,7 +695,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   // ---------------------------------------------------------------------------
 
   app.get("/api/watchlists", requireAuth, (req, res) => {
-    const userId = req.query["userId"] ? Number(req.query["userId"]) : undefined;
+    const userId = parsePositiveIntegerQuery(req.query["userId"]);
     const mediaTypeParam = req.query["mediaType"];
     const mediaType =
       mediaTypeParam === "movie" || mediaTypeParam === "show"
@@ -699,8 +712,8 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       sortByParam === "title-asc" || sortByParam === "title-desc"
         ? sortByParam
         : "added-desc";
-    const page = req.query["page"] ? Math.max(1, Number(req.query["page"])) : 1;
-    const pageSize = req.query["pageSize"] ? Math.min(200, Math.max(1, Number(req.query["pageSize"]))) : 50;
+    const page = parsePositiveIntegerQuery(req.query["page"]) ?? 1;
+    const pageSize = Math.min(200, parsePositiveIntegerQuery(req.query["pageSize"]) ?? 50);
     res.json(db.getWatchlistGrouped({ userId, mediaType, availability, sortBy, page, pageSize }));
   });
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -51,8 +51,12 @@ function parsePositiveIntegerQuery(value: unknown): number | undefined {
     return undefined;
   }
 
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 1) {
+  if (!/^[1-9]\d*$/.test(value)) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
     return undefined;
   }
 
@@ -695,7 +699,11 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
   // ---------------------------------------------------------------------------
 
   app.get("/api/watchlists", requireAuth, (req, res) => {
-    const userId = parsePositiveIntegerQuery(req.query["userId"]);
+    const rawUserId = req.query["userId"];
+    const rawPage = req.query["page"];
+    const rawPageSize = req.query["pageSize"];
+
+    const userId = parsePositiveIntegerQuery(rawUserId);
     const mediaTypeParam = req.query["mediaType"];
     const mediaType =
       mediaTypeParam === "movie" || mediaTypeParam === "show"
@@ -712,8 +720,45 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       sortByParam === "title-asc" || sortByParam === "title-desc"
         ? sortByParam
         : "added-desc";
-    const page = parsePositiveIntegerQuery(req.query["page"]) ?? 1;
-    const pageSize = Math.min(200, parsePositiveIntegerQuery(req.query["pageSize"]) ?? 50);
+
+    const parsedPage = parsePositiveIntegerQuery(rawPage);
+    const page = parsedPage ?? 1;
+
+    const parsedPageSize = parsePositiveIntegerQuery(rawPageSize);
+    const pageSize = Math.min(200, parsedPageSize ?? 50);
+
+    const invalidFields: string[] = [];
+    const clampedFields: string[] = [];
+    if (rawUserId !== undefined && userId === undefined) {
+      invalidFields.push("userId");
+    }
+    if (rawPage !== undefined && parsedPage === undefined) {
+      invalidFields.push("page");
+    }
+    if (rawPageSize !== undefined && parsedPageSize === undefined) {
+      invalidFields.push("pageSize");
+    }
+    if (parsedPageSize !== undefined && pageSize !== parsedPageSize) {
+      clampedFields.push("pageSize");
+    }
+
+    if (invalidFields.length > 0 || clampedFields.length > 0) {
+      logger.debug("Watchlist query parameters normalized", {
+        originalQuery: {
+          userId: rawUserId,
+          page: rawPage,
+          pageSize: rawPageSize
+        },
+        invalidFields,
+        clampedFields,
+        effectiveValues: {
+          userId,
+          page,
+          pageSize
+        }
+      });
+    }
+
     res.json(db.getWatchlistGrouped({ userId, mediaType, availability, sortBy, page, pageSize }));
   });
 


### PR DESCRIPTION
## Summary

This PR hardens the `/api/watchlists` query parsing so malformed numeric parameters no longer propagate `NaN` into pagination and filtering logic. Valid requests keep the existing behavior, while invalid `userId`, `page`, and `pageSize` values now fall back to safe defaults.

## Changes

- Added a small `parsePositiveIntegerQuery()` helper in `src/server/app.ts` to centralize positive-integer parsing for query string values.
- Updated the `/api/watchlists` route to use the helper for `userId`, `page`, and `pageSize` instead of calling `Number(...)` inline.
- Preserved the existing defaults and `pageSize` cap while ensuring malformed values are ignored cleanly.

## Test plan

- [x] Run `npm run build`
- [ ] Call `GET /api/watchlists` with valid `userId`, `page`, and `pageSize` values and confirm the response matches existing behavior.
- [ ] Call `GET /api/watchlists` with malformed values such as `page=abc`, `pageSize=-1`, or `userId=` and confirm the endpoint falls back to safe defaults instead of producing invalid pagination state.

🤖 Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strict validation for watchlists API query parameters: positive integers parsed correctly; invalid or empty values now fall back to sensible defaults (page → 1, pageSize → 50; userId → undefined).
  * pageSize is capped at a maximum of 200 to prevent oversized requests.

* **New Features**
  * Conditional debug logging when parameters are invalid or are clamped, including raw and effective values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->