### PR TITLE
feat: add admin watchlist cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Hubarr uses a few background jobs:
 
 - **Watchlist RSS Sync** watches Plex RSS feeds for quick watchlist changes and stores new items fast
 - **Watchlist GraphQL Sync** regularly performs a fuller watchlist reconciliation to catch anything RSS missed
+- **Watchlist Cleanup** runs the optional watched-item cleanup checks on schedule
 - **Plex Library Scans** help Hubarr notice when something from a watchlist has now actually appeared in your Plex libraries
 - **Collection Sync** is the job that updates the Plex collections and hub rows
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -127,6 +127,9 @@ Read-only. Safe to run against a live instance.
 | Disabled users never show a Sync Watchlist button | Expands the disabled users section and asserts no `Sync Watchlist` button is rendered there |
 | Refresh Users button is present | Asserts the Refresh Users button renders |
 | Edit modal shows collection ordering override section | Clicks the first user's edit button, asserts the "Collection Ordering" section is visible in the modal, and that the dropdown contains the two watchlist date sort options |
+| Watchlist tab is only available when editing the self user | Opens the self user edit modal and asserts the Watchlist tab is present, then opens a non-self user when available and asserts the tab is absent |
+| Self Watchlist tab shows cleanup options without changing them | Opens the self user edit modal, navigates to Watchlist, and asserts both cleanup options and explanatory text are visible without saving |
+| Watchlist Cleanup job is enabled when cleanup settings are already enabled | Reads current settings; if cleanup is already enabled, verifies the Jobs row is enabled, otherwise skips without changing settings |
 
 ---
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -6,6 +6,7 @@ Hubarr uses separate background jobs so each job has one clear responsibility:
 
 - `Watchlist RSS Sync`
 - `Watchlist GraphQL Sync`
+- `Watchlist Cleanup`
 - `Activity Cache Fetch`
 - `Plex Recently Added Scan`
 - `Plex Full Library Scan`
@@ -14,8 +15,8 @@ Hubarr uses separate background jobs so each job has one clear responsibility:
 - `Plex Refresh Token`
 - `Maintenance Tasks`
 
-For a detailed explanation of how the three watchlist-specific jobs work together
-— including date resolution, RSS deduplication, and the activity feed cache —
+For a detailed explanation of how the watchlist-specific jobs work together
+— including date resolution, RSS deduplication, cleanup, and the activity feed cache —
 see [docs/watchlist.md](watchlist.md).
 
 ---
@@ -67,6 +68,7 @@ The most important data groups are:
 
 - `Watchlist RSS Sync` interval
 - `Watchlist GraphQL Sync` interval
+- `Watchlist Cleanup` interval and enablement
 - `Activity Cache Fetch` interval
 - `Collection Sync` interval
 - `Plex Recently Added Scan` interval

--- a/docs/watchlist.md
+++ b/docs/watchlist.md
@@ -16,10 +16,12 @@ different frequencies and serve different purposes:
 | GraphQL full sync | Configurable (default 1h) | Authoritative list of what is currently on each watchlist |
 | RSS polling | Configurable (default 30s) | Fast detection of new additions |
 | Activity feed cache | Configurable (default 1h), independently scheduled | Historical `addedAt` dates for watchlist items |
+| Watchlist cleanup | Configurable (default 30m), disabled until enabled | Removes watched admin/self items from the Plex watchlist |
 
 The GraphQL sync is the source of truth for what is on a watchlist right now.
 The RSS feeds catch new items quickly between full syncs. The activity feed
 cache fills in when items were added, which GraphQL alone cannot answer.
+The cleanup job is optional and only acts on the admin/self watchlist.
 
 Hubarr distinguishes between:
 
@@ -166,6 +168,72 @@ When the background RSS poll detects new items and processes them, a collection
 publish is triggered immediately afterwards. Only enabled users publish
 collections, so disabled tracked users may refresh cached watchlist state
 without becoming visible in Plex or the main Hubarr watchlist views.
+
+---
+
+## Watchlist Cleanup
+
+**Endpoint:** Local Plex history via `/status/sessions/history/all?metadataItemID=<ratingKey>`,
+Plex Discover metadata via `discover.provider.plex.tv`, and Discover watchlist
+removal via `/actions/removeFromWatchlist?ratingKey=<discoverKey>`
+**Schedule:** Every `watchlistCleanupIntervalMinutes` (default 30 minutes) when
+movie or show cleanup is enabled.
+**Code:** `src/server/services.ts` → `runWatchlistCleanup()`,
+`src/server/integrations/plex.ts` → history, Discover children, and removal helpers
+
+### What it does
+
+Watchlist cleanup removes items from the admin's Plex watchlist after Hubarr can
+prove they were watched after they were added to the watchlist. The settings live
+in the existing app settings JSON and are exposed in the admin/self user's edit
+modal under the Watchlist tab:
+
+- `Remove Movie When Watched`
+- `Remove Show When Watched`
+
+The job is always visible on Settings > Jobs as `Watchlist Cleanup`, but remains
+disabled until at least one of those options is enabled. When disabled, the job
+has no next run and cannot be run manually.
+
+### Movie cleanup
+
+For movies, Hubarr checks admin watchlist rows that have a local
+`matchedRatingKey`. It queries Plex play history with `metadataItemID`, not
+`ratingKey`, because `metadataItemID` is the server-side filter that correctly
+scopes history to one local metadata item. A movie is removed only when at least
+one history entry has `viewedAt` later than the stored watchlist `addedAt`.
+
+Older history is explicitly ignored so a title watched before being watchlisted
+for a rewatch is not removed.
+
+### Show cleanup
+
+For shows, Hubarr uses Discover season and episode children as the expected
+episode list. Specials (`season 0`) are ignored. The top-level show `leafCount`
+is not used because Discover season/episode children are more precise and expose
+future episode dates.
+
+A show is removed only when:
+
+- Discover returns a complete non-special episode list
+- every expected non-special episode exists in the local Plex library
+- no expected episode has a future or uncertain air date
+- every expected non-special episode has local play history after the watchlist
+  `addedAt`
+
+If any of those checks is uncertain, the show stays on the watchlist and the
+cleanup run records a skipped decision in History.
+
+### Removal and publish
+
+Removal uses the admin Plex account token stored in the `admin` setting, not a
+friend token. After Plex accepts the removal, Hubarr deletes the corresponding
+admin row from `watchlist_cache` immediately so the UI reflects the change before
+the next GraphQL sync.
+
+When at least one item is removed, Hubarr triggers a collection publish pass so
+Plex collections update promptly. Runs with no removals complete as successful
+skipped/no-change runs and do not trigger a publish.
 
 ---
 

--- a/docs/watchlist.md
+++ b/docs/watchlist.md
@@ -185,7 +185,7 @@ movie or show cleanup is enabled.
 
 Watchlist cleanup removes items from the admin's Plex watchlist after Hubarr can
 prove they were watched after they were added to the watchlist. The settings live
-in the existing app settings JSON and are exposed in the admin/self user's edit
+in the existing app settings JSON and are exposed in the admin/self-user's edit
 modal under the Watchlist tab:
 
 - `Remove Movie When Watched`

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -47,7 +47,9 @@ const ACTION_LABELS: Record<string, string> = {
   "seerr.request.failed": "Seerr request failed",
   "watchlist.cleanup.removed": "Watchlist cleanup removed",
   "watchlist.cleanup.skipped": "Watchlist cleanup skipped",
-  "watchlist.cleanup.failed": "Watchlist cleanup failed"
+  "watchlist.cleanup.failed": "Watchlist cleanup failed",
+  "watchlist.cleanup.failed-item": "Watchlist cleanup item failed",
+  "watchlist.publish.failed": "Watchlist cleanup publish failed"
 };
 
 const VALID_KINDS: KindFilter[] = ["all", "full", "rss", "user", "publish", "seerr", "watchlist-cleanup"];

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -939,11 +939,8 @@ function StepsCollapsible({ items }: { items: HistoryStep[] }) {
     return "border-transparent bg-background-container/50";
   };
 
-  const labelClass = (item: HistoryStep) => {
-    if (item.variant === "removed") return "text-error";
-    if (item.variant === "skipped") return "text-on-surface-variant";
-    return "text-on-surface-variant";
-  };
+  const labelClass = (item: HistoryStep) =>
+    item.variant === "removed" ? "text-error" : "text-on-surface-variant";
 
   return (
     <div>

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -313,7 +313,7 @@ function formatStepLabel(item: SyncRunItem): string {
 
   if (item.action === "collection.publish.followup") {
     const details = item.details as { message?: string } | null;
-    return details?.message ?? "Triggered collection publish after full sync";
+    return details?.message ?? "Triggered collection publish";
   }
 
   return ACTION_LABELS[item.action] ?? item.action;

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -1,12 +1,12 @@
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { AlertCircle, CheckCircle, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Clock, XCircle } from "lucide-react";
+import { AlertCircle, CheckCircle, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Clock, MinusCircle, Trash2, XCircle } from "lucide-react";
 import { apiGet } from "../lib/api";
 import { useLiveRefresh } from "../lib/useLiveRefresh";
 import { formatDateTime, formatRelativeTime } from "../lib/utils";
 import type { HistoryPageResponse, SearchCandidate, SyncRun, SyncRunDetail, SyncRunItem } from "../../shared/types";
 
-type KindFilter = "all" | "full" | "rss" | "user" | "publish" | "seerr";
+type KindFilter = "all" | "full" | "rss" | "user" | "publish" | "seerr" | "watchlist-cleanup";
 type StatusFilter = "all" | "success" | "error" | "running";
 
 const KIND_LABELS: Record<string, string> = {
@@ -14,13 +14,14 @@ const KIND_LABELS: Record<string, string> = {
   rss: "RSS",
   user: "Manual",
   publish: "Collection",
-  seerr: "Seerr"
+  seerr: "Seerr",
+  "watchlist-cleanup": "Watchlist Cleanup"
 };
 
 // Strip the leading sync-kind prefix from a summary
 // string since the row header already shows the sync type.
 function stripKindPrefix(summary: string): string {
-  return summary.replace(/^(RSS sync|Full sync|Manual sync|Collection publish|Collection sync|Seerr request sync)[:\s]*/i, "").trim();
+  return summary.replace(/^(RSS sync|Full sync|Manual sync|Collection publish|Collection sync|Seerr request sync|Watchlist Cleanup)[:\s]*/i, "").trim();
 }
 
 function capitalizeSentence(text: string): string {
@@ -43,10 +44,13 @@ const ACTION_LABELS: Record<string, string> = {
   "seerr.request.created": "Seerr request created",
   "seerr.request.existing": "Already in Seerr",
   "seerr.request.skipped": "Seerr request skipped",
-  "seerr.request.failed": "Seerr request failed"
+  "seerr.request.failed": "Seerr request failed",
+  "watchlist.cleanup.removed": "Watchlist cleanup removed",
+  "watchlist.cleanup.skipped": "Watchlist cleanup skipped",
+  "watchlist.cleanup.failed": "Watchlist cleanup failed"
 };
 
-const VALID_KINDS: KindFilter[] = ["all", "full", "rss", "user", "publish", "seerr"];
+const VALID_KINDS: KindFilter[] = ["all", "full", "rss", "user", "publish", "seerr", "watchlist-cleanup"];
 const VALID_STATUSES: StatusFilter[] = ["all", "success", "error", "running"];
 const VALID_PAGE_SIZES = [10, 25, 50, 100];
 const HISTORY_FAST_REFRESH_MS = 2_500;
@@ -218,6 +222,7 @@ interface HistoryStep {
   status: "success" | "error";
   label: string;
   meta?: string;
+  variant?: "default" | "removed" | "skipped";
 }
 
 interface WatchlistFetchDetails {
@@ -437,6 +442,51 @@ function groupSuccessfulSteps(run: SyncRun, items: SyncRunItem[]): HistoryStep[]
         meta: formatStepMeta(item)
       });
     }
+  } else if (run.kind === "watchlist-cleanup") {
+    const cleanupItems = items.filter(
+      (item) =>
+        item.status === "success" &&
+        (item.action === "watchlist.cleanup.removed" || item.action === "watchlist.cleanup.skipped")
+    ).sort((a, b) => {
+      const aRemoved = a.action === "watchlist.cleanup.removed";
+      const bRemoved = b.action === "watchlist.cleanup.removed";
+      if (aRemoved !== bRemoved) return aRemoved ? -1 : 1;
+      return a.id - b.id;
+    });
+
+    for (const item of cleanupItems) {
+      const details = item.details as {
+        title?: string;
+        type?: string;
+        reason?: string;
+        message?: string;
+      } | null;
+      const title = details?.title ?? "Unknown item";
+      const type = details?.type ? ` (${details.type})` : "";
+      const verb = item.action === "watchlist.cleanup.removed" ? "Removed" : "Skipped";
+      steps.push({
+        id: `${item.id}-cleanup-item`,
+        status: "success",
+        label: `${verb}: ${title}${type}`,
+        meta: details?.message ?? details?.reason,
+        variant: item.action === "watchlist.cleanup.removed" ? "removed" : "skipped"
+      });
+    }
+
+    const genericSuccesses = items.filter(
+      (item) =>
+        item.status === "success" &&
+        item.action !== "watchlist.cleanup.removed" &&
+        item.action !== "watchlist.cleanup.skipped"
+    );
+    for (const item of genericSuccesses) {
+      steps.push({
+        id: `${item.id}-generic-success`,
+        status: "success",
+        label: formatStepLabel(item),
+        meta: formatStepMeta(item)
+      });
+    }
   } else {
     const genericSuccesses = items.filter(
       (item) =>
@@ -611,7 +661,7 @@ function RunRow({ run }: { run: SyncRun }) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="font-medium text-on-surface text-sm">
-              {KIND_LABELS[run.kind] ?? run.kind} Sync
+              {run.kind === "watchlist-cleanup" ? "Watchlist Cleanup" : `${KIND_LABELS[run.kind] ?? run.kind} Sync`}
             </span>
             <span className={`text-xs px-1.5 py-0.5 rounded-full border font-medium ${config.badge}`}>
               {titleCaseStatus(liveRun.status)}
@@ -867,6 +917,32 @@ function DateUnresolvedRow({ item }: { item: SyncRunItem }) {
 function StepsCollapsible({ items }: { items: HistoryStep[] }) {
   const [open, setOpen] = useState(false);
 
+  const renderStepIcon = (item: HistoryStep) => {
+    if (item.variant === "removed") {
+      return <Trash2 size={12} className="text-error flex-shrink-0" />;
+    }
+    if (item.variant === "skipped") {
+      return <MinusCircle size={12} className="text-warning flex-shrink-0" />;
+    }
+    return <CheckCircle size={12} className="text-success flex-shrink-0" />;
+  };
+
+  const stepClass = (item: HistoryStep) => {
+    if (item.variant === "removed") {
+      return "border-error/20 bg-error/5";
+    }
+    if (item.variant === "skipped") {
+      return "border-warning/20 bg-warning/5";
+    }
+    return "border-transparent bg-background-container/50";
+  };
+
+  const labelClass = (item: HistoryStep) => {
+    if (item.variant === "removed") return "text-error";
+    if (item.variant === "skipped") return "text-on-surface-variant";
+    return "text-on-surface-variant";
+  };
+
   return (
     <div>
       <button
@@ -879,9 +955,9 @@ function StepsCollapsible({ items }: { items: HistoryStep[] }) {
       {open && (
         <div className="mt-2 space-y-1">
           {items.map((item) => (
-            <div key={item.id} className="flex items-center gap-2 text-xs px-2 py-1 rounded-lg bg-background-container/50">
-              <CheckCircle size={12} className="text-success flex-shrink-0" />
-              <span className="text-on-surface-variant">{item.label}</span>
+            <div key={item.id} className={`flex items-center gap-2 text-xs px-2 py-1 rounded-lg border ${stepClass(item)}`}>
+              {renderStepIcon(item)}
+              <span className={labelClass(item)}>{item.label}</span>
               {item.meta && (
                 <span className="text-on-surface-variant/60 ml-auto text-right">{item.meta}</span>
               )}

--- a/src/client/pages/Settings.tsx
+++ b/src/client/pages/Settings.tsx
@@ -631,6 +631,7 @@ const JOB_PRESETS: Record<string, { unit: "minutes" | "hours"; values: number[] 
   "full-sync": { unit: "minutes", values: [5, 10, 15, 20, 30, 60, 120, 240, 360, 720, 1440] },
   "rss-sync":  { unit: "minutes", values: [1, 2, 5, 10, 15, 30] },
   "activity-cache-fetch": { unit: "minutes", values: [30, 60, 120, 240, 360, 720, 1440] },
+  "watchlist-cleanup": { unit: "minutes", values: [15, 30, 60, 120, 240, 360, 720, 1440] },
 };
 
 const JOBS_FAST_REFRESH_MS = 2_500;
@@ -856,15 +857,16 @@ function JobsTab() {
                       <div className="flex items-center justify-end gap-2">
                         {JOB_PRESETS[job.id] && (
                           <button
+                            disabled={!job.isEnabled}
                             onClick={() => openEdit(job)}
-                            className="flex items-center gap-1.5 text-on-surface-variant hover:text-on-surface hover:bg-background-container-high text-xs font-medium rounded-lg px-3 py-1.5 transition-colors border border-outline-variant/20"
+                            className="flex items-center gap-1.5 text-on-surface-variant hover:text-on-surface hover:bg-background-container-high disabled:opacity-50 disabled:hover:bg-transparent text-xs font-medium rounded-lg px-3 py-1.5 transition-colors border border-outline-variant/20"
                           >
                             <Pencil size={13} />
                             Edit
                           </button>
                         )}
                         <button
-                          disabled={runningId === job.id || job.isRunning}
+                          disabled={!job.isEnabled || runningId === job.id || job.isRunning}
                           onClick={() => void runJob(job.id)}
                           className="flex items-center gap-1.5 bg-primary-dim hover:bg-primary disabled:opacity-50 text-on-surface text-xs font-medium rounded-lg px-3 py-1.5 transition-colors border border-primary-dim"
                         >

--- a/src/client/pages/Users.tsx
+++ b/src/client/pages/Users.tsx
@@ -868,14 +868,14 @@ function EditModal({
           {activeTab === "watchlist" && user.isSelf && (
             <div className="space-y-4">
               <ToggleField
-                label="Remove Movie When Watched"
-                hint="Remove movies from watchlist once viewed."
+                label="Remove Movies When Watched"
+                hint="Remove movies from your watchlist once watched."
                 checked={watchlistCleanupMovies}
                 onChange={setWatchlistCleanupMovies}
               />
               <ToggleField
-                label="Remove Show When Watched"
-                hint="Remove show from watchlist once all non special episodes viewed."
+                label="Remove Shows When Watched"
+                hint="Remove shows from your watchlist once all non-special episodes are watched."
                 checked={watchlistCleanupShows}
                 onChange={setWatchlistCleanupShows}
               />

--- a/src/client/pages/Users.tsx
+++ b/src/client/pages/Users.tsx
@@ -534,7 +534,7 @@ function OverridableField({
   );
 }
 
-type EditModalTab = "user" | "collection" | "seerr";
+type EditModalTab = "user" | "collection" | "watchlist" | "seerr";
 
 function EditModal({
   user,
@@ -557,6 +557,8 @@ function EditModal({
   const [collectionSortOrderOverride, setCollectionSortOrderOverride] = useState<CollectionSortOrder | null>(
     user.collectionSortOrderOverride ?? null
   );
+  const [watchlistCleanupMovies, setWatchlistCleanupMovies] = useState(settings.watchlistCleanup.movieEnabled);
+  const [watchlistCleanupShows, setWatchlistCleanupShows] = useState(settings.watchlistCleanup.showEnabled);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -657,6 +659,15 @@ function EditModal({
         });
       }
 
+      if (user.isSelf) {
+        await apiPatch("/api/settings", {
+          watchlistCleanup: {
+            movieEnabled: watchlistCleanupMovies,
+            showEnabled: watchlistCleanupShows
+          }
+        });
+      }
+
       onClose();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
@@ -668,7 +679,8 @@ function EditModal({
   const tabs: { id: EditModalTab; label: string }[] = [
     { id: "user", label: "User" },
     { id: "collection", label: "Collection" },
-    ...(seerrEnabled ? [{ id: "seerr" as EditModalTab, label: "Seerr" }] : [])
+    ...(seerrEnabled ? [{ id: "seerr" as EditModalTab, label: "Seerr" }] : []),
+    ...(user.isSelf ? [{ id: "watchlist" as EditModalTab, label: "Watchlist" }] : [])
   ];
 
   const headerDisplayName = displayNameOverride.trim() || user.displayName;
@@ -849,6 +861,27 @@ function EditModal({
                   ))}
                 </div>
               </OverridableField>
+            </div>
+          )}
+
+          {/* Watchlist tab */}
+          {activeTab === "watchlist" && user.isSelf && (
+            <div className="space-y-4">
+              <ToggleField
+                label="Remove Movie When Watched"
+                hint="Remove movies from watchlist once viewed."
+                checked={watchlistCleanupMovies}
+                onChange={setWatchlistCleanupMovies}
+              />
+              <ToggleField
+                label="Remove Show When Watched"
+                hint="Remove show from watchlist once all non special episodes viewed."
+                checked={watchlistCleanupShows}
+                onChange={setWatchlistCleanupShows}
+              />
+              <p className="text-xs text-on-surface-variant leading-relaxed">
+                Hubarr can remove items from your Plex watchlist, but only when they have been fully viewed after they were watchlisted.
+              </p>
             </div>
           )}
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1392,8 +1392,18 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         enabled: true
       });
       res.json({ updated: true });
-    } else if (jobId === "watchlist-cleanup" && body.intervalMinutes) {
-      const updated = db.updateAppSettings({ watchlistCleanupIntervalMinutes: body.intervalMinutes });
+    } else if (jobId === "watchlist-cleanup") {
+      const intervalMinutes = body.intervalMinutes;
+      if (typeof intervalMinutes !== "number" || !Number.isInteger(intervalMinutes) || intervalMinutes < 1) {
+        logger.warn("Job schedule update rejected", {
+          jobId,
+          intervalMinutes,
+          reason: "missing-or-invalid-interval"
+        });
+        res.status(400).json({ error: "intervalMinutes must be a positive integer." });
+        return;
+      }
+      const updated = db.updateAppSettings({ watchlistCleanupIntervalMinutes: intervalMinutes });
       scheduler?.updateJob("watchlist-cleanup", {
         intervalMs: updated.watchlistCleanupIntervalMinutes * 60 * 1000,
         enabled: updated.watchlistCleanupMovies || updated.watchlistCleanupShows

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -847,6 +847,10 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         rssPollIntervalSeconds: app.rssPollIntervalSeconds,
         rssEnabled: app.rssEnabled
       },
+      watchlistCleanup: {
+        movieEnabled: app.watchlistCleanupMovies,
+        showEnabled: app.watchlistCleanupShows
+      },
       plex: plexView,
       collections: {
         collectionNamePattern: app.collectionNamePattern,
@@ -874,6 +878,10 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         reconciliationIntervalMinutes?: number;
         rssPollIntervalSeconds?: number;
         rssEnabled?: boolean;
+      };
+      watchlistCleanup?: {
+        movieEnabled?: boolean;
+        showEnabled?: boolean;
       };
     };
 
@@ -935,6 +943,15 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       }
     }
 
+    if (body.watchlistCleanup) {
+      if (typeof body.watchlistCleanup.movieEnabled === "boolean") {
+        patch.watchlistCleanupMovies = body.watchlistCleanup.movieEnabled;
+      }
+      if (typeof body.watchlistCleanup.showEnabled === "boolean") {
+        patch.watchlistCleanupShows = body.watchlistCleanup.showEnabled;
+      }
+    }
+
     const updated = services.updateSettings(patch);
 
     scheduler?.updateJob("full-sync", {
@@ -944,6 +961,10 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     scheduler?.updateJob("rss-sync", {
       intervalMs: updated.rssPollIntervalSeconds * 1000,
       enabled: updated.rssEnabled
+    });
+    scheduler?.updateJob("watchlist-cleanup", {
+      intervalMs: updated.watchlistCleanupIntervalMinutes * 60 * 1000,
+      enabled: updated.watchlistCleanupMovies || updated.watchlistCleanupShows
     });
 
     logger.info("Application settings updated", {
@@ -1085,13 +1106,16 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     const lastPublish = recentRuns.find((r) => r.kind === "publish" && r.completedAt);
     const lastRss = recentRuns.find((r) => r.kind === "rss" && r.completedAt);
     const lastSeerr = recentRuns.find((r) => r.kind === "seerr" && r.completedAt);
+    const lastCleanup = recentRuns.find((r) => r.kind === "watchlist-cleanup" && r.completedAt);
     const seerrJobState = db.getJobRunState("seerr-request-sync");
+    const cleanupEnabled = settings.watchlistCleanupMovies || settings.watchlistCleanupShows;
 
     const jobs: JobInfo[] = [
       {
         id: "collection-publish",
         name: "Collection Sync",
         intervalDescription: `Every ${settings.collectionPublishIntervalMinutes} minutes`,
+        isEnabled: true,
         isRunning: scheduler?.isRunning("collection-publish") ?? false,
         nextRunAt:
           scheduler?.getNextRunAt("collection-publish") ??
@@ -1108,6 +1132,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         id: "full-sync",
         name: "Watchlist GraphQL Sync",
         intervalDescription: `Every ${settings.reconciliationIntervalMinutes} minutes`,
+        isEnabled: true,
         isRunning: scheduler?.isRunning("full-sync") ?? false,
         nextRunAt:
           scheduler?.getNextRunAt("full-sync") ??
@@ -1123,6 +1148,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         id: "plex-recently-added-scan",
         name: "Plex Recently Added Scan",
         intervalDescription: `Every ${settings.plexRecentlyAddedScanIntervalMinutes} minutes`,
+        isEnabled: true,
         isRunning: scheduler?.isRunning("plex-recently-added-scan") ?? false,
         nextRunAt: scheduler?.getNextRunAt("plex-recently-added-scan") ?? null,
         lastRunAt: scheduler?.getLastRunAt("plex-recently-added-scan") ?? null,
@@ -1132,6 +1158,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         id: "plex-full-library-scan",
         name: "Plex Full Library Scan",
         intervalDescription: `Every ${settings.plexFullLibraryScanIntervalMinutes / 60} hour${settings.plexFullLibraryScanIntervalMinutes / 60 !== 1 ? "s" : ""}`,
+        isEnabled: true,
         isRunning: scheduler?.isRunning("plex-full-library-scan") ?? false,
         nextRunAt: scheduler?.getNextRunAt("plex-full-library-scan") ?? null,
         lastRunAt: scheduler?.getLastRunAt("plex-full-library-scan") ?? null,
@@ -1141,6 +1168,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         id: "plex-refresh-token",
         name: "Plex Refresh Token",
         intervalDescription: "Daily at 5:00 AM",
+        isEnabled: true,
         isRunning: scheduler?.isRunning("plex-refresh-token") ?? false,
         nextRunAt: scheduler?.getNextRunAt("plex-refresh-token") ?? null,
         lastRunAt: scheduler?.getLastRunAt("plex-refresh-token") ?? null,
@@ -1150,6 +1178,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         id: "users-discover",
         name: "Refresh Users",
         intervalDescription: "Daily at 5:00 AM",
+        isEnabled: true,
         isRunning: scheduler?.isRunning("users-discover") ?? false,
         nextRunAt: scheduler?.getNextRunAt("users-discover") ?? null,
         lastRunAt: scheduler?.getLastRunAt("users-discover") ?? null,
@@ -1159,6 +1188,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         id: "maintenance-tasks",
         name: "Maintenance Tasks",
         intervalDescription: "Daily at 5:30 AM",
+        isEnabled: true,
         isRunning: scheduler?.isRunning("maintenance-tasks") ?? false,
         nextRunAt: scheduler?.getNextRunAt("maintenance-tasks") ?? null,
         lastRunAt: scheduler?.getLastRunAt("maintenance-tasks") ?? null,
@@ -1170,6 +1200,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         intervalDescription: settings.rssEnabled
           ? `Every ${settings.rssPollIntervalSeconds / 60} minute${settings.rssPollIntervalSeconds / 60 !== 1 ? "s" : ""}`
           : "Disabled",
+        isEnabled: settings.rssEnabled,
         isRunning: scheduler?.isRunning("rss-sync") ?? false,
         nextRunAt: scheduler?.getNextRunAt("rss-sync") ?? null,
         lastRunAt: lastRss?.completedAt ?? null,
@@ -1179,10 +1210,23 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         id: "activity-cache-fetch",
         name: "Watchlist Activity Cache",
         intervalDescription: `Every ${settings.activityCacheFetchIntervalMinutes} minutes`,
+        isEnabled: true,
         isRunning: scheduler?.isRunning("activity-cache-fetch") ?? false,
         nextRunAt: scheduler?.getNextRunAt("activity-cache-fetch") ?? null,
         lastRunAt: scheduler?.getLastRunAt("activity-cache-fetch") ?? null,
         lastRunStatus: scheduler?.getLastRunStatus("activity-cache-fetch") ?? null
+      },
+      {
+        id: "watchlist-cleanup",
+        name: "Watchlist Cleanup",
+        intervalDescription: cleanupEnabled
+          ? `Every ${settings.watchlistCleanupIntervalMinutes} minutes`
+          : "Disabled",
+        isEnabled: cleanupEnabled,
+        isRunning: scheduler?.isRunning("watchlist-cleanup") ?? false,
+        nextRunAt: scheduler?.getNextRunAt("watchlist-cleanup") ?? null,
+        lastRunAt: lastCleanup?.completedAt ?? null,
+        lastRunStatus: lastCleanup?.status === "success" || lastCleanup?.status === "error" ? lastCleanup.status : null
       }
     ];
 
@@ -1191,6 +1235,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         id: "seerr-request-sync",
         name: "Seerr Request Sync",
         intervalDescription: "Manual",
+        isEnabled: true,
         isRunning: services.isSeerrRequestSyncRunning(),
         nextRunAt: null,
         nextRunLabel: "Manual",
@@ -1282,6 +1327,18 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
           logger.warn("Manual activity cache fetch failed", { error: err instanceof Error ? err.message : String(err) });
         });
         res.json({ triggered: true });
+      } else if (jobId === "watchlist-cleanup") {
+        const settings = db.getAppSettings();
+        if (!settings.watchlistCleanupMovies && !settings.watchlistCleanupShows) {
+          res.status(400).json({ error: "Watchlist Cleanup is disabled." });
+          return;
+        }
+        const triggered = scheduler?.runNow("watchlist-cleanup") ?? false;
+        if (!triggered) {
+          res.status(404).json({ error: "Unknown job." });
+          return;
+        }
+        res.json({ triggered: true });
       } else if (jobId === "seerr-request-sync") {
         services.runSeerrRequestSync({ mode: "all", triggeredBy: "manual" }).catch((err) => {
           logger.warn("Manual Seerr request sync failed", { error: err instanceof Error ? err.message : String(err) });
@@ -1325,6 +1382,13 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       scheduler?.updateJob("plex-full-library-scan", {
         intervalMs: updated.plexFullLibraryScanIntervalMinutes * 60 * 1000,
         enabled: true
+      });
+      res.json({ updated: true });
+    } else if (jobId === "watchlist-cleanup" && body.intervalMinutes) {
+      const updated = db.updateAppSettings({ watchlistCleanupIntervalMinutes: body.intervalMinutes });
+      scheduler?.updateJob("watchlist-cleanup", {
+        intervalMs: updated.watchlistCleanupIntervalMinutes * 60 * 1000,
+        enabled: updated.watchlistCleanupMovies || updated.watchlistCleanupShows
       });
       res.json({ updated: true });
     } else if (jobId === "rss-sync" && body.intervalMinutes) {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1329,15 +1329,23 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         res.json({ triggered: true });
       } else if (jobId === "watchlist-cleanup") {
         const settings = db.getAppSettings();
+        const meta = {
+          jobId,
+          movieEnabled: settings.watchlistCleanupMovies,
+          showEnabled: settings.watchlistCleanupShows
+        };
         if (!settings.watchlistCleanupMovies && !settings.watchlistCleanupShows) {
+          logger.warn("Manual job run rejected", { ...meta, reason: "watchlist-cleanup-disabled" });
           res.status(400).json({ error: "Watchlist Cleanup is disabled." });
           return;
         }
         const triggered = scheduler?.runNow("watchlist-cleanup") ?? false;
         if (!triggered) {
+          logger.warn("Manual job run rejected", { ...meta, reason: "scheduler-rejected" });
           res.status(404).json({ error: "Unknown job." });
           return;
         }
+        logger.info("Manual job run requested", meta);
         res.json({ triggered: true });
       } else if (jobId === "seerr-request-sync") {
         services.runSeerrRequestSync({ mode: "all", triggeredBy: "manual" }).catch((err) => {
@@ -1390,6 +1398,10 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         intervalMs: updated.watchlistCleanupIntervalMinutes * 60 * 1000,
         enabled: updated.watchlistCleanupMovies || updated.watchlistCleanupShows
       });
+      logger.info("Job schedule updated", {
+        jobId,
+        intervalMinutes: updated.watchlistCleanupIntervalMinutes
+      });
       res.json({ updated: true });
     } else if (jobId === "rss-sync" && body.intervalMinutes) {
       const updated = db.updateAppSettings({ rssPollIntervalSeconds: body.intervalMinutes * 60 });
@@ -1406,6 +1418,13 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       });
       res.json({ updated: true });
     } else {
+      if (jobId === "watchlist-cleanup") {
+        logger.warn("Job schedule update rejected", {
+          jobId,
+          intervalMinutes: body.intervalMinutes,
+          reason: "missing-or-invalid-interval"
+        });
+      }
       res.status(400).json({ error: "Unknown job or missing interval." });
     }
   });

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -232,6 +232,10 @@ export class HubarrDatabase {
     watchlistRepo.clearMatchedRatingKeyByValue(this.db, ratingKey);
   }
 
+  deleteWatchlistItem(userId: number, plexItemId: string): number {
+    return watchlistRepo.deleteWatchlistItem(this.db, userId, plexItemId);
+  }
+
   upsertMediaItemIdentifiers(item: Pick<WatchlistItem, "plexItemId" | "type" | "guids" | "discoverKey">): void {
     identifiersRepo.upsertMediaItemIdentifiers(this.db, item);
   }

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -15,6 +15,9 @@ export type SettingKey = "admin" | "plex" | "app" | "session_secret" | "seerr";
 export const defaultAppSettings: AppSettings = {
   reconciliationIntervalMinutes: 60,
   activityCacheFetchIntervalMinutes: 60,
+  watchlistCleanupIntervalMinutes: 30,
+  watchlistCleanupMovies: false,
+  watchlistCleanupShows: false,
   rssPollIntervalSeconds: 300,
   rssEnabled: true,
   trackAllUsers: false,
@@ -210,7 +213,10 @@ export function calculateHistoryRetentionEvents(settings: AppSettings): number {
   const fullSyncsPerDay = 1440 / settings.reconciliationIntervalMinutes;
   const rssSyncsPerDay = settings.rssEnabled ? 86400 / settings.rssPollIntervalSeconds : 0;
   const publishSyncsPerDay = 1440 / settings.collectionPublishIntervalMinutes;
-  const totalSyncsPerDay = fullSyncsPerDay + rssSyncsPerDay + publishSyncsPerDay;
+  const cleanupSyncsPerDay = (settings.watchlistCleanupMovies || settings.watchlistCleanupShows)
+    ? 1440 / settings.watchlistCleanupIntervalMinutes
+    : 0;
+  const totalSyncsPerDay = fullSyncsPerDay + rssSyncsPerDay + publishSyncsPerDay + cleanupSyncsPerDay;
   return Math.max(1, Math.floor(settings.historyRetentionDays * totalSyncsPerDay));
 }
 

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -213,11 +213,14 @@ export function calculateHistoryRetentionEvents(settings: AppSettings): number {
   const fullSyncsPerDay = 1440 / settings.reconciliationIntervalMinutes;
   const rssSyncsPerDay = settings.rssEnabled ? 86400 / settings.rssPollIntervalSeconds : 0;
   const publishSyncsPerDay = 1440 / settings.collectionPublishIntervalMinutes;
-  const cleanupSyncsPerDay = (settings.watchlistCleanupMovies || settings.watchlistCleanupShows)
-    ? 1440 / settings.watchlistCleanupIntervalMinutes
+  const cleanupEnabled = settings.watchlistCleanupMovies || settings.watchlistCleanupShows;
+  const cleanupInterval = settings.watchlistCleanupIntervalMinutes;
+  const cleanupSyncsPerDay = cleanupEnabled && Number.isFinite(cleanupInterval) && cleanupInterval > 0
+    ? 1440 / cleanupInterval
     : 0;
   const totalSyncsPerDay = fullSyncsPerDay + rssSyncsPerDay + publishSyncsPerDay + cleanupSyncsPerDay;
-  return Math.max(1, Math.floor(settings.historyRetentionDays * totalSyncsPerDay));
+  const finiteTotalSyncsPerDay = Number.isFinite(totalSyncsPerDay) ? totalSyncsPerDay : 0;
+  return Math.max(1, Math.floor(settings.historyRetentionDays * finiteTotalSyncsPerDay));
 }
 
 // -------------------------------------------------------------------------

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -301,6 +301,11 @@ export function clearMatchedRatingKeyByValue(db: Database.Database, ratingKey: s
   ).run(ratingKey);
 }
 
+export function deleteWatchlistItem(db: Database.Database, userId: number, plexItemId: string): number {
+  const result = db.prepare("DELETE FROM watchlist_cache WHERE user_id = ? AND plex_item_id = ?").run(userId, plexItemId);
+  return result.changes;
+}
+
 export function upsertWatchlistItem(db: Database.Database, userId: number, item: WatchlistItem): void {
   const discoverKey = item.discoverKey ?? null;
   db.prepare(`

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -132,6 +132,15 @@ scheduler.registerRecurringJob({
   })
 });
 
+scheduler.registerRecurringJob({
+  id: "watchlist-cleanup",
+  intervalMs: appSettings.watchlistCleanupIntervalMinutes * 60 * 1000,
+  enabled: appSettings.watchlistCleanupMovies || appSettings.watchlistCleanupShows,
+  task: requiresSetup(async () => {
+    await services.runWatchlistCleanup();
+  })
+});
+
 if (setupReady && appSettings.rssEnabled) {
   services.initRss().catch((error) => {
     logger.warn("RSS initialization failed at startup", {

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -754,7 +754,8 @@ export class PlexIntegration {
 
     if (seasons.length === 0) return null;
 
-    const seasonResults = await Promise.all(seasons.map(async (season) => {
+    const seasonResults: Array<PlexDiscoverEpisodeRef[] | null> = [];
+    for (const season of seasons) {
       const seasonIndex = Number(season.index);
       const seasonJson = await fetchChildren(season.key!);
       const seasonEpisodes = (seasonJson.MediaContainer?.Metadata ?? [])
@@ -766,21 +767,23 @@ export class PlexIntegration {
           leafCount: season.leafCount,
           episodeChildren: seasonEpisodes.length
         });
-        return null;
+        seasonResults.push(null);
+        continue;
       }
 
       const episodes: PlexDiscoverEpisodeRef[] = [];
+      let invalid = false;
       for (const episode of seasonEpisodes) {
         const episodeIndex = Number(episode.index);
-        if (!Number.isFinite(seasonIndex) || !Number.isFinite(episodeIndex)) return null;
+        if (!Number.isFinite(seasonIndex) || !Number.isFinite(episodeIndex)) { invalid = true; break; }
         episodes.push({
           seasonIndex,
           episodeIndex,
           originallyAvailableAt: episode.originallyAvailableAt ?? null
         });
       }
-      return episodes;
-    }));
+      seasonResults.push(invalid ? null : episodes);
+    }
 
     if (seasonResults.some((result) => result === null)) return null;
     return seasonResults.flatMap((result) => result ?? []);

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -241,6 +241,20 @@ export interface PlexLibraryItemMatch {
   guids: string[];
 }
 
+export interface PlexEpisodeRef {
+  ratingKey: string;
+  seasonIndex: number;
+  episodeIndex: number;
+  viewCount: number | null;
+  lastViewedAt: string | null;
+}
+
+export interface PlexDiscoverEpisodeRef {
+  seasonIndex: number;
+  episodeIndex: number;
+  originallyAvailableAt: string | null;
+}
+
 const COMMUNITY_API_URL = "https://community.plex.tv/api";
 const DISCOVER_ORIGIN = "https://discover.provider.plex.tv";
 const DISCOVER_RSS_PATH = "/rss";
@@ -297,15 +311,25 @@ export class PlexIntegration {
   }
 
   private buildDiscoverMetadataUrl(rawEndpoint: string) {
-    const match = rawEndpoint.trim().match(/^\/?library\/metadata\/(.+)$/);
+    const match = rawEndpoint.trim().match(/^\/?library\/metadata\/([a-f0-9]{24})(\/children)?$/i);
     if (!match) {
       throw new Error(`Unsupported discover metadata endpoint: ${rawEndpoint}`);
     }
 
     const url = new URL(DISCOVER_ORIGIN);
-    url.pathname = `/library/metadata/${this.normalizeMetadataId(match[1])}`;
+    url.pathname = `/library/metadata/${this.normalizeMetadataId(match[1])}${match[2] ?? ""}`;
     url.searchParams.set("format", "json");
     return url;
+  }
+
+  private getDiscoverMetadataEndpoint(item: Pick<WatchlistItem, "plexItemId" | "discoverKey">): string | null {
+    const plexItemId = item.plexItemId.trim();
+    const plexGuidMatch = plexItemId.match(/^plex:\/\/(?:movie|show)\/([a-f0-9]{24})$/i);
+    const plexGuidHex = plexGuidMatch
+      ? plexGuidMatch[1].toLowerCase()
+      : (/^[a-f0-9]{24}$/i.test(plexItemId) ? plexItemId.toLowerCase() : null);
+
+    return item.discoverKey?.replace(/^\//, "") ?? (plexGuidHex ? `library/metadata/${plexGuidHex}` : null);
   }
 
   private buildDiscoverRssRequestUrl(rawUrl: string) {
@@ -496,17 +520,9 @@ export class PlexIntegration {
     // (extract the hex part) or a bare 24-char hex. RSS items temporarily use a
     // stableKey as plexItemId before enrichment resolves the real GUID, and that
     // format is not a valid discover endpoint path.
-    const plexGuidHex = (() => {
-      const plexItemId = item.plexItemId.trim();
-      const m = plexItemId.match(/^plex:\/\/(?:movie|show)\/([a-f0-9]{24})$/i);
-      if (m) return m[1].toLowerCase();
-      if (/^[a-f0-9]{24}$/i.test(plexItemId)) return plexItemId.toLowerCase();
-      return null;
-    })();
-
     const endpoints = Array.from(new Set([
       item.discoverKey ? item.discoverKey.replace(/^\//, "") : null,
-      plexGuidHex ? `library/metadata/${plexGuidHex}` : null,
+      this.getDiscoverMetadataEndpoint(item),
     ].filter((endpoint): endpoint is string => Boolean(endpoint))));
 
     let lastErr: Error | null = null;
@@ -632,6 +648,165 @@ export class PlexIntegration {
       }
     }
     return null;
+  }
+
+  async fetchPlayHistoryViewedAt(ratingKey: string, accountId?: string): Promise<string[]> {
+    const params = new URLSearchParams({ metadataItemID: ratingKey });
+    const response = await this.requestServer<{
+      MediaContainer?: {
+        Metadata?: Array<{ viewedAt?: string | number; accountID?: string | number }>;
+      };
+    }>(`/status/sessions/history/all?${params.toString()}`);
+
+    return (response.MediaContainer?.Metadata ?? [])
+      .filter((entry) => accountId === undefined || String(entry.accountID ?? "") === accountId)
+      .map((entry) => {
+        if (entry.viewedAt === undefined || entry.viewedAt === null) return null;
+        const seconds = Number(entry.viewedAt);
+        if (!Number.isFinite(seconds)) return null;
+        return new Date(seconds * 1000).toISOString();
+      })
+      .filter((value): value is string => Boolean(value));
+  }
+
+  async fetchServerAccounts(): Promise<Array<{ id: string; name: string }>> {
+    const response = await this.requestServer<{
+      MediaContainer?: {
+        Account?: Array<{ id?: string | number; name?: string }>;
+      };
+    }>("/accounts");
+
+    return (response.MediaContainer?.Account ?? [])
+      .map((account) => ({
+        id: String(account.id ?? ""),
+        name: account.name ?? ""
+      }))
+      .filter((account) => account.id && account.name);
+  }
+
+  async fetchLocalShowEpisodes(showRatingKey: string): Promise<PlexEpisodeRef[]> {
+    const response = await this.requestServer<{
+      MediaContainer?: {
+        Metadata?: Array<{
+          ratingKey?: string;
+          parentIndex?: string | number;
+          index?: string | number;
+          viewCount?: string | number;
+          lastViewedAt?: string | number;
+        }>;
+      };
+    }>(`/library/metadata/${encodeURIComponent(showRatingKey)}/allLeaves`);
+
+    return (response.MediaContainer?.Metadata ?? [])
+      .map((episode) => {
+        const ratingKey = episode.ratingKey;
+        const seasonIndex = Number(episode.parentIndex);
+        const episodeIndex = Number(episode.index);
+        if (!ratingKey || !Number.isFinite(seasonIndex) || !Number.isFinite(episodeIndex)) return null;
+        const lastViewedAtSeconds = Number(episode.lastViewedAt);
+        return {
+          ratingKey,
+          seasonIndex,
+          episodeIndex,
+          viewCount: episode.viewCount === undefined ? null : Number(episode.viewCount),
+          lastViewedAt: Number.isFinite(lastViewedAtSeconds) ? new Date(lastViewedAtSeconds * 1000).toISOString() : null
+        };
+      })
+      .filter((episode): episode is PlexEpisodeRef => Boolean(episode));
+  }
+
+  async fetchDiscoverShowEpisodes(item: Pick<WatchlistItem, "plexItemId" | "discoverKey">): Promise<PlexDiscoverEpisodeRef[] | null> {
+    const endpoint = this.getDiscoverMetadataEndpoint(item);
+    if (!endpoint) return null;
+
+    const fetchChildren = async (parentEndpoint: string) => {
+      const normalizedEndpoint = parentEndpoint.replace(/\/$/, "");
+      const childrenEndpoint = normalizedEndpoint.endsWith("/children")
+        ? normalizedEndpoint
+        : `${normalizedEndpoint}/children`;
+      const response = await fetch(this.buildDiscoverMetadataUrl(childrenEndpoint), {
+        headers: {
+          "User-Agent": PLEX_USER_AGENT,
+          "X-Plex-Token": this.settings.token,
+          Accept: "application/json"
+        }
+      });
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(`Discover children request failed with HTTP ${response.status}: ${body}`);
+      }
+      return (await response.json()) as {
+        MediaContainer?: {
+          Metadata?: Array<{
+            key?: string;
+            type?: string;
+            index?: number;
+            leafCount?: number;
+            originallyAvailableAt?: string;
+          }>;
+        };
+      };
+    };
+
+    const seasonsJson = await fetchChildren(endpoint);
+    const seasons = (seasonsJson.MediaContainer?.Metadata ?? [])
+      .filter((season) => season.type === "season" && Number(season.index) > 0 && season.key);
+
+    if (seasons.length === 0) return null;
+
+    const episodes: PlexDiscoverEpisodeRef[] = [];
+    for (const season of seasons) {
+      const seasonIndex = Number(season.index);
+      const seasonJson = await fetchChildren(season.key!);
+      const seasonEpisodes = (seasonJson.MediaContainer?.Metadata ?? [])
+        .filter((episode) => episode.type === "episode");
+
+      if (typeof season.leafCount === "number" && season.leafCount !== seasonEpisodes.length) {
+        this.logger.warn("Discover episode data did not match season leaf count", {
+          seasonIndex,
+          leafCount: season.leafCount,
+          episodeChildren: seasonEpisodes.length
+        });
+        return null;
+      }
+
+      for (const episode of seasonEpisodes) {
+        const episodeIndex = Number(episode.index);
+        if (!Number.isFinite(seasonIndex) || !Number.isFinite(episodeIndex)) return null;
+        episodes.push({
+          seasonIndex,
+          episodeIndex,
+          originallyAvailableAt: episode.originallyAvailableAt ?? null
+        });
+      }
+    }
+
+    return episodes;
+  }
+
+  async removeFromWatchlist(item: Pick<WatchlistItem, "plexItemId" | "discoverKey" | "title">, ownerToken: string): Promise<void> {
+    const endpoint = this.getDiscoverMetadataEndpoint(item);
+    const match = endpoint?.match(/^library\/metadata\/([a-f0-9]{24})$/i);
+    const ratingKey = match?.[1];
+    if (!ratingKey) {
+      throw new Error(`Cannot remove "${item.title}" from watchlist because it has no Discover rating key.`);
+    }
+
+    const url = new URL(`${DISCOVER_ORIGIN}/actions/removeFromWatchlist`);
+    url.searchParams.set("ratingKey", ratingKey);
+    const response = await fetch(url, {
+      method: "PUT",
+      headers: {
+        "User-Agent": PLEX_USER_AGENT,
+        "X-Plex-Token": ownerToken,
+        Accept: "application/json"
+      }
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(`Plex watchlist removal failed: ${response.status} ${response.statusText}. Response: ${body}`);
+    }
   }
 
   /**

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -754,8 +754,7 @@ export class PlexIntegration {
 
     if (seasons.length === 0) return null;
 
-    const episodes: PlexDiscoverEpisodeRef[] = [];
-    for (const season of seasons) {
+    const seasonResults = await Promise.all(seasons.map(async (season) => {
       const seasonIndex = Number(season.index);
       const seasonJson = await fetchChildren(season.key!);
       const seasonEpisodes = (seasonJson.MediaContainer?.Metadata ?? [])
@@ -770,6 +769,7 @@ export class PlexIntegration {
         return null;
       }
 
+      const episodes: PlexDiscoverEpisodeRef[] = [];
       for (const episode of seasonEpisodes) {
         const episodeIndex = Number(episode.index);
         if (!Number.isFinite(seasonIndex) || !Number.isFinite(episodeIndex)) return null;
@@ -779,9 +779,11 @@ export class PlexIntegration {
           originallyAvailableAt: episode.originallyAvailableAt ?? null
         });
       }
-    }
+      return episodes;
+    }));
 
-    return episodes;
+    if (seasonResults.some((result) => result === null)) return null;
+    return seasonResults.flatMap((result) => result ?? []);
   }
 
   async removeFromWatchlist(item: Pick<WatchlistItem, "plexItemId" | "discoverKey" | "title">, ownerToken: string): Promise<void> {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1917,6 +1917,8 @@ export class HubarrServices {
     }
 
     const watchedEpisodeKeys = new Set<string>();
+    // Tracks episodes confirmed via the viewCount/lastViewedAt fallback rather than
+    // the play history API — only used in logging meta, not in the removal decision.
     const watchedByMetadataKeys = new Set<string>();
     const historyLimit = pLimit(PLEX_SYNC_CONCURRENCY);
     await Promise.all(discoverEpisodes.map((episode) =>

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -16,7 +16,7 @@ import { generateCollectionPoster } from "./collection-artwork.js";
 import { HubarrDatabase } from "./db/index.js";
 import { ImageCacheService } from "./image-cache.js";
 import { Logger } from "./logger.js";
-import { PlexIntegration, WATCHLIST_DATE_UNKNOWN_SENTINEL, type PlexLibraryItemMatch, type ResolvedWatchlistItem } from "./integrations/plex.js";
+import { PlexIntegration, WATCHLIST_DATE_UNKNOWN_SENTINEL, type PlexDiscoverEpisodeRef, type PlexEpisodeRef, type PlexLibraryItemMatch, type ResolvedWatchlistItem } from "./integrations/plex.js";
 import { SeerrIntegration, extractTmdbId } from "./integrations/seerr.js";
 import { RssCache, type RssFeedItem } from "./rss-cache.js";
 
@@ -58,6 +58,16 @@ type SeerrRequestProcessingOptions = {
 };
 
 type SeerrRequestWorkItem = { user: UserRecord; items: WatchlistItem[] };
+
+function buildEpisodeKey(episode: Pick<PlexEpisodeRef | PlexDiscoverEpisodeRef, "seasonIndex" | "episodeIndex">): string {
+  return `${episode.seasonIndex}:${episode.episodeIndex}`;
+}
+
+function isPastOrTodayDate(value: string | null, todayUtc: Date): boolean {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isFinite(parsed.getTime()) && parsed.getTime() <= todayUtc.getTime();
+}
 
 /**
  * Compare two watchlist items by release date for Plex collection ordering.
@@ -1660,6 +1670,272 @@ export class HubarrServices {
     }
 
     return this.db.listSyncRuns(1)[0];
+  }
+
+  async runWatchlistCleanup() {
+    const startedAt = Date.now();
+    const settings = this.db.getAppSettings();
+    const runId = this.db.createSyncRun("watchlist-cleanup", "Watchlist Cleanup started.");
+    const cleanupMovies = settings.watchlistCleanupMovies;
+    const cleanupShows = settings.watchlistCleanupShows;
+
+    this.logger.info("Watchlist Cleanup started", { cleanupMovies, cleanupShows });
+
+    if (!cleanupMovies && !cleanupShows) {
+      this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
+        reason: "cleanup-disabled",
+        message: "Watchlist cleanup is disabled."
+      });
+      this.db.completeSyncRun(runId, "success", "Watchlist Cleanup skipped: cleanup is disabled.", null);
+      this.logger.info("Watchlist Cleanup skipped because cleanup is disabled");
+      return { removed: 0, skipped: 1 };
+    }
+
+    const selfUser = this.db.listUsers().find((user) => user.isSelf);
+    const owner = this.db.getPlexOwner();
+    if (!selfUser || !owner) {
+      this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
+        reason: "missing-admin-user",
+        message: "Admin/self user is not configured."
+      });
+      this.db.completeSyncRun(runId, "success", "Watchlist Cleanup skipped: admin user is not configured.", null);
+      return { removed: 0, skipped: 1 };
+    }
+
+    const plex = this.getPlexIntegration();
+    const selfServerAccountId = await this.resolveSelfServerAccountId(plex, selfUser.username);
+    const items = this.db.getWatchlistItems(selfUser.id)
+      .filter((item) => item.type === "movie" ? cleanupMovies : cleanupShows);
+    let removed = 0;
+    let skipped = 0;
+
+    const logDecision = (
+      level: "info" | "warn",
+      message: string,
+      item: WatchlistItem,
+      meta: Record<string, unknown>
+    ) => {
+      this.logger[level](message, {
+        userId: selfUser.id,
+        title: item.title,
+        type: item.type,
+        plexItemId: item.plexItemId,
+        matchedRatingKey: item.matchedRatingKey,
+        addedAt: item.addedAt,
+        ...meta
+      });
+    };
+
+    try {
+      for (const item of items) {
+        const details = { plexItemId: item.plexItemId, title: item.title, type: item.type, addedAt: item.addedAt };
+
+        if (!item.matchedRatingKey) {
+          skipped++;
+          logDecision("info", "Watchlist Cleanup skipped item", item, {
+            reason: "not-matched-locally",
+            message: "Item is not matched to a local Plex library item."
+          });
+          this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
+            ...details,
+            reason: "not-matched-locally",
+            message: "Item is not matched to a local Plex library item."
+          }, selfUser.id);
+          continue;
+        }
+
+        const addedAtMs = Date.parse(item.addedAt);
+        if (!Number.isFinite(addedAtMs) || item.addedAt === WATCHLIST_DATE_UNKNOWN_SENTINEL) {
+          skipped++;
+          logDecision("info", "Watchlist Cleanup skipped item", item, {
+            reason: "watchlist-date-unknown",
+            message: "Item does not have a trustworthy watchlisted date."
+          });
+          this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
+            ...details,
+            reason: "watchlist-date-unknown",
+            message: "Item does not have a trustworthy watchlisted date."
+          }, selfUser.id);
+          continue;
+        }
+
+        const decision = item.type === "movie"
+          ? await this.shouldRemoveWatchedMovie(item, plex, addedAtMs, selfServerAccountId)
+          : await this.shouldRemoveWatchedShow(item, plex, addedAtMs, selfServerAccountId);
+
+        if (!decision.remove) {
+          skipped++;
+          logDecision("info", "Watchlist Cleanup skipped item", item, {
+            reason: decision.reason,
+            message: decision.message,
+            ...decision.meta
+          });
+          this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
+            ...details,
+            reason: decision.reason,
+            message: decision.message,
+            ...decision.meta
+          }, selfUser.id);
+          continue;
+        }
+
+        await plex.removeFromWatchlist(item, owner.plexToken);
+        const deletedRows = this.db.deleteWatchlistItem(selfUser.id, item.plexItemId);
+        removed++;
+        logDecision("info", "Watchlist Cleanup removed item", item, {
+          reason: decision.reason,
+          message: decision.message,
+          deletedRows,
+          ...decision.meta
+        });
+        this.db.addSyncRunItem(runId, "watchlist.cleanup.removed", "success", {
+          ...details,
+          reason: decision.reason,
+          message: decision.message,
+          deletedRows,
+          ...decision.meta
+        }, selfUser.id);
+      }
+
+      const summary = removed > 0
+        ? `Watchlist Cleanup removed ${removed} item${removed !== 1 ? "s" : ""}; skipped ${skipped}.`
+        : `Watchlist Cleanup skipped: no watched items to remove (${skipped} checked).`;
+      this.db.completeSyncRun(runId, "success", summary, null);
+      this.logger.info("Watchlist Cleanup complete", { removed, skipped, durationMs: Date.now() - startedAt });
+
+      if (removed > 0) {
+        this.logger.info("Collection publish queued after Watchlist Cleanup removed items", { removed });
+        await this.runPublishPass();
+      }
+
+      return { removed, skipped };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.db.addSyncRunItem(runId, "watchlist.cleanup.failed", "error", { message });
+      this.db.completeSyncRun(runId, "error", "Watchlist Cleanup failed.", message);
+      this.logger.error("Watchlist Cleanup failed", { message, durationMs: Date.now() - startedAt });
+      throw error;
+    }
+  }
+
+  private async resolveSelfServerAccountId(plex: PlexIntegration, selfUsername: string): Promise<string> {
+    const accounts = await plex.fetchServerAccounts();
+    const selfAccount = accounts.find((account) => account.name.toLowerCase() === selfUsername.toLowerCase());
+    if (!selfAccount) {
+      throw new Error(`Unable to resolve Plex server account ID for self user "${selfUsername}".`);
+    }
+    return selfAccount.id;
+  }
+
+  private async shouldRemoveWatchedMovie(item: WatchlistItem, plex: PlexIntegration, addedAtMs: number, selfServerAccountId: string) {
+    const viewedAt = await plex.fetchPlayHistoryViewedAt(item.matchedRatingKey!, selfServerAccountId);
+    const watchedAfter = viewedAt.filter((value) => Date.parse(value) > addedAtMs);
+
+    if (watchedAfter.length > 0) {
+      return {
+        remove: true as const,
+        reason: "watched-after-watchlist-date",
+        message: "Movie was watched after it was added to the watchlist.",
+        meta: { watchedAfter }
+      };
+    }
+
+    return {
+      remove: false as const,
+      reason: viewedAt.length > 0 ? "watched-before-watchlist-date" : "not-watched",
+      message: viewedAt.length > 0
+        ? "Movie was only watched before it was added to the watchlist."
+        : "Movie has no completed play history.",
+      meta: { viewedAt }
+    };
+  }
+
+  private async shouldRemoveWatchedShow(item: WatchlistItem, plex: PlexIntegration, addedAtMs: number, selfServerAccountId: string) {
+    const [localEpisodes, discoverEpisodes] = await Promise.all([
+      plex.fetchLocalShowEpisodes(item.matchedRatingKey!),
+      plex.fetchDiscoverShowEpisodes(item)
+    ]);
+
+    if (!discoverEpisodes?.length) {
+      return {
+        remove: false as const,
+        reason: "discover-data-incomplete",
+        message: "Plex Discover did not return a complete non-special episode list.",
+        meta: { localEpisodeCount: localEpisodes.length }
+      };
+    }
+
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    const uncertainEpisode = discoverEpisodes.find((episode) => !isPastOrTodayDate(episode.originallyAvailableAt, today));
+    if (uncertainEpisode) {
+      return {
+        remove: false as const,
+        reason: "future-or-uncertain-episodes",
+        message: "Show has future, current-season, or uncertain Discover episode data.",
+        meta: { episode: uncertainEpisode, expectedEpisodeCount: discoverEpisodes.length }
+      };
+    }
+
+    const localBySeasonEpisode = new Map(localEpisodes.map((episode) => [
+      buildEpisodeKey(episode),
+      episode
+    ]));
+
+    const missingLocal = discoverEpisodes.filter((episode) => !localBySeasonEpisode.has(buildEpisodeKey(episode)));
+    if (missingLocal.length > 0) {
+      return {
+        remove: false as const,
+        reason: "local-episodes-incomplete",
+        message: "Not every expected non-special episode exists in the local Plex library.",
+        meta: { missingLocalCount: missingLocal.length, expectedEpisodeCount: discoverEpisodes.length }
+      };
+    }
+
+    const watchedEpisodeKeys = new Set<string>();
+    const watchedByMetadataKeys = new Set<string>();
+    const historyLimit = pLimit(PLEX_SYNC_CONCURRENCY);
+    await Promise.all(discoverEpisodes.map((episode) =>
+      historyLimit(async () => {
+        const localEpisode = localBySeasonEpisode.get(buildEpisodeKey(episode));
+        if (!localEpisode) return;
+        const viewedAt = await plex.fetchPlayHistoryViewedAt(localEpisode.ratingKey, selfServerAccountId);
+        if (viewedAt.some((value) => Date.parse(value) > addedAtMs)) {
+          watchedEpisodeKeys.add(buildEpisodeKey(episode));
+          return;
+        }
+        if ((localEpisode.viewCount ?? 0) > 0 && localEpisode.lastViewedAt && Date.parse(localEpisode.lastViewedAt) > addedAtMs) {
+          watchedEpisodeKeys.add(buildEpisodeKey(episode));
+          watchedByMetadataKeys.add(buildEpisodeKey(episode));
+        }
+      })
+    ));
+
+    if (watchedEpisodeKeys.size === discoverEpisodes.length) {
+      return {
+        remove: true as const,
+        reason: "all-episodes-watched-after-watchlist-date",
+        message: "Every required non-special episode was watched after the show was added to the watchlist.",
+        meta: {
+          watchedEpisodeCount: watchedEpisodeKeys.size,
+          expectedEpisodeCount: discoverEpisodes.length,
+          watchedByMetadataCount: watchedByMetadataKeys.size
+        }
+      };
+    }
+
+    return {
+      remove: false as const,
+      reason: watchedEpisodeKeys.size > 0 ? "partially-watched-after-watchlist-date" : "watched-before-watchlist-date",
+      message: watchedEpisodeKeys.size > 0
+        ? "Only some required non-special episodes were watched after the watchlist date."
+        : "No required non-special episodes were watched after the watchlist date.",
+      meta: {
+        watchedEpisodeCount: watchedEpisodeKeys.size,
+        expectedEpisodeCount: discoverEpisodes.length,
+        watchedByMetadataCount: watchedByMetadataKeys.size
+      }
+    };
   }
 
   // ---------------------------------------------------------------------------

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1708,9 +1708,10 @@ export class HubarrServices {
       .filter((item) => item.type === "movie" ? cleanupMovies : cleanupShows);
     let removed = 0;
     let skipped = 0;
+    let failed = 0;
 
     const logDecision = (
-      level: "info" | "warn",
+      level: "info" | "warn" | "error",
       message: string,
       item: WatchlistItem,
       meta: Record<string, unknown>
@@ -1730,82 +1731,105 @@ export class HubarrServices {
       for (const item of items) {
         const details = { plexItemId: item.plexItemId, title: item.title, type: item.type, addedAt: item.addedAt };
 
-        if (!item.matchedRatingKey) {
-          skipped++;
-          logDecision("info", "Watchlist Cleanup skipped item", item, {
-            reason: "not-matched-locally",
-            message: "Item is not matched to a local Plex library item."
-          });
-          this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
-            ...details,
-            reason: "not-matched-locally",
-            message: "Item is not matched to a local Plex library item."
-          }, selfUser.id);
-          continue;
-        }
+        try {
+          if (!item.matchedRatingKey) {
+            skipped++;
+            logDecision("info", "Watchlist Cleanup skipped item", item, {
+              reason: "not-matched-locally",
+              message: "Item is not matched to a local Plex library item."
+            });
+            this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
+              ...details,
+              reason: "not-matched-locally",
+              message: "Item is not matched to a local Plex library item."
+            }, selfUser.id);
+            continue;
+          }
 
-        const addedAtMs = Date.parse(item.addedAt);
-        if (!Number.isFinite(addedAtMs) || item.addedAt === WATCHLIST_DATE_UNKNOWN_SENTINEL) {
-          skipped++;
-          logDecision("info", "Watchlist Cleanup skipped item", item, {
-            reason: "watchlist-date-unknown",
-            message: "Item does not have a trustworthy watchlisted date."
-          });
-          this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
-            ...details,
-            reason: "watchlist-date-unknown",
-            message: "Item does not have a trustworthy watchlisted date."
-          }, selfUser.id);
-          continue;
-        }
+          const addedAtMs = Date.parse(item.addedAt);
+          if (!Number.isFinite(addedAtMs) || item.addedAt === WATCHLIST_DATE_UNKNOWN_SENTINEL) {
+            skipped++;
+            logDecision("info", "Watchlist Cleanup skipped item", item, {
+              reason: "watchlist-date-unknown",
+              message: "Item does not have a trustworthy watchlisted date."
+            });
+            this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
+              ...details,
+              reason: "watchlist-date-unknown",
+              message: "Item does not have a trustworthy watchlisted date."
+            }, selfUser.id);
+            continue;
+          }
 
-        const decision = item.type === "movie"
-          ? await this.shouldRemoveWatchedMovie(item, plex, addedAtMs, selfServerAccountId)
-          : await this.shouldRemoveWatchedShow(item, plex, addedAtMs, selfServerAccountId);
+          const decision = item.type === "movie"
+            ? await this.shouldRemoveWatchedMovie(item, plex, addedAtMs, selfServerAccountId)
+            : await this.shouldRemoveWatchedShow(item, plex, addedAtMs, selfServerAccountId);
 
-        if (!decision.remove) {
-          skipped++;
-          logDecision("info", "Watchlist Cleanup skipped item", item, {
+          if (!decision.remove) {
+            skipped++;
+            logDecision("info", "Watchlist Cleanup skipped item", item, {
+              reason: decision.reason,
+              message: decision.message,
+              ...decision.meta
+            });
+            this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
+              ...details,
+              reason: decision.reason,
+              message: decision.message,
+              ...decision.meta
+            }, selfUser.id);
+            continue;
+          }
+
+          await plex.removeFromWatchlist(item, owner.plexToken);
+          const deletedRows = this.db.deleteWatchlistItem(selfUser.id, item.plexItemId);
+          removed++;
+          logDecision("info", "Watchlist Cleanup removed item", item, {
             reason: decision.reason,
             message: decision.message,
+            deletedRows,
             ...decision.meta
           });
-          this.db.addSyncRunItem(runId, "watchlist.cleanup.skipped", "success", {
+          this.db.addSyncRunItem(runId, "watchlist.cleanup.removed", "success", {
             ...details,
             reason: decision.reason,
             message: decision.message,
+            deletedRows,
             ...decision.meta
           }, selfUser.id);
-          continue;
+        } catch (error) {
+          failed++;
+          const message = error instanceof Error ? error.message : String(error);
+          logDecision("error", "Watchlist Cleanup item failed", item, {
+            reason: "item-processing-failed",
+            message
+          });
+          this.db.addSyncRunItem(runId, "watchlist.cleanup.failed-item", "error", {
+            ...details,
+            reason: "item-processing-failed",
+            message
+          }, selfUser.id);
         }
-
-        await plex.removeFromWatchlist(item, owner.plexToken);
-        const deletedRows = this.db.deleteWatchlistItem(selfUser.id, item.plexItemId);
-        removed++;
-        logDecision("info", "Watchlist Cleanup removed item", item, {
-          reason: decision.reason,
-          message: decision.message,
-          deletedRows,
-          ...decision.meta
-        });
-        this.db.addSyncRunItem(runId, "watchlist.cleanup.removed", "success", {
-          ...details,
-          reason: decision.reason,
-          message: decision.message,
-          deletedRows,
-          ...decision.meta
-        }, selfUser.id);
       }
 
       const summary = removed > 0
-        ? `Watchlist Cleanup removed ${removed} item${removed !== 1 ? "s" : ""}; skipped ${skipped}.`
-        : `Watchlist Cleanup skipped: no watched items to remove (${skipped} checked).`;
+        ? `Watchlist Cleanup removed ${removed} item${removed !== 1 ? "s" : ""}; skipped ${skipped}; failed ${failed}.`
+        : `Watchlist Cleanup skipped: no watched items to remove (${skipped} skipped; ${failed} failed).`;
       this.db.completeSyncRun(runId, "success", summary, null);
-      this.logger.info("Watchlist Cleanup complete", { removed, skipped, durationMs: Date.now() - startedAt });
+      this.logger.info("Watchlist Cleanup complete", { removed, skipped, failed, durationMs: Date.now() - startedAt });
 
       if (removed > 0) {
         this.logger.info("Collection publish queued after Watchlist Cleanup removed items", { removed });
-        await this.runPublishPass();
+        try {
+          await this.runPublishPass();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.error("Collection publish after Watchlist Cleanup failed", { removed, message });
+          this.db.addSyncRunItem(runId, "watchlist.publish.failed", "error", {
+            removed,
+            message
+          });
+        }
       }
 
       return { removed, skipped };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -69,6 +69,9 @@ export type WatchlistSortBy = "added-desc" | "added-asc" | "title-asc" | "title-
 export interface AppSettings {
   reconciliationIntervalMinutes: number;
   activityCacheFetchIntervalMinutes: number;
+  watchlistCleanupIntervalMinutes: number;
+  watchlistCleanupMovies: boolean;
+  watchlistCleanupShows: boolean;
   rssPollIntervalSeconds: number;
   rssEnabled: boolean;
   trackAllUsers: boolean;
@@ -226,7 +229,7 @@ export interface PlexCollectionRecord {
 
 export interface SyncRun {
   id: number;
-  kind: "full" | "user" | "rss" | "publish" | "seerr";
+  kind: "full" | "user" | "rss" | "publish" | "seerr" | "watchlist-cleanup";
   status: SyncStatus;
   startedAt: string;
   completedAt: string | null;
@@ -355,6 +358,7 @@ export interface JobInfo {
   id: string;
   name: string;
   intervalDescription: string;
+  isEnabled: boolean;
   nextRunAt: string | null;
   nextRunLabel?: string;
   lastRunAt: string | null;
@@ -383,6 +387,10 @@ export interface SettingsResponse {
     reconciliationIntervalMinutes: number;
     rssPollIntervalSeconds: number;
     rssEnabled: boolean;
+  };
+  watchlistCleanup: {
+    movieEnabled: boolean;
+    showEnabled: boolean;
   };
   plex: PlexSettingsView | null;
   collections: {

--- a/tests/playwright/pages.spec.ts
+++ b/tests/playwright/pages.spec.ts
@@ -29,7 +29,7 @@ test.describe("Page smoke tests", () => {
   test("Settings loads", async ({ page }) => {
     await page.goto("/settings");
     // exact: true prevents matching section headings like "General Settings"
-    await expect(page.getByRole("heading", { name: "Settings", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Settings", exact: true, level: 1 })).toBeVisible();
   });
 
   test("Sidebar navigation links are present", async ({ page }) => {

--- a/tests/playwright/seerr.spec.ts
+++ b/tests/playwright/seerr.spec.ts
@@ -17,7 +17,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Settings — Seerr tab", () => {
   test("Seerr tab button is visible", async ({ page }) => {
     await page.goto("/settings");
-    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Settings", level: 1 })).toBeVisible();
     await expect(page.getByRole("button", { name: "Seerr", exact: true })).toBeVisible();
   });
 

--- a/tests/playwright/settings.spec.ts
+++ b/tests/playwright/settings.spec.ts
@@ -11,7 +11,7 @@ const TABS = ["General", "Plex", "Collections", "Seerr", "Logs", "Jobs", "About"
 test.describe("Settings tabs", () => {
   test("All seven tabs are visible", async ({ page }) => {
     await page.goto("/settings");
-    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Settings", level: 1 })).toBeVisible();
 
     for (const tab of TABS) {
       await expect(page.getByRole("button", { name: tab, exact: true })).toBeVisible();

--- a/tests/playwright/users.spec.ts
+++ b/tests/playwright/users.spec.ts
@@ -80,7 +80,7 @@ test.describe("Users page structure", () => {
     const friend = users.find((user) => !user.isSelf);
     test.skip(!friend, "No non-self user exists on this live instance.");
 
-    const friendLabel = friend!.displayNameOverride?.trim() ? friend!.displayName : friend!.username;
+    const friendLabel = friend!.displayNameOverride?.trim() || friend!.displayName || friend!.username;
     const friendCard = page.locator("div.relative").filter({ hasText: friendLabel }).first();
     await expect(friendCard).toBeVisible();
     await friendCard.getByTitle("Edit user").click();
@@ -113,11 +113,12 @@ test.describe("Users page structure", () => {
 
     const cleanupRow = page.locator("tr", { hasText: "Watchlist Cleanup" });
     await expect(cleanupRow).toBeVisible();
-    await expect(cleanupRow).toContainText("Every 30 minutes");
-    await expect(cleanupRow.getByRole("button", { name: "Run Now", exact: true })).toBeEnabled();
 
     const jobs = await request.get("/api/settings/jobs").then((response) => response.json() as Promise<JobInfo[]>);
     const cleanupJob = jobs.find((job) => job.id === "watchlist-cleanup");
     expect(cleanupJob?.isEnabled).toBe(true);
+    expect(cleanupJob?.intervalDescription).toBeTruthy();
+    await expect(cleanupRow).toContainText(cleanupJob!.intervalDescription);
+    await expect(cleanupRow.getByRole("button", { name: "Run Now", exact: true })).toBeEnabled();
   });
 });

--- a/tests/playwright/users.spec.ts
+++ b/tests/playwright/users.spec.ts
@@ -96,8 +96,8 @@ test.describe("Users page structure", () => {
     const modal = page.locator("div.fixed.inset-0.z-50");
     await modal.getByRole("button", { name: "Watchlist", exact: true }).click();
 
-    await expect(modal.getByLabel("Remove Movie When Watched")).toBeVisible();
-    await expect(modal.getByLabel("Remove Show When Watched")).toBeVisible();
+    await expect(modal.getByLabel("Remove Movies When Watched")).toBeVisible();
+    await expect(modal.getByLabel("Remove Shows When Watched")).toBeVisible();
     await expect(modal.getByText(/fully viewed after they were watchlisted/i)).toBeVisible();
 
     await modal.getByRole("button", { name: "Cancel", exact: true }).click();

--- a/tests/playwright/users.spec.ts
+++ b/tests/playwright/users.spec.ts
@@ -85,6 +85,7 @@ test.describe("Users page structure", () => {
     await expect(friendCard).toBeVisible();
     await friendCard.getByTitle("Edit user").click();
 
+    await expect(modal.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
     await expect(modal.getByRole("button", { name: "Watchlist", exact: true })).toHaveCount(0);
   });
 

--- a/tests/playwright/users.spec.ts
+++ b/tests/playwright/users.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import type { JobInfo, SettingsResponse, UserRecord } from "../../src/shared/types";
 
 /**
  * Users page structure tests — verify the Active/Disabled sections and key action
@@ -61,5 +62,62 @@ test.describe("Users page structure", () => {
     await expect(select.locator("option[value='watchlist-date-asc']")).toHaveText("Watchlisted Date (Old to New)");
 
     await expect(modal.getByRole("button", { name: "Cancel" })).toBeVisible();
+  });
+
+  test("Watchlist tab is only available when editing the self user", async ({ page, request }) => {
+    const users = await request.get("/api/users").then((response) => response.json() as Promise<UserRecord[]>);
+    const selfUser = users.find((user) => user.isSelf);
+    expect(selfUser, "Expected the live instance to have a self user").toBeTruthy();
+
+    const selfCard = page.locator("div.relative").filter({ hasText: "You" }).first();
+    await expect(selfCard).toBeVisible();
+    await selfCard.getByTitle("Edit user").click();
+
+    const modal = page.locator("div.fixed.inset-0.z-50");
+    await expect(modal.getByRole("button", { name: "Watchlist", exact: true })).toBeVisible();
+    await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+
+    const friend = users.find((user) => !user.isSelf);
+    test.skip(!friend, "No non-self user exists on this live instance.");
+
+    const friendLabel = friend!.displayNameOverride?.trim() ? friend!.displayName : friend!.username;
+    const friendCard = page.locator("div.relative").filter({ hasText: friendLabel }).first();
+    await expect(friendCard).toBeVisible();
+    await friendCard.getByTitle("Edit user").click();
+
+    await expect(modal.getByRole("button", { name: "Watchlist", exact: true })).toHaveCount(0);
+  });
+
+  test("Self Watchlist tab shows cleanup options without changing them", async ({ page }) => {
+    const selfCard = page.locator("div.relative").filter({ hasText: "You" }).first();
+    await expect(selfCard).toBeVisible();
+    await selfCard.getByTitle("Edit user").click();
+
+    const modal = page.locator("div.fixed.inset-0.z-50");
+    await modal.getByRole("button", { name: "Watchlist", exact: true }).click();
+
+    await expect(modal.getByLabel("Remove Movie When Watched")).toBeVisible();
+    await expect(modal.getByLabel("Remove Show When Watched")).toBeVisible();
+    await expect(modal.getByText(/fully viewed after they were watchlisted/i)).toBeVisible();
+
+    await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+  });
+
+  test("Watchlist Cleanup job is enabled when cleanup settings are already enabled", async ({ page, request }) => {
+    const settings = await request.get("/api/settings").then((response) => response.json() as Promise<SettingsResponse>);
+    const cleanupEnabled = settings.watchlistCleanup.movieEnabled || settings.watchlistCleanup.showEnabled;
+    test.skip(!cleanupEnabled, "Watchlist cleanup is currently disabled on this live instance.");
+
+    await page.goto("/settings?tab=jobs");
+    await expect(page.getByText("Loading jobs...")).not.toBeVisible({ timeout: 10_000 });
+
+    const cleanupRow = page.locator("tr", { hasText: "Watchlist Cleanup" });
+    await expect(cleanupRow).toBeVisible();
+    await expect(cleanupRow).toContainText("Every 30 minutes");
+    await expect(cleanupRow.getByRole("button", { name: "Run Now", exact: true })).toBeEnabled();
+
+    const jobs = await request.get("/api/settings/jobs").then((response) => response.json() as Promise<JobInfo[]>);
+    const cleanupJob = jobs.find((job) => job.id === "watchlist-cleanup");
+    expect(cleanupJob?.isEnabled).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Adds an optional admin/self watchlist cleanup feature that removes watched movies and fully watched shows from the admin Plex watchlist only when Hubarr can prove the item was viewed after it was watchlisted. The feature includes self-user controls, a scheduler-managed cleanup job, clear history/log output for removed vs skipped items, and collection publish follow-up when cleanup changes the watchlist.

Closes #156

## Changes

- `src/client/pages/Users.tsx` adds a self-only `Watchlist` tab at the end of the edit modal with movie/show cleanup toggles and concise explanatory copy.
- `src/client/pages/Settings.tsx`, `src/server/app.ts`, `src/server/index.ts`, and settings/types files expose the `Watchlist Cleanup` job, interval handling, enabled/disabled state, Run Now behavior, and settings API shape.
- `src/server/services.ts` implements the cleanup workflow, per-item decision recording, self Plex server account resolution, show/movie watched checks, immediate local watchlist row deletion, and collection publish triggering only after removals.
- `src/server/integrations/plex.ts` adds Plex history, server account, Discover episode, local episode metadata, and watchlist removal helpers, including fixes for Discover child endpoints and account-scoped play history.
- `src/client/pages/History.tsx` renders cleanup history with removed/skipped variants, distinct icon/color treatment, and removed entries sorted first.
- `src/server/db/watchlist.ts`, `src/server/db/index.ts`, and shared types add the small DB helpers and history kind/action support needed by cleanup.
- `README.md`, `docs/watchlist.md`, `docs/sync.md`, and `TESTING.md` document the new job, behavior, and read-only Playwright coverage.
- `tests/playwright/users.spec.ts` adds read-only coverage for self-only Watchlist tab visibility, cleanup option rendering, and cleanup job enablement when already configured.

## Test plan

- [x] Run `npm run check` and confirm TypeScript passes.
- [x] Run `npm run build` and confirm the production client/server build passes.
- [x] Run `node --import tsx --test tests/server/*.test.ts` and confirm all server tests pass.
- [x] Build a fresh local `hubarr` Docker image and recreate the `hubarr` container with `/opt/hubarr:/config`, bridge networking, port `9301`, and `unless-stopped`.
- [x] Run `npm run test:e2e`; 64/65 passed on the full run, with one existing live-refresh test timing out while waiting on a live background collection publish.
- [x] Rerun the timed-out live-refresh test directly with `npm run test:e2e -- tests/playwright/live-refresh.spec.ts -g "Dashboard recent syncs updates"` and confirm it passes.
- [x] Manually inspect cleanup history/log output from live runs to confirm removed/skipped item names and reasons are understandable.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watchlist Cleanup job: optional scheduled removal of watched movies/shows; per-type toggles in self user settings
  * Settings UI & Jobs list reflect cleanup enablement, interval and last-run; “Run Now” respects enabled state
  * History displays distinct “Watchlist Cleanup” runs with removed/skipped variants and variant-specific styling
  * Removes trigger a follow-up collection publish when applicable

* **Documentation**
  * Added comprehensive Watchlist Cleanup docs and architecture notes

* **Tests**
  * Playwright coverage for Watchlist UI, Jobs state, and Settings headings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Migz93/hubarr/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->