### PR TITLE
feat: skip collection publish when state is unchanged

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1211,14 +1211,24 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     const jobId = req.params.id;
     try {
       if (jobId === "collection-publish") {
-        const triggered = scheduler?.runNow("collection-publish") ?? false;
+        if (!scheduler) {
+          res.status(404).json({ error: "Unknown job." });
+          return;
+        }
+        // Force=true: manual Run Now always pushes to Plex regardless of hash.
+        const triggered = scheduler.runNow("collection-publish", () => services.runPublishPass(true).then(() => undefined));
         if (!triggered) {
           res.status(404).json({ error: "Unknown job." });
           return;
         }
         res.json({ triggered: true });
       } else if (jobId === "full-sync") {
-        const triggered = scheduler?.runNow("full-sync") ?? false;
+        if (!scheduler) {
+          res.status(404).json({ error: "Unknown job." });
+          return;
+        }
+        // Force=true: manual Run Now always pushes to Plex regardless of hash.
+        const triggered = scheduler.runNow("full-sync", () => services.runFullSync(true).then(() => undefined));
         if (!triggered) {
           res.status(404).json({ error: "Unknown job." });
           return;

--- a/src/server/db/collections.ts
+++ b/src/server/db/collections.ts
@@ -34,6 +34,19 @@ export function upsertCollectionRecord(
   );
 }
 
+export function getCollectionRecord(
+  db: Database.Database,
+  userId: number,
+  mediaType: "movie" | "show"
+): PlexCollectionRecord | null {
+  return (db.prepare(`
+    SELECT id, user_id AS userId, media_type AS mediaType, collection_rating_key AS collectionRatingKey,
+           visible_name AS visibleName, label_name AS labelName, hub_identifier AS hubIdentifier,
+           last_synced_hash AS lastSyncedHash, last_synced_at AS lastSyncedAt, last_sync_error AS lastSyncError
+    FROM plex_collections WHERE user_id = ? AND media_type = ?
+  `).get(userId, mediaType) as PlexCollectionRecord | undefined) ?? null;
+}
+
 export function listCollections(db: Database.Database): PlexCollectionRecord[] {
   return db
     .prepare(`

--- a/src/server/db/collections.ts
+++ b/src/server/db/collections.ts
@@ -47,6 +47,18 @@ export function getCollectionRecord(
   `).get(userId, mediaType) as PlexCollectionRecord | undefined) ?? null;
 }
 
+export function clearCollectionRatingKey(
+  db: Database.Database,
+  userId: number,
+  mediaType: "movie" | "show"
+): void {
+  db.prepare(`
+    UPDATE plex_collections
+    SET collection_rating_key = NULL, last_synced_hash = NULL
+    WHERE user_id = ? AND media_type = ?
+  `).run(userId, mediaType);
+}
+
 export function listCollections(db: Database.Database): PlexCollectionRecord[] {
   return db
     .prepare(`

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -337,6 +337,10 @@ export class HubarrDatabase {
     collectionsRepo.upsertCollectionRecord(this.db, userId, mediaType, patch);
   }
 
+  getCollectionRecord(userId: number, mediaType: "movie" | "show"): PlexCollectionRecord | null {
+    return collectionsRepo.getCollectionRecord(this.db, userId, mediaType);
+  }
+
   listCollections(): PlexCollectionRecord[] {
     return collectionsRepo.listCollections(this.db);
   }

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -341,6 +341,10 @@ export class HubarrDatabase {
     return collectionsRepo.getCollectionRecord(this.db, userId, mediaType);
   }
 
+  clearCollectionRatingKey(userId: number, mediaType: "movie" | "show"): void {
+    collectionsRepo.clearCollectionRatingKey(this.db, userId, mediaType);
+  }
+
   listCollections(): PlexCollectionRecord[] {
     return collectionsRepo.listCollections(this.db);
   }

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1157,6 +1157,21 @@ export class PlexIntegration {
     return { ratingKey: null, matchedBy: "none", candidates };
   }
 
+  /**
+   * Returns true if the collection ratingKey still exists on the Plex server.
+   * Returns false on HTTP 400/404 (deleted or never existed).
+   * Re-throws on transient errors (auth, network, 5xx) so callers can handle them.
+   */
+  async collectionExists(ratingKey: string): Promise<boolean> {
+    try {
+      await this.requestServer(`/library/metadata/${ratingKey}`);
+      return true;
+    } catch (err) {
+      if (this.isItemMissingError(err)) return false;
+      throw err;
+    }
+  }
+
   async getCollections(libraryId: string) {
     const response = await this.requestServer<{
       MediaContainer?: {

--- a/src/server/job-scheduler.ts
+++ b/src/server/job-scheduler.ts
@@ -161,15 +161,15 @@ export class JobScheduler {
     return (this.jobs.get(id)?.activeRuns ?? 0) > 0;
   }
 
-  runNow(id: string) {
+  runNow(id: string, taskOverride?: () => Promise<void>) {
     const job = this.jobs.get(id);
     if (!job) {
       this.logger?.warn("Cannot trigger unknown job", { id });
       return false;
     }
 
-    this.logger?.info("Job triggered manually", { id });
-    void this.execute(job, false);
+    this.logger?.info("Job triggered manually", { id, taskOverride: taskOverride !== undefined });
+    void this.execute(job, false, taskOverride);
     return true;
   }
 
@@ -210,7 +210,7 @@ export class JobScheduler {
     }, Math.max(0, nextRunAt.getTime() - Date.now()));
   }
 
-  private async execute(job: ScheduledJob, scheduled: boolean) {
+  private async execute(job: ScheduledJob, scheduled: boolean, taskOverride?: () => Promise<void>) {
     if (scheduled) {
       this.reschedule(job);
     }
@@ -218,7 +218,7 @@ export class JobScheduler {
     job.activeRuns += 1;
     this.logger?.debug("Job started", { id: job.id, scheduled });
     try {
-      await job.task();
+      await (taskOverride ?? job.task)();
       job.lastRunAt = new Date().toISOString();
       job.lastRunStatus = "success";
       this.persistState(job);

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type {
   AppSettings,
   CollectionSortOrder,
@@ -7,7 +8,8 @@ import type {
   SeerrUser,
   UserRecord,
   PlexSettingsInput,
-  WatchlistItem
+  WatchlistItem,
+  VisibilityConfig
 } from "../shared/types.js";
 import pLimit from "p-limit";
 import { HubarrDatabase } from "./db/index.js";
@@ -18,6 +20,31 @@ import { SeerrIntegration, extractTmdbId } from "./integrations/seerr.js";
 import { RssCache, type RssFeedItem } from "./rss-cache.js";
 
 const PLEX_SYNC_CONCURRENCY = 3;
+
+/**
+ * Compute a deterministic hash covering all state that affects what Plex sees
+ * for a single user+mediaType collection. If this hash is unchanged from the
+ * stored value the publish step can be skipped entirely.
+ *
+ * Covers: item list, collection name, sort order, visibility, and label.
+ * Display name is intentionally excluded — it only drives the poster (future).
+ */
+function computePublishStateHash(params: {
+  matchedRatingKeys: string[];
+  collectionName: string;
+  sortOrder: CollectionSortOrder;
+  visibility: VisibilityConfig;
+  labelName: string;
+}): string {
+  const payload = JSON.stringify({
+    keys: params.matchedRatingKeys,
+    name: params.collectionName,
+    sort: params.sortOrder,
+    vis: params.visibility,
+    label: params.labelName
+  });
+  return crypto.createHash("sha256").update(payload).digest("hex");
+}
 
 type SeerrRequestSyncScope =
   | { mode: "all"; triggeredBy: "manual" | "full" }
@@ -410,7 +437,7 @@ export class HubarrServices {
       // ------------------------------------------------------------------
       emit("publish-collections", "running", "Publishing collections...");
       try {
-        await withTimeout(this.runPublishPass(), 120_000, "Publish collections");
+        await withTimeout(this.runPublishPass(true), 120_000, "Publish collections");
         emit("publish-collections", "done", "Collections published");
         this.logger.info("Onboarding preload: collection publish complete");
       } catch (err) {
@@ -1098,6 +1125,7 @@ export class HubarrServices {
     friend: UserRecord,
     items: WatchlistItem[],
     runId: number | null,
+    force: boolean,
     plex = this.getPlexIntegration()
   ) {
     const appSettings = this.db.getAppSettings();
@@ -1109,7 +1137,8 @@ export class HubarrServices {
       isSelf: friend.isSelf,
       totalItems: items.length,
       effectiveSortOrder,
-      sortOrderOverride: friend.collectionSortOrderOverride
+      sortOrderOverride: friend.collectionSortOrderOverride,
+      force
     });
     if (friend.collectionSortOrderOverride) {
       this.logger.info("Using per-user collection sort order override", {
@@ -1152,6 +1181,32 @@ export class HubarrServices {
       }
       const matchedRatingKeys = filteredItems.map((item) => item.matchedRatingKey as string);
       const collectionName = friend.collectionName;
+      const labelName = plex.createCollectionLabel(friend.username);
+      const visibility = friend.visibilityOverride ?? appSettings.visibilityDefaults;
+
+      // Compute a hash of everything that affects what Plex sees for this
+      // collection. If nothing has changed since the last successful publish
+      // and we have a stored rating key, skip all Plex API calls.
+      const stateHash = computePublishStateHash({
+        matchedRatingKeys,
+        collectionName,
+        sortOrder: effectiveSortOrder,
+        visibility,
+        labelName
+      });
+
+      if (!force) {
+        const stored = this.db.getCollectionRecord(friend.id, mediaType);
+        if (stored?.collectionRatingKey && stored.lastSyncedHash === stateHash) {
+          this.logger.debug("Collection state unchanged, skipping publish", {
+            userId: friend.id,
+            mediaType,
+            collectionRatingKey: stored.collectionRatingKey
+          });
+          continue;
+        }
+      }
+
       this.logger.info("Publishing media bucket", {
         userId: friend.id,
         mediaType,
@@ -1218,7 +1273,6 @@ export class HubarrServices {
         matchedItems: cleanedKeys.length
       });
 
-      const labelName = plex.createCollectionLabel(friend.username);
       await plex.applyLabelToCollection(collectionRatingKey, labelName);
       this.logger.info("Collection label applied", {
         userId: friend.id,
@@ -1227,7 +1281,6 @@ export class HubarrServices {
         labelName
       });
 
-      const visibility = friend.visibilityOverride ?? appSettings.visibilityDefaults;
       const hubIdentifier = await plex.updateCollectionVisibility(
         collectionRatingKey,
         libraryId,
@@ -1239,13 +1292,21 @@ export class HubarrServices {
         collectionRatingKey,
         hubIdentifier
       });
-      const hash = plex.hashRatingKeys(cleanedKeys);
+
+      // If stale keys were removed during this publish the stored hash must
+      // reflect the cleaned list, not the pre-sync desired list. That way the
+      // next scheduled run recomputes from the (now-shorter) matched set and
+      // recognises the change, triggering a re-publish to clean up Plex.
+      const storedHash = (syncStaleKeys.size > 0 || reorderStaleKeys.size > 0)
+        ? computePublishStateHash({ matchedRatingKeys: cleanedKeys, collectionName, sortOrder: effectiveSortOrder, visibility, labelName })
+        : stateHash;
+
       this.db.upsertCollectionRecord(friend.id, mediaType, {
         collectionRatingKey,
         visibleName: collectionName,
         labelName,
         hubIdentifier,
-        lastSyncedHash: hash,
+        lastSyncedHash: storedHash,
         lastSyncedAt: new Date().toISOString(),
         lastSyncError: null
       });
@@ -1268,7 +1329,7 @@ export class HubarrServices {
     }
   }
 
-  async runFullSync() {
+  async runFullSync(force = false) {
     const syncStart = Date.now();
     const runId = this.db.createSyncRun("full", "Full sync started.");
     const { trackedUsers, publishingUsers } = this.getUserScopes();
@@ -1358,7 +1419,7 @@ export class HubarrServices {
 
     // Publish pass runs first so stale matchedRatingKey values are cleared before
     // Seerr sync evaluates which items are genuinely missing from Plex.
-    await this.runPublishPass().then(() => {
+    await this.runPublishPass(force).then(() => {
       this.db.addSyncRunItem(runId, "collection.publish.followup", "success", {
         sourceRunKind: "full",
         message: "Triggered collection publish after full sync."
@@ -1435,7 +1496,8 @@ export class HubarrServices {
 
       // Publish pass runs first so stale matchedRatingKey values are cleared before
       // Seerr sync evaluates which items are genuinely missing from Plex.
-      await this.runPublishPass().catch((err) => {
+      // Force is true — manual sync should always push to Plex regardless of hash.
+      await this.runPublishPass(true).catch((err) => {
         this.logger.warn("Collection publish after user sync failed", {
           userId: friend.id,
           message: err instanceof Error ? err.message : String(err)
@@ -1467,10 +1529,10 @@ export class HubarrServices {
   }
 
   async refreshAllWatchlists() {
-    return this.runFullSync();
+    return this.runFullSync(true);
   }
 
-  async runPublishPass() {
+  async runPublishPass(force = false) {
     const syncStart = Date.now();
     const runId = this.db.createSyncRun("publish", "Collection sync started.");
     const { publishingUsers } = this.getUserScopes();
@@ -1478,7 +1540,7 @@ export class HubarrServices {
     const failures: string[] = [];
     const plex = this.getPlexIntegration();
 
-    this.logger.info("Collection sync started", { userCount: friends.length });
+    this.logger.info("Collection sync started", { userCount: friends.length, force });
 
     const publishLimit = pLimit(PLEX_SYNC_CONCURRENCY);
     let publishCompleted = 0;
@@ -1486,7 +1548,7 @@ export class HubarrServices {
     await Promise.all(friends.map((friend) =>
       publishLimit(async () => {
         try {
-          await this.publishUserCollections(friend, this.db.getWatchlistItems(friend.id), runId, plex);
+          await this.publishUserCollections(friend, this.db.getWatchlistItems(friend.id), runId, force, plex);
           this.db.markUserSyncResult(friend.id, null);
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1198,12 +1198,38 @@ export class HubarrServices {
       if (!force) {
         const stored = this.db.getCollectionRecord(friend.id, mediaType);
         if (stored?.collectionRatingKey && stored.lastSyncedHash === stateHash) {
-          this.logger.debug("Collection state unchanged, skipping publish", {
+          // Hash matches — validate the collection still exists in Plex before
+          // skipping. A transient error (network, auth) falls through to the
+          // full publish rather than silently skipping; a definitive 400/404
+          // means the collection was externally deleted and needs to be recreated.
+          let exists: boolean;
+          try {
+            exists = await plex.collectionExists(stored.collectionRatingKey);
+          } catch (err) {
+            this.logger.warn("Could not validate collection existence, proceeding with full publish", {
+              userId: friend.id,
+              mediaType,
+              collectionRatingKey: stored.collectionRatingKey,
+              error: err instanceof Error ? err.message : String(err)
+            });
+            exists = false; // fall through to full publish
+          }
+
+          if (exists) {
+            this.logger.debug("Collection state unchanged and collection validated, skipping publish", {
+              userId: friend.id,
+              mediaType,
+              collectionRatingKey: stored.collectionRatingKey
+            });
+            continue;
+          }
+
+          this.logger.info("Stored collection no longer exists in Plex, clearing and republishing", {
             userId: friend.id,
             mediaType,
             collectionRatingKey: stored.collectionRatingKey
           });
-          continue;
+          this.db.clearCollectionRatingKey(friend.id, mediaType);
         }
       }
 


### PR DESCRIPTION
## Summary

The collection publish job previously ran the full Plex API sequence on every scheduled tick — `ensureCollection`, `syncCollectionItems`, `applyLabelToCollection`, `updateCollectionVisibility` — even when nothing about the collection had changed. For multi-user installs this meant unnecessary API traffic on every job interval (potentially every few minutes), putting avoidable load on both Plex and Hubarr.

This PR makes scheduled publish passes skip any collection bucket where the state hasn't changed since the last successful publish. Manual triggers (button clicks) always force a full push to Plex, so clicking a button still does what you expect even if something went wrong externally.

## Changes

**`src/server/services.ts`**
- Added `computePublishStateHash()` — SHA-256 hash of all publish-relevant state per user+mediaType: matched rating keys (sorted), collection name, sort order, visibility settings, and label name.
- `publishUserCollections()` gains a `force: boolean` parameter. When `force` is false, it reads the stored `plex_collections` record for the bucket and skips all Plex API calls if the hash matches and a rating key is already stored.
- `runPublishPass(force = false)` and `runFullSync(force = false)` propagate `force` down to `publishUserCollections`.
- Manual callers pass `force = true`: `runUserSync`, `refreshAllWatchlists`, and onboarding preload.
- RSS-triggered publish stays at `force = false` — the hash will already have changed because new items just arrived.
- If stale keys are cleaned during a publish, the stored hash is recomputed from the cleaned list so the next scheduled run detects the shorter key list and re-publishes.

**`src/server/app.ts`**
- "Run Now" handlers for `collection-publish` and `full-sync` now pass a `taskOverride` to `scheduler.runNow()` that calls the forced variant, so manual triggers bypass the hash check while still routing through the scheduler for concurrency tracking.

**`src/server/job-scheduler.ts`**
- `runNow()` and `execute()` accept an optional `taskOverride` function, allowing callers to substitute an alternative task for a single manual run without changing the registered scheduled task.

**`src/server/db/collections.ts`** / **`src/server/db/index.ts`**
- Added `getCollectionRecord(userId, mediaType)` DB helper so `publishUserCollections` can look up the stored hash for a specific bucket without loading all collections.

## Test plan

- [x] Trigger a scheduled collection publish (or wait for the job to fire) with no watchlist changes — confirm logs show "Collection state unchanged, skipping publish" for each user+mediaType bucket and no Plex API calls are made.
- [x] Add an item to a user's watchlist and wait for the next scheduled publish — confirm the hash changes and the collection is updated in Plex.
- [x] Change a collection setting (sort order, visibility, collection name) and trigger a scheduled publish — confirm the hash changes and the update is pushed to Plex.
- [x] Click the per-user sync button — confirm the collection is published to Plex regardless of whether anything changed.
- [x] Click "Run Now" on the collection-publish job in Settings → Jobs — confirm force publish runs.
- [x] Click "Run Now" on the full-sync job — confirm force publish runs.
- [x] Click the watchlist refresh button — confirm force publish runs.
- [x] Complete onboarding preload — confirm collections are force-published.
- [x] Verify RSS sync: when new RSS items arrive, confirm the collection is updated (hash will differ due to new items).


🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection publishing now computes and stores a deterministic hash to skip unchanged publishes and re-checks external collection existence to avoid unnecessary API calls.
  * Manual triggers and onboarding flows can force immediate publish/full-sync to ensure updates complete.

* **Bug Fixes**
  * Manual job-run endpoint now returns 404 for unavailable jobs when the scheduler is not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->