### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hubarr",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hubarr",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hubarr",
   "private": true,
   "license": "GPL-3.0-only",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server/index.ts",


### PR DESCRIPTION
## Summary

Bumps the package version from 2.0.0 to 2.1.0 in preparation for the v2.1.0 release. This is a minor release that includes two feature PRs (custom collection posters) and dependency updates since v2.0.0.

## Changes

- **package.json** — version field updated from `2.0.0` to `2.1.0`
- **package-lock.json** — version field updated from `2.0.0` to `2.1.0`

## Test plan

- [ ] Confirm `package.json` shows `"version": "2.1.0"`
- [ ] Confirm `package-lock.json` shows `"version": "2.1.0"`
- [ ] PR merges cleanly into `develop` with no conflicts

🤖 Generated with Claude Code