### PR TITLE
feat: add custom collection posters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ ARG BUILD_CHANNEL=custom
 ARG COMMIT_SHA=local
 ENV BUILD_CHANNEL=$BUILD_CHANNEL
 ENV COMMIT_SHA=$COMMIT_SHA
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
@@ -26,4 +29,3 @@ RUN mkdir -p /config && chown -R node:node /config /app
 USER node
 EXPOSE 9301
 CMD ["node", "dist/server/server/index.js"]
-

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -174,6 +174,7 @@ How it works:
 - loads the cached watchlist state for each publishing user
 - builds the movie and TV collections for that user from matched items
 - ensures collection labels and sort behavior are correct
+- generates and uploads Hubarr artwork for each collection
 - updates Plex hub visibility settings
 - reapplies user visibility isolation rules
 

--- a/src/server/collection-artwork.ts
+++ b/src/server/collection-artwork.ts
@@ -1,0 +1,131 @@
+import sharp from "sharp";
+import type { MediaType } from "../shared/types.js";
+
+const POSTER_WIDTH = 1000;
+const POSTER_HEIGHT = 1500;
+const MAX_TITLE_LINES = 3;
+
+const THEMES: Record<MediaType, {
+  label: string;
+  accent: string;
+  accentSoft: string;
+  background: string;
+  glow: string;
+}> = {
+  movie: {
+    label: "MOVIES",
+    accent: "#4ade80",
+    accentSoft: "#bbf7d0",
+    background: "#07130d",
+    glow: "#12452a"
+  },
+  show: {
+    label: "SHOWS",
+    accent: "#5ec8ff",
+    accentSoft: "#b5e9ff",
+    background: "#0d1320",
+    glow: "#123f57"
+  }
+};
+
+function escapeSvgText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function normalizeCollectionName(value: string | null | undefined): string {
+  const cleaned = value?.trim().replace(/\s+/g, " ");
+  return cleaned || "Watchlist";
+}
+
+function wrapTitle(value: string): string[] {
+  const words = value.split(" ").filter(Boolean);
+  if (words.length <= MAX_TITLE_LINES) {
+    return words;
+  }
+
+  return [
+    ...words.slice(0, MAX_TITLE_LINES - 1),
+    words.slice(MAX_TITLE_LINES - 1).join(" ")
+  ];
+}
+
+function buildTitleText(title: string): { lines: string[]; fontSize: number; lineHeight: number } {
+  const lines = wrapTitle(title);
+  const longestLine = Math.max(...lines.map((line) => line.length), 1);
+  const fittedSize = Math.floor(1220 / longestLine);
+
+  if (lines.length === 1) {
+    return { lines, fontSize: Math.min(132, fittedSize), lineHeight: 146 };
+  }
+  if (lines.length === 2) {
+    return { lines, fontSize: Math.min(104, fittedSize), lineHeight: 116 };
+  }
+  return { lines, fontSize: Math.min(78, fittedSize), lineHeight: 90 };
+}
+
+function buildIcon(mediaType: MediaType, accent: string): string {
+  if (mediaType === "movie") {
+    return `
+      <path d="M500 205l75 153 169 25-122 119 29 168-151-79-151 79 29-168-122-119 169-25z" fill="none" stroke="${accent}" stroke-width="28" stroke-linejoin="round"/>
+    `;
+  }
+
+  return `
+    <rect x="230" y="302" width="540" height="320" rx="34" fill="none" stroke="${accent}" stroke-width="24"/>
+    <rect x="282" y="356" width="436" height="188" rx="18" fill="${accent}" opacity="0.14"/>
+    <path d="M404 302l-92 -96M596 302l92 -96" stroke="${accent}" stroke-width="22" stroke-linecap="round"/>
+    <circle cx="360" cy="580" r="15" fill="${accent}"/>
+    <circle cx="640" cy="580" r="15" fill="${accent}"/>
+  `;
+}
+
+export async function generateCollectionPoster(params: {
+  collectionName: string | null | undefined;
+  mediaType: MediaType;
+}): Promise<Buffer> {
+  const theme = THEMES[params.mediaType];
+  const title = normalizeCollectionName(params.collectionName);
+  const text = buildTitleText(title);
+  const firstLineY = 852 - ((text.lines.length - 1) * text.lineHeight) / 2;
+  const titleLines = text.lines
+    .map((line, index) => (
+      `<text x="500" y="${firstLineY + index * text.lineHeight}" text-anchor="middle" class="title">${escapeSvgText(line)}</text>`
+    ))
+    .join("");
+
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="${POSTER_WIDTH}" height="${POSTER_HEIGHT}" viewBox="0 0 ${POSTER_WIDTH} ${POSTER_HEIGHT}">
+      <defs>
+        <radialGradient id="glow" cx="50%" cy="35%" r="72%">
+          <stop offset="0%" stop-color="${theme.glow}" stop-opacity="1"/>
+          <stop offset="58%" stop-color="${theme.background}" stop-opacity="1"/>
+          <stop offset="100%" stop-color="#08090d" stop-opacity="1"/>
+        </radialGradient>
+        <linearGradient id="band" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stop-color="${theme.accent}" stop-opacity="0.92"/>
+          <stop offset="100%" stop-color="${theme.accentSoft}" stop-opacity="0.72"/>
+        </linearGradient>
+        <style>
+          .label { font: 700 54px Arial, Helvetica, sans-serif; letter-spacing: 10px; fill: ${theme.accentSoft}; }
+          .title { font: 800 ${text.fontSize}px Arial, Helvetica, sans-serif; fill: #f8f8f4; }
+        </style>
+      </defs>
+      <rect width="1000" height="1500" fill="url(#glow)"/>
+      <rect x="68" y="68" width="864" height="1364" rx="54" fill="none" stroke="url(#band)" stroke-width="10"/>
+      <rect x="118" y="118" width="764" height="1264" rx="34" fill="none" stroke="#ffffff" stroke-opacity="0.1" stroke-width="3"/>
+      <g opacity="0.98">${buildIcon(params.mediaType, theme.accent)}</g>
+      ${titleLines}
+      <rect x="305" y="1096" width="390" height="8" rx="4" fill="${theme.accent}"/>
+      <text x="500" y="1268" text-anchor="middle" class="label">${theme.label}</text>
+    </svg>
+  `;
+
+  return sharp(Buffer.from(svg))
+    .jpeg({ quality: 92, mozjpeg: true })
+    .toBuffer();
+}

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1287,6 +1287,20 @@ export class PlexIntegration {
     await this.requestServer(`/library/metadata/${ratingKey}?${params.toString()}`, { method: "PUT" });
   }
 
+  async uploadCollectionPoster(ratingKey: string, poster: Buffer): Promise<void> {
+    this.logger.info("Uploading Plex collection poster", {
+      ratingKey,
+      bytes: poster.byteLength
+    });
+    await this.requestServer(`/library/metadata/${ratingKey}/posters`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "image/jpeg"
+      },
+      body: new Blob([new Uint8Array(poster)], { type: "image/jpeg" })
+    });
+  }
+
   async ensureCollection(title: string, username: string, mediaType: MediaType, libraryId: string) {
     const collections = await this.getCollections(libraryId);
     const label = this.createCollectionLabel(username);

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -12,6 +12,7 @@ import type {
   VisibilityConfig
 } from "../shared/types.js";
 import pLimit from "p-limit";
+import { generateCollectionPoster } from "./collection-artwork.js";
 import { HubarrDatabase } from "./db/index.js";
 import { ImageCacheService } from "./image-cache.js";
 import { Logger } from "./logger.js";
@@ -27,7 +28,8 @@ const PLEX_SYNC_CONCURRENCY = 3;
  * stored value the publish step can be skipped entirely.
  *
  * Covers: item list, collection name, sort order, visibility, and label.
- * Display name is intentionally excluded — it only drives the poster (future).
+ * Poster artwork is intentionally applied during each publish rather than
+ * participating in the skip hash.
  */
 function computePublishStateHash(params: {
   matchedRatingKeys: string[];
@@ -152,6 +154,7 @@ export class HubarrServices {
   private usersRssUrl: string | null = null;
   private usersRssPrimed = false;
   private readonly usersRssCache = new RssCache();
+  private readonly uploadedCollectionPosterKeys = new Set<string>();
   private seerrRequestSyncActiveRuns = 0;
   private seerrRequestSyncQueue: Promise<void> = Promise.resolve();
   private onboardingPreloadSession: {
@@ -1246,6 +1249,7 @@ export class HubarrServices {
         mediaType,
         collectionRatingKey
       });
+      await this.applyCollectionPoster(plex, friend, mediaType, collectionRatingKey);
       await plex.updateCollectionSortTitle(collectionRatingKey, `!10_${collectionName}`);
       await plex.updateCollectionContentSort(collectionRatingKey, effectiveSortOrder);
       const { staleKeys: syncStaleKeys } = await plex.syncCollectionItems(collectionRatingKey, matchedRatingKeys);
@@ -1353,6 +1357,31 @@ export class HubarrServices {
         );
       }
     }
+  }
+
+  private async applyCollectionPoster(
+    plex: PlexIntegration,
+    friend: UserRecord,
+    mediaType: "movie" | "show",
+    collectionRatingKey: string
+  ): Promise<void> {
+    const posterKey = `${collectionRatingKey}:${mediaType}:${friend.collectionName}`;
+    if (this.uploadedCollectionPosterKeys.has(posterKey)) {
+      return;
+    }
+
+    const poster = await generateCollectionPoster({
+      collectionName: friend.collectionName,
+      mediaType
+    });
+    await plex.uploadCollectionPoster(collectionRatingKey, poster);
+    this.uploadedCollectionPosterKeys.add(posterKey);
+    this.logger.info("Collection poster uploaded", {
+      userId: friend.id,
+      displayName: friend.displayName,
+      mediaType,
+      collectionRatingKey
+    });
   }
 
   async runFullSync(force = false) {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1372,11 +1372,23 @@ export class HubarrServices {
       return;
     }
 
-    const poster = await generateCollectionPoster({
-      collectionName: friend.collectionName,
-      mediaType
-    });
-    await plex.uploadCollectionPoster(collectionRatingKey, poster);
+    try {
+      const poster = await generateCollectionPoster({
+        collectionName: friend.collectionName,
+        mediaType
+      });
+      await plex.uploadCollectionPoster(collectionRatingKey, poster);
+    } catch (err) {
+      this.logger.warn("Collection poster upload failed; continuing collection publish", {
+        posterKey,
+        collectionRatingKey,
+        mediaType,
+        userId: friend.id,
+        message: err instanceof Error ? err.message : String(err)
+      });
+      return;
+    }
+
     this.uploadedCollectionPosterKeys.add(posterKey);
     this.logger.info("Collection poster uploaded", {
       userId: friend.id,

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -154,6 +154,8 @@ export class HubarrServices {
   private usersRssUrl: string | null = null;
   private usersRssPrimed = false;
   private readonly usersRssCache = new RssCache();
+  // Process-local guard to avoid re-uploading generated collection posters during one run.
+  // A restart may upload the same poster again, which is acceptable for this low-frequency path.
   private readonly uploadedCollectionPosterKeys = new Set<string>();
   private seerrRequestSyncActiveRuns = 0;
   private seerrRequestSyncQueue: Promise<void> = Promise.resolve();

--- a/tests/server/collection-artwork.test.ts
+++ b/tests/server/collection-artwork.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import sharp from "sharp";
+import { generateCollectionPoster } from "../../src/server/collection-artwork.js";
+
+test("generateCollectionPoster creates a Plex poster-sized JPEG", async () => {
+  const poster = await generateCollectionPoster({
+    collectionName: "Alexs Watchlist",
+    mediaType: "movie"
+  });
+  const metadata = await sharp(poster).metadata();
+
+  assert.equal(metadata.format, "jpeg");
+  assert.equal(metadata.width, 1000);
+  assert.equal(metadata.height, 1500);
+  assert.ok(poster.byteLength > 10_000);
+});
+
+test("generateCollectionPoster creates different artwork for movies and shows", async () => {
+  const moviePoster = await generateCollectionPoster({
+    collectionName: "Alexs Watchlist",
+    mediaType: "movie"
+  });
+  const showPoster = await generateCollectionPoster({
+    collectionName: "Alexs Watchlist",
+    mediaType: "show"
+  });
+
+  assert.notEqual(moviePoster.toString("base64"), showPoster.toString("base64"));
+});


### PR DESCRIPTION
## Summary

Adds generated artwork for Hubarr-managed Plex watchlist collections so movie and show collections have distinctive posters instead of relying on Plex defaults. The artwork uses the assigned collection name, applies separate movie/show visual treatments, and is uploaded as part of the normal collection publish flow.

Closes #129

## Changes

- `src/server/collection-artwork.ts`: adds a Sharp-backed poster generator that renders 1000x1500 JPEG artwork with collection-name text, media-type label, movie star artwork, and show TV artwork.
- `src/server/services.ts`: applies generated posters during collection publishes without adding poster settings or persistent poster hash tracking, while unchanged collection state still skips Plex writes during normal scheduled/startup runs.
- `src/server/integrations/plex.ts`: adds a Plex collection poster upload helper for `/library/metadata/{ratingKey}/posters`.
- `Dockerfile`: installs `fontconfig` and DejaVu fonts in the runtime image so SVG text rendering works cleanly in the slim container.
- `tests/server/collection-artwork.test.ts`: covers generated poster dimensions/format and verifies movie/show artwork differs.
- `docs/sync.md`: documents that collection sync now generates and uploads Hubarr artwork.

## Test plan

- [x] Run `npm run check` to verify client and server TypeScript.
- [x] Run `node --import tsx --test tests/server/*.test.ts` to verify server unit coverage including artwork generation.
- [x] Build a local `hubarr` Docker image from this branch and recreate the `hubarr` container with bridge networking, `/opt/hubarr:/config`, and port `9301:9301`.
- [x] Confirm the container serves `200 text/html` from inside the container.
- [x] Run a forced collection publish and confirm Plex poster uploads are logged for movie and show collections.
- [x] Restart/recreate the container and confirm unchanged collections are validated and skipped without re-uploading posters.

Closes #129 

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection posters are generated (movie/show themes) and uploaded to Plex when collections are published; upload failures are logged but won't abort publishing.

* **Documentation**
  * Collection sync docs updated to note poster generation and upload.

* **Tests**
  * Added tests validating poster generation and output differences.

* **Chores**
  * Runtime image now includes system fonts for consistent poster rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->