### PR TITLE
fix: validate Plex collection order before skipping publish

### DIFF
--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -4,6 +4,7 @@ import type { RssFeedItem } from "../rss-cache.js";
 import type { Logger } from "../logger.js";
 import { PLEX_USER_AGENT } from "../version.js";
 import type { CollectionSortOrder, UserRecord, MediaType, PlexSettingsInput, RichItemMetadata, SearchCandidate, WatchlistItem } from "../../shared/types.js";
+import { buildOrderMismatchMeta, ratingKeyOrderMatches } from "../utils/collection-order.js";
 
 export interface ResolvedWatchlistItem extends WatchlistItem {
   searchCandidates?: SearchCandidate[];
@@ -266,7 +267,7 @@ const PLEX_TV_RESOURCES_URL = "https://plex.tv/api/v2/resources";
 
 const RSS_PLEX_UUID_PATH = /^\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 const COLLECTION_REORDER_MAX_PASSES = 8;
-const COLLECTION_REORDER_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000, 8_000, 12_000];
+const COLLECTION_REORDER_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000, 8_000, 12_000, 16_000];
 
 // Sentinel value used when no real watchlist date can be determined.
 // Stored in the DB so it can be overwritten later if a real date is found.
@@ -274,25 +275,6 @@ export const WATCHLIST_DATE_UNKNOWN_SENTINEL = "2001-01-01T00:00:00.000Z";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function ratingKeyOrderMatches(actual: string[], expected: string[]): boolean {
-  return actual.length === expected.length && actual.every((key, i) => key === expected[i]);
-}
-
-function buildOrderMismatchMeta(actual: string[], expected: string[]) {
-  const mismatchIndex = expected.findIndex((key, i) => actual[i] !== key);
-  const firstMismatchIndex = mismatchIndex === -1 && actual.length !== expected.length
-    ? Math.min(actual.length, expected.length)
-    : mismatchIndex;
-
-  return {
-    expectedCount: expected.length,
-    actualCount: actual.length,
-    firstMismatchIndex,
-    expectedSample: expected.slice(0, 8),
-    actualSample: actual.slice(0, 8)
-  };
 }
 
 export class PlexIntegration {

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -265,10 +265,35 @@ const PLEX_TV_PING_URL = "https://plex.tv/api/v2/ping";
 const PLEX_TV_RESOURCES_URL = "https://plex.tv/api/v2/resources";
 
 const RSS_PLEX_UUID_PATH = /^\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+const COLLECTION_REORDER_MAX_PASSES = 8;
+const COLLECTION_REORDER_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000, 8_000, 12_000];
 
 // Sentinel value used when no real watchlist date can be determined.
 // Stored in the DB so it can be overwritten later if a real date is found.
 export const WATCHLIST_DATE_UNKNOWN_SENTINEL = "2001-01-01T00:00:00.000Z";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function ratingKeyOrderMatches(actual: string[], expected: string[]): boolean {
+  return actual.length === expected.length && actual.every((key, i) => key === expected[i]);
+}
+
+function buildOrderMismatchMeta(actual: string[], expected: string[]) {
+  const mismatchIndex = expected.findIndex((key, i) => actual[i] !== key);
+  const firstMismatchIndex = mismatchIndex === -1 && actual.length !== expected.length
+    ? Math.min(actual.length, expected.length)
+    : mismatchIndex;
+
+  return {
+    expectedCount: expected.length,
+    actualCount: actual.length,
+    firstMismatchIndex,
+    expectedSample: expected.slice(0, 8),
+    actualSample: actual.slice(0, 8)
+  };
+}
 
 export class PlexIntegration {
   private resolvedMachineIdentifier: string | null = null;
@@ -1620,41 +1645,58 @@ export class PlexIntegration {
 
   /**
    * Enforce a specific item order in a custom-sorted collection.
-   * Moves every item into position sequentially — simple and guaranteed correct.
+   * Moves the first misplaced item into position, re-fetches live order, and
+   * repeats with progressive backoff so Plex has time to settle each move.
    * Skips the whole operation if the collection is already in the desired order.
    */
-  async reorderCollectionItems(collectionRatingKey: string, orderedRatingKeys: string[]): Promise<{ staleKeys: Set<string> }> {
+  async reorderCollectionItems(collectionRatingKey: string, orderedRatingKeys: string[]): Promise<{
+    staleKeys: Set<string>;
+    converged: boolean;
+    finalOrder: string[];
+  }> {
     const staleKeys = new Set<string>();
 
-    if (orderedRatingKeys.length <= 1) return { staleKeys };
-
-    const currentOrder = await this.getCollectionItems(collectionRatingKey);
-
-    if (
-      currentOrder.length === orderedRatingKeys.length &&
-      currentOrder.every((key, i) => key === orderedRatingKeys[i])
-    ) {
-      return { staleKeys }; // already in correct order
+    if (orderedRatingKeys.length <= 1) {
+      const finalOrder = await this.getCollectionItems(collectionRatingKey);
+      return { staleKeys, converged: true, finalOrder };
     }
 
-    // Track the last successfully placed key so the anchor for subsequent moves
-    // stays valid even when stale keys are skipped mid-sequence.
-    let lastPlacedKey: string | null = null;
+    let currentOrder = await this.getCollectionItems(collectionRatingKey);
 
-    for (const itemKey of orderedRatingKeys) {
+    if (ratingKeyOrderMatches(currentOrder, orderedRatingKeys)) {
+      return { staleKeys, converged: true, finalOrder: currentOrder }; // already in correct order
+    }
+
+    let remainingKeys = [...orderedRatingKeys];
+
+    for (let pass = 0; pass < COLLECTION_REORDER_MAX_PASSES; pass++) {
+      const itemKey = remainingKeys.find((key, i) => currentOrder[i] !== key);
+      if (!itemKey) {
+        return { staleKeys, converged: true, finalOrder: currentOrder };
+      }
+      const targetIndex = remainingKeys.indexOf(itemKey);
+      const afterKey = targetIndex > 0 ? remainingKeys[targetIndex - 1] : null;
+
       try {
-        if (lastPlacedKey === null) {
+        this.logger.debug("Moving collection item into desired position", {
+          collectionRatingKey,
+          itemKey,
+          afterKey,
+          targetIndex,
+          pass: pass + 1
+        });
+
+        if (afterKey === null) {
           await this.requestServer(
             `/library/collections/${collectionRatingKey}/items/${itemKey}/move`,
             { method: "PUT" }
           );
         } else {
           await this.requestServer(
-            `/library/collections/${collectionRatingKey}/items/${itemKey}/move?after=${lastPlacedKey}`,
+            `/library/collections/${collectionRatingKey}/items/${itemKey}/move?after=${afterKey}`,
             { method: "PUT" }
           );
         }
-        lastPlacedKey = itemKey;
       } catch (err) {
         if (!this.isItemMissingError(err)) throw err;
         this.logger.warn("Skipping stale rating key during collection reorder", {
@@ -1663,10 +1705,39 @@ export class PlexIntegration {
           error: err instanceof Error ? err.message : String(err)
         });
         staleKeys.add(itemKey);
+        remainingKeys = remainingKeys.filter((key) => key !== itemKey);
+        currentOrder = currentOrder.filter((key) => key !== itemKey);
+        continue;
       }
+
+      const delayMs = COLLECTION_REORDER_RETRY_DELAYS_MS[
+        Math.min(pass, COLLECTION_REORDER_RETRY_DELAYS_MS.length - 1)
+      ];
+      await sleep(delayMs);
+      currentOrder = await this.getCollectionItems(collectionRatingKey);
+      if (ratingKeyOrderMatches(currentOrder, remainingKeys)) {
+        return { staleKeys, converged: true, finalOrder: currentOrder };
+      }
+
+      this.logger.warn("Collection order still mismatched after item move", {
+        collectionRatingKey,
+        movedKey: itemKey,
+        targetIndex,
+        pass: pass + 1,
+        nextDelayMs: COLLECTION_REORDER_RETRY_DELAYS_MS[
+          Math.min(pass + 1, COLLECTION_REORDER_RETRY_DELAYS_MS.length - 1)
+        ],
+        ...buildOrderMismatchMeta(currentOrder, remainingKeys)
+      });
     }
 
-    return { staleKeys };
+    this.logger.warn("Collection reorder did not converge within bounded attempts", {
+      collectionRatingKey,
+      attempts: COLLECTION_REORDER_MAX_PASSES,
+      ...buildOrderMismatchMeta(currentOrder, remainingKeys)
+    });
+
+    return { staleKeys, converged: false, finalOrder: currentOrder };
   }
 
   /**

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -266,8 +266,9 @@ const PLEX_TV_PING_URL = "https://plex.tv/api/v2/ping";
 const PLEX_TV_RESOURCES_URL = "https://plex.tv/api/v2/resources";
 
 const RSS_PLEX_UUID_PATH = /^\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
-const COLLECTION_REORDER_MAX_PASSES = 8;
-const COLLECTION_REORDER_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000, 8_000, 12_000, 16_000];
+const COLLECTION_REORDER_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000, 8_000];
+// How many times to retry a single item move before giving up on the whole collection.
+const COLLECTION_REORDER_MAX_ITEM_RETRIES = COLLECTION_REORDER_RETRY_DELAYS_MS.length;
 
 // Sentinel value used when no real watchlist date can be determined.
 // Stored in the DB so it can be overwritten later if a real date is found.
@@ -1630,6 +1631,8 @@ export class PlexIntegration {
    * Moves the first misplaced item into position, re-fetches live order, and
    * repeats with progressive backoff so Plex has time to settle each move.
    * Skips the whole operation if the collection is already in the desired order.
+   * Retries are tracked per-item: if the same item fails to settle after
+   * COLLECTION_REORDER_MAX_ITEM_RETRIES attempts, the whole reorder is abandoned.
    */
   async reorderCollectionItems(collectionRatingKey: string, orderedRatingKeys: string[]): Promise<{
     staleKeys: Set<string>;
@@ -1639,8 +1642,7 @@ export class PlexIntegration {
     const staleKeys = new Set<string>();
 
     if (orderedRatingKeys.length <= 1) {
-      const finalOrder = await this.getCollectionItems(collectionRatingKey);
-      return { staleKeys, converged: true, finalOrder };
+      return { staleKeys, converged: true, finalOrder: [...orderedRatingKeys] };
     }
 
     let currentOrder = await this.getCollectionItems(collectionRatingKey);
@@ -1650,24 +1652,43 @@ export class PlexIntegration {
     }
 
     let remainingKeys = [...orderedRatingKeys];
+    let lastAttemptedKey: string | null = null;
+    let consecutiveRetries = 0;
 
-    for (let pass = 0; pass < COLLECTION_REORDER_MAX_PASSES; pass++) {
-      const itemKey = remainingKeys.find((key, i) => currentOrder[i] !== key);
-      if (!itemKey) {
+    while (true) {
+      const mismatchIndex = remainingKeys.findIndex((key, i) => currentOrder[i] !== key);
+      if (mismatchIndex === -1) {
         return { staleKeys, converged: true, finalOrder: currentOrder };
       }
-      const targetIndex = remainingKeys.indexOf(itemKey);
-      const afterKey = targetIndex > 0 ? remainingKeys[targetIndex - 1] : null;
+
+      const itemKey = remainingKeys[mismatchIndex];
+      const afterKey = mismatchIndex > 0 ? remainingKeys[mismatchIndex - 1] : null;
+
+      if (itemKey === lastAttemptedKey) {
+        consecutiveRetries++;
+        if (consecutiveRetries >= COLLECTION_REORDER_MAX_ITEM_RETRIES) {
+          this.logger.warn("Collection reorder did not converge within bounded attempts", {
+            collectionRatingKey,
+            stuckKey: itemKey,
+            itemRetries: consecutiveRetries,
+            ...buildOrderMismatchMeta(currentOrder, remainingKeys)
+          });
+          return { staleKeys, converged: false, finalOrder: currentOrder };
+        }
+      } else {
+        consecutiveRetries = 0;
+        lastAttemptedKey = itemKey;
+      }
+
+      this.logger.debug("Moving collection item into desired position", {
+        collectionRatingKey,
+        itemKey,
+        afterKey,
+        targetIndex: mismatchIndex,
+        consecutiveRetries
+      });
 
       try {
-        this.logger.debug("Moving collection item into desired position", {
-          collectionRatingKey,
-          itemKey,
-          afterKey,
-          targetIndex,
-          pass: pass + 1
-        });
-
         if (afterKey === null) {
           await this.requestServer(
             `/library/collections/${collectionRatingKey}/items/${itemKey}/move`,
@@ -1689,11 +1710,13 @@ export class PlexIntegration {
         staleKeys.add(itemKey);
         remainingKeys = remainingKeys.filter((key) => key !== itemKey);
         currentOrder = currentOrder.filter((key) => key !== itemKey);
+        consecutiveRetries = 0;
+        lastAttemptedKey = null;
         continue;
       }
 
       const delayMs = COLLECTION_REORDER_RETRY_DELAYS_MS[
-        Math.min(pass, COLLECTION_REORDER_RETRY_DELAYS_MS.length - 1)
+        Math.min(consecutiveRetries, COLLECTION_REORDER_RETRY_DELAYS_MS.length - 1)
       ];
       await sleep(delayMs);
       currentOrder = await this.getCollectionItems(collectionRatingKey);
@@ -1704,22 +1727,11 @@ export class PlexIntegration {
       this.logger.warn("Collection order still mismatched after item move", {
         collectionRatingKey,
         movedKey: itemKey,
-        targetIndex,
-        pass: pass + 1,
-        nextDelayMs: COLLECTION_REORDER_RETRY_DELAYS_MS[
-          Math.min(pass + 1, COLLECTION_REORDER_RETRY_DELAYS_MS.length - 1)
-        ],
+        targetIndex: mismatchIndex,
+        consecutiveRetries,
         ...buildOrderMismatchMeta(currentOrder, remainingKeys)
       });
     }
-
-    this.logger.warn("Collection reorder did not converge within bounded attempts", {
-      collectionRatingKey,
-      attempts: COLLECTION_REORDER_MAX_PASSES,
-      ...buildOrderMismatchMeta(currentOrder, remainingKeys)
-    });
-
-    return { staleKeys, converged: false, finalOrder: currentOrder };
   }
 
   /**

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -48,6 +48,29 @@ function computePublishStateHash(params: {
   return crypto.createHash("sha256").update(payload).digest("hex");
 }
 
+function isCustomCollectionSort(sortOrder: CollectionSortOrder): boolean {
+  return sortOrder !== "title";
+}
+
+function ratingKeyOrderMatches(actual: string[], expected: string[]): boolean {
+  return actual.length === expected.length && actual.every((key, i) => key === expected[i]);
+}
+
+function buildOrderMismatchMeta(actual: string[], expected: string[]) {
+  const mismatchIndex = expected.findIndex((key, i) => actual[i] !== key);
+  const firstMismatchIndex = mismatchIndex === -1 && actual.length !== expected.length
+    ? Math.min(actual.length, expected.length)
+    : mismatchIndex;
+
+  return {
+    expectedCount: expected.length,
+    actualCount: actual.length,
+    firstMismatchIndex,
+    expectedSample: expected.slice(0, 8),
+    actualSample: actual.slice(0, 8)
+  };
+}
+
 type SeerrRequestSyncScope =
   | { mode: "all"; triggeredBy: "manual" | "full" }
   | { mode: "user"; userId: number; triggeredBy: "user" }
@@ -1142,7 +1165,8 @@ export class HubarrServices {
     runId: number | null,
     force: boolean,
     plex = this.getPlexIntegration()
-  ) {
+  ): Promise<string[]> {
+    const publishFailures: string[] = [];
     const appSettings = this.db.getAppSettings();
     // Per-user override takes precedence over the global setting; null means use global.
     const effectiveSortOrder = friend.collectionSortOrderOverride ?? appSettings.collectionSortOrder ?? "date-desc";
@@ -1231,20 +1255,58 @@ export class HubarrServices {
           }
 
           if (exists) {
-            this.logger.debug("Collection state unchanged and collection validated, skipping publish", {
+            if (isCustomCollectionSort(effectiveSortOrder)) {
+              let liveKeys: string[] | null;
+              try {
+                liveKeys = await plex.getCollectionItems(stored.collectionRatingKey);
+              } catch (err) {
+                this.logger.warn("Could not validate collection item order, proceeding with full publish", {
+                  userId: friend.id,
+                  mediaType,
+                  collectionRatingKey: stored.collectionRatingKey,
+                  effectiveSortOrder,
+                  error: err instanceof Error ? err.message : String(err)
+                });
+                liveKeys = null;
+              }
+
+              if (liveKeys && ratingKeyOrderMatches(liveKeys, matchedRatingKeys)) {
+                this.logger.debug("Collection state unchanged and collection order validated, skipping publish", {
+                  userId: friend.id,
+                  mediaType,
+                  collectionRatingKey: stored.collectionRatingKey,
+                  effectiveSortOrder
+                });
+                continue;
+              }
+
+              if (liveKeys) {
+                this.logger.info("Collection item order differs from desired state, republishing", {
+                  userId: friend.id,
+                  mediaType,
+                  collectionRatingKey: stored.collectionRatingKey,
+                  effectiveSortOrder,
+                  ...buildOrderMismatchMeta(liveKeys, matchedRatingKeys)
+                });
+              }
+              // Hash matches but Plex order drifted, so keep the stored
+              // collection identity and fall through to the reorder path.
+            } else {
+              this.logger.debug("Collection state unchanged and collection validated, skipping publish", {
+                userId: friend.id,
+                mediaType,
+                collectionRatingKey: stored.collectionRatingKey
+              });
+              continue;
+            }
+          } else {
+            this.logger.info("Stored collection no longer exists in Plex, clearing and republishing", {
               userId: friend.id,
               mediaType,
               collectionRatingKey: stored.collectionRatingKey
             });
-            continue;
+            this.db.clearCollectionRatingKey(friend.id, mediaType);
           }
-
-          this.logger.info("Stored collection no longer exists in Plex, clearing and republishing", {
-            userId: friend.id,
-            mediaType,
-            collectionRatingKey: stored.collectionRatingKey
-          });
-          this.db.clearCollectionRatingKey(friend.id, mediaType);
         }
       }
 
@@ -1285,11 +1347,16 @@ export class HubarrServices {
       // For custom-order modes (date/watchlist-date, collectionSort=2) push
       // explicit item positions which also catches stale keys via 404 failures.
       let reorderStaleKeys: Set<string>;
+      let reorderConverged = true;
+      let reorderFinalOrder: string[] | null = null;
       if (effectiveSortOrder === "title") {
         const liveKeys = new Set(await plex.getCollectionItems(collectionRatingKey));
         reorderStaleKeys = new Set(reorderKeys.filter((k) => !liveKeys.has(k)));
       } else {
-        ({ staleKeys: reorderStaleKeys } = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys));
+        const reorderResult = await plex.reorderCollectionItems(collectionRatingKey, reorderKeys);
+        reorderStaleKeys = reorderResult.staleKeys;
+        reorderConverged = reorderResult.converged;
+        reorderFinalOrder = reorderResult.finalOrder;
       }
       if (reorderStaleKeys.size > 0) {
         this.logger.warn("Clearing stale matched rating keys found during post-sync validation", {
@@ -1314,6 +1381,60 @@ export class HubarrServices {
         collectionRatingKey,
         matchedItems: cleanedKeys.length
       });
+
+      let customOrderValidated = true;
+      let collectionPublishErrorDetails: Record<string, unknown> | null = null;
+      if (isCustomCollectionSort(effectiveSortOrder)) {
+        try {
+          const liveKeys = reorderFinalOrder ?? await plex.getCollectionItems(collectionRatingKey);
+          customOrderValidated = ratingKeyOrderMatches(liveKeys, cleanedKeys);
+          if (!customOrderValidated) {
+            const mismatch = buildOrderMismatchMeta(liveKeys, cleanedKeys);
+            this.logger.warn("Collection item order still differs after reorder; leaving sync hash dirty", {
+              userId: friend.id,
+              mediaType,
+              collectionRatingKey,
+              effectiveSortOrder,
+              reorderConverged,
+              ...mismatch
+            });
+            collectionPublishErrorDetails = {
+              userId: friend.id,
+              displayName: friend.displayName,
+              mediaType,
+              collectionName,
+              collectionRatingKey,
+              effectiveSortOrder,
+              matchedItems: cleanedKeys.length,
+              reason: reorderConverged ? "post-reorder-validation-mismatch" : "reorder-did-not-converge",
+              message: "Plex collection order does not match Hubarr's desired order after bounded reorder attempts.",
+              ...mismatch
+            };
+          }
+        } catch (err) {
+          customOrderValidated = false;
+          const error = err instanceof Error ? err.message : String(err);
+          this.logger.warn("Could not validate collection item order after reorder; leaving sync hash dirty", {
+            userId: friend.id,
+            mediaType,
+            collectionRatingKey,
+            effectiveSortOrder,
+            error
+          });
+          collectionPublishErrorDetails = {
+            userId: friend.id,
+            displayName: friend.displayName,
+            mediaType,
+            collectionName,
+            collectionRatingKey,
+            effectiveSortOrder,
+            matchedItems: cleanedKeys.length,
+            reason: "post-reorder-validation-error",
+            message: "Hubarr could not verify Plex collection order after reorder.",
+            error
+          };
+        }
+      }
 
       await plex.applyLabelToCollection(collectionRatingKey, labelName);
       this.logger.info("Collection label applied", {
@@ -1348,27 +1469,39 @@ export class HubarrServices {
         visibleName: collectionName,
         labelName,
         hubIdentifier,
-        lastSyncedHash: storedHash,
+        lastSyncedHash: customOrderValidated ? storedHash : null,
         lastSyncedAt: new Date().toISOString(),
-        lastSyncError: null
+        lastSyncError: collectionPublishErrorDetails
+          ? String(collectionPublishErrorDetails.message)
+          : null
       });
       if (runId !== null) {
-        this.db.addSyncRunItem(
-          runId,
-          "collection.publish",
-          "success",
-          {
-            userId: friend.id,
-            displayName: friend.displayName,
-            mediaType,
-            collectionName,
-            collectionRatingKey,
-            matchedItems: cleanedKeys.length
-          },
-          friend.id
-        );
+        if (collectionPublishErrorDetails) {
+          this.db.addSyncRunItem(runId, "collection.publish", "error", collectionPublishErrorDetails, friend.id);
+        } else {
+          this.db.addSyncRunItem(
+            runId,
+            "collection.publish",
+            "success",
+            {
+              userId: friend.id,
+              displayName: friend.displayName,
+              mediaType,
+              collectionName,
+              collectionRatingKey,
+              matchedItems: cleanedKeys.length
+            },
+            friend.id
+          );
+        }
+      }
+
+      if (collectionPublishErrorDetails) {
+        publishFailures.push(`${friend.displayName} ${mediaType} collection ${collectionRatingKey}: ${collectionPublishErrorDetails.message}`);
       }
     }
+
+    return publishFailures;
   }
 
   private async applyCollectionPoster(
@@ -1627,8 +1760,14 @@ export class HubarrServices {
     await Promise.all(friends.map((friend) =>
       publishLimit(async () => {
         try {
-          await this.publishUserCollections(friend, this.db.getWatchlistItems(friend.id), runId, force, plex);
-          this.db.markUserSyncResult(friend.id, null);
+          const publishFailures = await this.publishUserCollections(friend, this.db.getWatchlistItems(friend.id), runId, force, plex);
+          if (publishFailures.length > 0) {
+            const message = publishFailures.join(" | ");
+            this.db.markUserSyncResult(friend.id, message);
+            failures.push(...publishFailures);
+          } else {
+            this.db.markUserSyncResult(friend.id, null);
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           this.logger.error("Collection sync failed for user — continuing with remaining users", {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1242,7 +1242,7 @@ export class HubarrServices {
               try {
                 liveKeys = await plex.getCollectionItems(stored.collectionRatingKey);
               } catch (err) {
-                this.logger.warn("Could not validate collection item order, proceeding with full publish", {
+                this.logger.warn("Could not validate collection item order, falling through to republish", {
                   userId: friend.id,
                   mediaType,
                   collectionRatingKey: stored.collectionRatingKey,

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1221,9 +1221,9 @@ export class HubarrServices {
         if (stored?.collectionRatingKey && stored.lastSyncedHash === stateHash) {
           // Hash matches — validate the collection still exists in Plex before
           // skipping. A transient error (network, auth) falls through to the
-          // full publish rather than silently skipping; a definitive 400/404
+          // full publish without clearing the stored key; a definitive false
           // means the collection was externally deleted and needs to be recreated.
-          let exists: boolean;
+          let exists: boolean | null;
           try {
             exists = await plex.collectionExists(stored.collectionRatingKey);
           } catch (err) {
@@ -1233,10 +1233,10 @@ export class HubarrServices {
               collectionRatingKey: stored.collectionRatingKey,
               error: err instanceof Error ? err.message : String(err)
             });
-            exists = false; // fall through to full publish
+            exists = null; // fall through to full publish without treating the collection as deleted
           }
 
-          if (exists) {
+          if (exists === true) {
             if (isCustomCollectionSort(effectiveSortOrder)) {
               let liveKeys: string[] | null;
               try {
@@ -1281,7 +1281,7 @@ export class HubarrServices {
               });
               continue;
             }
-          } else {
+          } else if (exists === false) {
             this.logger.info("Stored collection no longer exists in Plex, clearing and republishing", {
               userId: friend.id,
               mediaType,

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1732,6 +1732,7 @@ export class HubarrServices {
     const { publishingUsers } = this.getUserScopes();
     const friends = publishingUsers;
     const failures: string[] = [];
+    const failedUserIds = new Set<number>();
     const plex = this.getPlexIntegration();
 
     this.logger.info("Collection sync started", { userCount: friends.length, force });
@@ -1746,6 +1747,7 @@ export class HubarrServices {
           if (publishFailures.length > 0) {
             const message = publishFailures.join(" | ");
             this.db.markUserSyncResult(friend.id, message);
+            failedUserIds.add(friend.id);
             failures.push(...publishFailures);
           } else {
             this.db.markUserSyncResult(friend.id, null);
@@ -1763,6 +1765,7 @@ export class HubarrServices {
             displayName: friend.displayName,
             message
           }, friend.id);
+          failedUserIds.add(friend.id);
           failures.push(`${friend.displayName}: ${message}`);
         } finally {
           publishCompleted++;
@@ -1774,11 +1777,12 @@ export class HubarrServices {
     await this.applyIsolationFilters(friends, runId);
 
     if (failures.length > 0) {
-      const summary = `Collection sync finished: ${friends.length - failures.length}/${friends.length} users succeeded.`;
+      const failedUsers = failedUserIds.size;
+      const summary = `Collection sync finished: ${friends.length - failedUsers}/${friends.length} users succeeded.`;
       this.db.completeSyncRun(runId, "error", summary, failures.join(" | "));
       this.logger.info("Collection sync complete", {
-        succeeded: friends.length - failures.length,
-        failed: failures.length,
+        succeeded: friends.length - failedUsers,
+        failed: failedUsers,
         durationMs: Date.now() - syncStart
       });
     } else {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -19,6 +19,7 @@ import { Logger } from "./logger.js";
 import { PlexIntegration, WATCHLIST_DATE_UNKNOWN_SENTINEL, type PlexDiscoverEpisodeRef, type PlexEpisodeRef, type PlexLibraryItemMatch, type ResolvedWatchlistItem } from "./integrations/plex.js";
 import { SeerrIntegration, extractTmdbId } from "./integrations/seerr.js";
 import { RssCache, type RssFeedItem } from "./rss-cache.js";
+import { buildOrderMismatchMeta, ratingKeyOrderMatches } from "./utils/collection-order.js";
 
 const PLEX_SYNC_CONCURRENCY = 3;
 
@@ -50,25 +51,6 @@ function computePublishStateHash(params: {
 
 function isCustomCollectionSort(sortOrder: CollectionSortOrder): boolean {
   return sortOrder !== "title";
-}
-
-function ratingKeyOrderMatches(actual: string[], expected: string[]): boolean {
-  return actual.length === expected.length && actual.every((key, i) => key === expected[i]);
-}
-
-function buildOrderMismatchMeta(actual: string[], expected: string[]) {
-  const mismatchIndex = expected.findIndex((key, i) => actual[i] !== key);
-  const firstMismatchIndex = mismatchIndex === -1 && actual.length !== expected.length
-    ? Math.min(actual.length, expected.length)
-    : mismatchIndex;
-
-  return {
-    expectedCount: expected.length,
-    actualCount: actual.length,
-    firstMismatchIndex,
-    expectedSample: expected.slice(0, 8),
-    actualSample: actual.slice(0, 8)
-  };
 }
 
 type SeerrRequestSyncScope =

--- a/src/server/utils/collection-order.ts
+++ b/src/server/utils/collection-order.ts
@@ -1,0 +1,18 @@
+export function ratingKeyOrderMatches(actual: string[], expected: string[]): boolean {
+  return actual.length === expected.length && actual.every((key, i) => key === expected[i]);
+}
+
+export function buildOrderMismatchMeta(actual: string[], expected: string[]) {
+  const mismatchIndex = expected.findIndex((key, i) => actual[i] !== key);
+  const firstMismatchIndex = mismatchIndex === -1 && actual.length !== expected.length
+    ? Math.min(actual.length, expected.length)
+    : mismatchIndex;
+
+  return {
+    expectedCount: expected.length,
+    actualCount: actual.length,
+    firstMismatchIndex,
+    expectedSample: expected.slice(0, 8),
+    actualSample: actual.slice(0, 8)
+  };
+}

--- a/tests/server/collection-order-validation.test.ts
+++ b/tests/server/collection-order-validation.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { CollectionSortOrder, UserRecord, WatchlistItem } from "../../src/shared/types.js";
+import { HubarrServices } from "../../src/server/services.js";
+import type { ImageCacheService } from "../../src/server/image-cache.js";
+import type { Logger } from "../../src/server/logger.js";
+import { createTestDatabase } from "./test-db.js";
+
+type LogEntry = { level: "debug" | "info" | "warn" | "error"; message: string; meta?: unknown };
+
+function createCapturingLogger() {
+  const entries: LogEntry[] = [];
+  const logger = {
+    debug: (message: string, meta?: unknown) => entries.push({ level: "debug", message, meta }),
+    info: (message: string, meta?: unknown) => entries.push({ level: "info", message, meta }),
+    warn: (message: string, meta?: unknown) => entries.push({ level: "warn", message, meta }),
+    error: (message: string, meta?: unknown) => entries.push({ level: "error", message, meta }),
+    getRecentLogs: () => entries
+  } as unknown as Logger;
+
+  return { logger, entries };
+}
+
+function createMovie(plexItemId: string, title: string, releaseDate: string, matchedRatingKey: string): WatchlistItem {
+  return {
+    plexItemId,
+    title,
+    type: "movie",
+    year: Number(releaseDate.slice(0, 4)),
+    releaseDate,
+    thumb: null,
+    guids: [],
+    discoverKey: plexItemId,
+    source: "graphql",
+    addedAt: `${releaseDate}T00:00:00.000Z`,
+    matchedRatingKey
+  };
+}
+
+function createPlexMock(options: {
+  collectionOrder: string[];
+  reorderAppliesOrder?: boolean;
+}) {
+  let collectionOrder = [...options.collectionOrder];
+  const calls = {
+    collectionExists: 0,
+    ensureCollection: 0,
+    getCollectionItems: 0,
+    reorderCollectionItems: 0,
+    syncCollectionItems: 0
+  };
+
+  return {
+    calls,
+    setCollectionOrder(nextOrder: string[]) {
+      collectionOrder = [...nextOrder];
+    },
+    createCollectionLabel(username: string) {
+      return `hubarr:${username}`;
+    },
+    async collectionExists() {
+      calls.collectionExists += 1;
+      return true;
+    },
+    async ensureCollection() {
+      calls.ensureCollection += 1;
+      return "collection-1";
+    },
+    async updateCollectionSortTitle() {},
+    async updateCollectionContentSort() {},
+    async syncCollectionItems(_collectionRatingKey: string, ratingKeys: string[]) {
+      calls.syncCollectionItems += 1;
+      const desired = new Set(ratingKeys);
+      collectionOrder = [
+        ...collectionOrder.filter((key) => desired.has(key)),
+        ...ratingKeys.filter((key) => !collectionOrder.includes(key))
+      ];
+      return { staleKeys: new Set<string>() };
+    },
+    async reorderCollectionItems(_collectionRatingKey: string, orderedRatingKeys: string[]) {
+      calls.reorderCollectionItems += 1;
+      if (options.reorderAppliesOrder !== false) {
+        collectionOrder = [...orderedRatingKeys];
+      }
+      return {
+        staleKeys: new Set<string>(),
+        converged: options.reorderAppliesOrder !== false,
+        finalOrder: [...collectionOrder]
+      };
+    },
+    async getCollectionItems() {
+      calls.getCollectionItems += 1;
+      return [...collectionOrder];
+    },
+    async applyLabelToCollection() {},
+    async updateCollectionVisibility() {
+      return "hub-1";
+    }
+  };
+}
+
+function createService(logger: Logger) {
+  const { db, cleanup } = createTestDatabase();
+  const service = new HubarrServices(db, logger, {} as ImageCacheService) as unknown as {
+    publishUserCollections: (
+      friend: UserRecord,
+      items: WatchlistItem[],
+      runId: number | null,
+      force: boolean,
+      plex: unknown
+    ) => Promise<string[]>;
+    applyCollectionPoster: () => Promise<void>;
+  };
+  service.applyCollectionPoster = async () => {};
+
+  return { db, service, cleanup };
+}
+
+function createUser(db: ReturnType<typeof createTestDatabase>["db"], sortOrder: CollectionSortOrder) {
+  db.updateAppSettings({
+    collectionSortOrder: sortOrder,
+    defaultMovieLibraryId: "movies",
+    defaultShowLibraryId: null
+  });
+  db.upsertUsers([{ plexUserId: "plex-1", username: "alex", displayName: "Alex", avatarUrl: null }]);
+  const user = db.listUsers()[0];
+  assert.ok(user);
+  return db.updateUser(user.id, { enabled: true });
+}
+
+test("custom collection sort republishes when stored hash matches but live order drifted", async () => {
+  const { logger, entries } = createCapturingLogger();
+  const { db, service, cleanup } = createService(logger);
+
+  try {
+    const user = createUser(db, "date-desc");
+    const items = [
+      createMovie("movie-new", "New Movie", "2026-01-01", "rk-new"),
+      createMovie("movie-old", "Old Movie", "2024-01-01", "rk-old")
+    ];
+    const plex = createPlexMock({ collectionOrder: ["rk-new", "rk-old"] });
+
+    await service.publishUserCollections(user, items, null, false, plex);
+    assert.equal(plex.calls.ensureCollection, 1);
+
+    plex.setCollectionOrder(["rk-old", "rk-new"]);
+    await service.publishUserCollections(user, items, null, false, plex);
+
+    assert.equal(plex.calls.ensureCollection, 2);
+    assert.equal(plex.calls.reorderCollectionItems, 2);
+    assert.deepEqual(await plex.getCollectionItems(), ["rk-new", "rk-old"]);
+    assert.ok(entries.some((entry) => entry.message === "Collection item order differs from desired state, republishing"));
+  } finally {
+    cleanup();
+  }
+});
+
+test("title collection sort still skips on hash match after existence validation", async () => {
+  const { logger } = createCapturingLogger();
+  const { service, db, cleanup } = createService(logger);
+
+  try {
+    const user = createUser(db, "title");
+    const items = [
+      createMovie("movie-new", "New Movie", "2026-01-01", "rk-new"),
+      createMovie("movie-old", "Old Movie", "2024-01-01", "rk-old")
+    ];
+    const plex = createPlexMock({ collectionOrder: ["rk-old", "rk-new"] });
+
+    await service.publishUserCollections(user, items, null, false, plex);
+    await service.publishUserCollections(user, items, null, false, plex);
+
+    assert.equal(plex.calls.collectionExists, 1);
+    assert.equal(plex.calls.ensureCollection, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("custom collection sort leaves lastSyncedHash dirty when post-reorder order validation fails", async () => {
+  const { logger, entries } = createCapturingLogger();
+  const { service, db, cleanup } = createService(logger);
+
+  try {
+    const user = createUser(db, "date-desc");
+    const items = [
+      createMovie("movie-new", "New Movie", "2026-01-01", "rk-new"),
+      createMovie("movie-old", "Old Movie", "2024-01-01", "rk-old")
+    ];
+    const plex = createPlexMock({
+      collectionOrder: ["rk-old", "rk-new"],
+      reorderAppliesOrder: false
+    });
+
+    await service.publishUserCollections(user, items, null, false, plex);
+
+    const stored = db.getCollectionRecord(user.id, "movie");
+    assert.ok(stored);
+    assert.equal(stored.lastSyncedHash, null);
+    assert.ok(entries.some((entry) => entry.message === "Collection item order still differs after reorder; leaving sync hash dirty"));
+  } finally {
+    cleanup();
+  }
+});
+
+test("custom collection sort records a failed history item when bounded reorder does not converge", async () => {
+  const { logger } = createCapturingLogger();
+  const { service, db, cleanup } = createService(logger);
+
+  try {
+    const user = createUser(db, "date-desc");
+    const items = [
+      createMovie("movie-new", "New Movie", "2026-01-01", "rk-new"),
+      createMovie("movie-old", "Old Movie", "2024-01-01", "rk-old")
+    ];
+    const plex = createPlexMock({
+      collectionOrder: ["rk-old", "rk-new"],
+      reorderAppliesOrder: false
+    });
+    const runId = db.createSyncRun("publish", "Collection sync started.");
+
+    const failures = await service.publishUserCollections(user, items, runId, false, plex);
+    const run = db.getSyncRunWithItems(runId);
+
+    assert.equal(failures.length, 1);
+    assert.ok(run);
+    const failedItem = run.items.find((item) => item.action === "collection.publish" && item.status === "error");
+    assert.ok(failedItem);
+    assert.deepEqual(failedItem.details, {
+      userId: user.id,
+      displayName: "alex",
+      mediaType: "movie",
+      collectionName: "alexs Watchlist",
+      collectionRatingKey: "collection-1",
+      effectiveSortOrder: "date-desc",
+      matchedItems: 2,
+      reason: "reorder-did-not-converge",
+      message: "Plex collection order does not match Hubarr's desired order after bounded reorder attempts.",
+      expectedCount: 2,
+      actualCount: 2,
+      firstMismatchIndex: 0,
+      expectedSample: ["rk-new", "rk-old"],
+      actualSample: ["rk-old", "rk-new"]
+    });
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/server/collection-order-validation.test.ts
+++ b/tests/server/collection-order-validation.test.ts
@@ -25,9 +25,11 @@ function createMovie(plexItemId: string, title: string, releaseDate: string, mat
 
 function createPlexMock(options: {
   collectionOrder: string[];
+  collectionExistsError?: Error;
   reorderAppliesOrder?: boolean;
 }) {
   let collectionOrder = [...options.collectionOrder];
+  let collectionExistsError = options.collectionExistsError;
   const calls = {
     collectionExists: 0,
     ensureCollection: 0,
@@ -41,11 +43,17 @@ function createPlexMock(options: {
     setCollectionOrder(nextOrder: string[]) {
       collectionOrder = [...nextOrder];
     },
+    setCollectionExistsError(error: Error | undefined) {
+      collectionExistsError = error;
+    },
     createCollectionLabel(username: string) {
       return `hubarr:${username}`;
     },
     async collectionExists() {
       calls.collectionExists += 1;
+      if (collectionExistsError) {
+        throw collectionExistsError;
+      }
       return true;
     },
     async ensureCollection() {
@@ -158,6 +166,37 @@ test("title collection sort still skips on hash match after existence validation
 
     assert.equal(plex.calls.collectionExists, 1);
     assert.equal(plex.calls.ensureCollection, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("collection existence validation errors do not clear the stored collection key", async () => {
+  const { logger, entries } = createCapturingLogger();
+  const { service, db, cleanup } = createService(logger);
+
+  try {
+    const user = createUser(db, "title");
+    const items = [
+      createMovie("movie-new", "New Movie", "2026-01-01", "rk-new"),
+      createMovie("movie-old", "Old Movie", "2024-01-01", "rk-old")
+    ];
+    const plex = createPlexMock({ collectionOrder: ["rk-old", "rk-new"] });
+    const originalClearCollectionRatingKey = db.clearCollectionRatingKey.bind(db);
+    let clearCollectionRatingKeyCalls = 0;
+    db.clearCollectionRatingKey = ((userId, mediaType) => {
+      clearCollectionRatingKeyCalls += 1;
+      return originalClearCollectionRatingKey(userId, mediaType);
+    }) as typeof db.clearCollectionRatingKey;
+
+    await service.publishUserCollections(user, items, null, false, plex);
+    plex.setCollectionExistsError(new Error("Plex temporarily unavailable"));
+    await service.publishUserCollections(user, items, null, false, plex);
+
+    assert.equal(plex.calls.collectionExists, 1);
+    assert.equal(plex.calls.ensureCollection, 2);
+    assert.equal(clearCollectionRatingKeyCalls, 0);
+    assert.ok(entries.some((entry) => entry.message === "Could not validate collection existence, proceeding with full publish"));
   } finally {
     cleanup();
   }

--- a/tests/server/collection-order-validation.test.ts
+++ b/tests/server/collection-order-validation.test.ts
@@ -5,21 +5,7 @@ import { HubarrServices } from "../../src/server/services.js";
 import type { ImageCacheService } from "../../src/server/image-cache.js";
 import type { Logger } from "../../src/server/logger.js";
 import { createTestDatabase } from "./test-db.js";
-
-type LogEntry = { level: "debug" | "info" | "warn" | "error"; message: string; meta?: unknown };
-
-function createCapturingLogger() {
-  const entries: LogEntry[] = [];
-  const logger = {
-    debug: (message: string, meta?: unknown) => entries.push({ level: "debug", message, meta }),
-    info: (message: string, meta?: unknown) => entries.push({ level: "info", message, meta }),
-    warn: (message: string, meta?: unknown) => entries.push({ level: "warn", message, meta }),
-    error: (message: string, meta?: unknown) => entries.push({ level: "error", message, meta }),
-    getRecentLogs: () => entries
-  } as unknown as Logger;
-
-  return { logger, entries };
-}
+import { createCapturingLogger } from "./test-helpers.js";
 
 function createMovie(plexItemId: string, title: string, releaseDate: string, matchedRatingKey: string): WatchlistItem {
   return {

--- a/tests/server/plex-reorder.test.ts
+++ b/tests/server/plex-reorder.test.ts
@@ -26,7 +26,7 @@ function moveItem(order: string[], itemKey: string, afterKey: string | null): st
 
   const afterIndex = withoutItem.indexOf(afterKey);
   if (afterIndex === -1) {
-    return withoutItem;
+    throw new Error(`afterKey not found in test order: ${afterKey} for item ${itemKey}`);
   }
 
   return [
@@ -66,6 +66,8 @@ test("reorderCollectionItems retries progressively until Plex reports the desire
   const result = await plex.reorderCollectionItems("collection-1", ["a", "b", "c"]);
 
   assert.equal(result.staleKeys.size, 0);
+  assert.equal(result.converged, true);
+  assert.deepEqual(result.finalOrder, ["a", "b", "c"]);
   assert.deepEqual(order, ["a", "b", "c"]);
   assert.equal(moveCalls, 2);
   assert.ok(entries.some((entry) => entry.message === "Collection order still mismatched after item move"));
@@ -96,8 +98,11 @@ test("reorderCollectionItems moves only the first misplaced item when that conve
     return {};
   };
 
-  await plex.reorderCollectionItems("collection-1", ["a", "b", "c"]);
+  const result = await plex.reorderCollectionItems("collection-1", ["a", "b", "c"]);
 
+  assert.equal(result.staleKeys.size, 0);
+  assert.equal(result.converged, true);
+  assert.deepEqual(result.finalOrder, ["a", "b", "c"]);
   assert.deepEqual(order, ["a", "b", "c"]);
   assert.deepEqual(moved, [{ itemKey: "b", afterKey: "a" }]);
 });

--- a/tests/server/plex-reorder.test.ts
+++ b/tests/server/plex-reorder.test.ts
@@ -1,22 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { PlexIntegration } from "../../src/server/integrations/plex.js";
-import type { Logger } from "../../src/server/logger.js";
-
-type LogEntry = { level: "debug" | "info" | "warn" | "error"; message: string; meta?: unknown };
-
-function createCapturingLogger() {
-  const entries: LogEntry[] = [];
-  const logger = {
-    debug: (message: string, meta?: unknown) => entries.push({ level: "debug", message, meta }),
-    info: (message: string, meta?: unknown) => entries.push({ level: "info", message, meta }),
-    warn: (message: string, meta?: unknown) => entries.push({ level: "warn", message, meta }),
-    error: (message: string, meta?: unknown) => entries.push({ level: "error", message, meta }),
-    getRecentLogs: () => entries
-  } as unknown as Logger;
-
-  return { logger, entries };
-}
+import { createCapturingLogger } from "./test-helpers.js";
 
 function moveItem(order: string[], itemKey: string, afterKey: string | null): string[] {
   const withoutItem = order.filter((key) => key !== itemKey);

--- a/tests/server/plex-reorder.test.ts
+++ b/tests/server/plex-reorder.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PlexIntegration } from "../../src/server/integrations/plex.js";
+import type { Logger } from "../../src/server/logger.js";
+
+type LogEntry = { level: "debug" | "info" | "warn" | "error"; message: string; meta?: unknown };
+
+function createCapturingLogger() {
+  const entries: LogEntry[] = [];
+  const logger = {
+    debug: (message: string, meta?: unknown) => entries.push({ level: "debug", message, meta }),
+    info: (message: string, meta?: unknown) => entries.push({ level: "info", message, meta }),
+    warn: (message: string, meta?: unknown) => entries.push({ level: "warn", message, meta }),
+    error: (message: string, meta?: unknown) => entries.push({ level: "error", message, meta }),
+    getRecentLogs: () => entries
+  } as unknown as Logger;
+
+  return { logger, entries };
+}
+
+function moveItem(order: string[], itemKey: string, afterKey: string | null): string[] {
+  const withoutItem = order.filter((key) => key !== itemKey);
+  if (afterKey === null) {
+    return [itemKey, ...withoutItem];
+  }
+
+  const afterIndex = withoutItem.indexOf(afterKey);
+  if (afterIndex === -1) {
+    return withoutItem;
+  }
+
+  return [
+    ...withoutItem.slice(0, afterIndex + 1),
+    itemKey,
+    ...withoutItem.slice(afterIndex + 1)
+  ];
+}
+
+test("reorderCollectionItems retries progressively until Plex reports the desired order", async () => {
+  const { logger, entries } = createCapturingLogger();
+  const plex = new PlexIntegration({
+    serverUrl: "http://plex.example",
+    token: "token",
+    machineIdentifier: "machine",
+    movieLibraryId: "1",
+    showLibraryId: "2"
+  }, logger);
+
+  let order = ["a", "c", "b"];
+  let moveCalls = 0;
+
+  plex.getCollectionItems = async () => [...order];
+  (plex as unknown as { requestServer: (path: string, options?: unknown) => Promise<unknown> }).requestServer = async (path: string) => {
+    moveCalls += 1;
+    const match = path.match(/\/items\/([^/]+)\/move(?:\?after=(.+))?$/);
+    assert.ok(match);
+
+    const itemKey = decodeURIComponent(match[1]);
+    const afterKey = match[2] ? decodeURIComponent(match[2]) : null;
+    if (moveCalls > 1) {
+      order = moveItem(order, itemKey, afterKey);
+    }
+    return {};
+  };
+
+  const result = await plex.reorderCollectionItems("collection-1", ["a", "b", "c"]);
+
+  assert.equal(result.staleKeys.size, 0);
+  assert.deepEqual(order, ["a", "b", "c"]);
+  assert.equal(moveCalls, 2);
+  assert.ok(entries.some((entry) => entry.message === "Collection order still mismatched after item move"));
+});
+
+test("reorderCollectionItems moves only the first misplaced item when that converges the order", async () => {
+  const { logger } = createCapturingLogger();
+  const plex = new PlexIntegration({
+    serverUrl: "http://plex.example",
+    token: "token",
+    machineIdentifier: "machine",
+    movieLibraryId: "1",
+    showLibraryId: "2"
+  }, logger);
+
+  let order = ["a", "c", "b"];
+  const moved: Array<{ itemKey: string; afterKey: string | null }> = [];
+
+  plex.getCollectionItems = async () => [...order];
+  (plex as unknown as { requestServer: (path: string, options?: unknown) => Promise<unknown> }).requestServer = async (path: string) => {
+    const match = path.match(/\/items\/([^/]+)\/move(?:\?after=(.+))?$/);
+    assert.ok(match);
+
+    const itemKey = decodeURIComponent(match[1]);
+    const afterKey = match[2] ? decodeURIComponent(match[2]) : null;
+    moved.push({ itemKey, afterKey });
+    order = moveItem(order, itemKey, afterKey);
+    return {};
+  };
+
+  await plex.reorderCollectionItems("collection-1", ["a", "b", "c"]);
+
+  assert.deepEqual(order, ["a", "b", "c"]);
+  assert.deepEqual(moved, [{ itemKey: "b", afterKey: "a" }]);
+});

--- a/tests/server/test-helpers.ts
+++ b/tests/server/test-helpers.ts
@@ -1,0 +1,16 @@
+import type { Logger } from "../../src/server/logger.js";
+
+export type LogEntry = { level: "debug" | "info" | "warn" | "error"; message: string; meta?: unknown };
+
+export function createCapturingLogger() {
+  const entries: LogEntry[] = [];
+  const logger = {
+    debug: (message: string, meta?: unknown) => entries.push({ level: "debug", message, meta }),
+    info: (message: string, meta?: unknown) => entries.push({ level: "info", message, meta }),
+    warn: (message: string, meta?: unknown) => entries.push({ level: "warn", message, meta }),
+    error: (message: string, meta?: unknown) => entries.push({ level: "error", message, meta }),
+    getRecentLogs: () => entries
+  } as unknown as Logger;
+
+  return { logger, entries };
+}


### PR DESCRIPTION
## Summary

Fixes collection publish skips for Hubarr-owned custom sort modes by validating the live Plex collection order before trusting a matching publish hash. If Plex order has drifted, Hubarr republishes the collection, verifies the post-reorder order before storing a clean hash, and surfaces persistent reorder failures in sync history instead of silently marking the publish as successful.

Closes #159

## Changes

- `src/server/services.ts`
  - Validates exact live Plex item order before skipping hash-matched collections for date and watchlist-date sort modes.
  - Keeps `title` sort on the existing existence-only skip path because Plex owns alphabetical ordering.
  - Verifies custom-sort order after publishing and only stores `lastSyncedHash` when Plex reports the expected order.
  - Records failed `collection.publish` history items, marks the publish run as failed, and stores useful mismatch details when Plex cannot converge on the requested order.

- `src/server/integrations/plex.ts`
  - Reworks collection reorder to move the first misplaced item, re-fetch live order, and retry with progressive bounded backoff.
  - Logs mismatch samples and bounded-attempt failures so recurring reorder problems identify the collection and first divergence.

- `tests/server/collection-order-validation.test.ts`
  - Covers hash-match drift detection, title-sort skip behavior, dirty-hash handling, and failed history item creation for non-converged reorder attempts.

- `tests/server/plex-reorder.test.ts`
  - Covers the converging reorder primitive, including a Plex-like delayed/ignored first move that succeeds on retry.

## Test plan

- [x] Run `npm run check` and confirm TypeScript passes.
- [x] Run `node --import tsx --test tests/server/*.test.ts` and confirm all server tests pass.
- [x] Build the local Docker image with `docker build -t hubarr --build-arg BUILD_CHANNEL=local --build-arg COMMIT_SHA=$(git rev-parse --short HEAD) .`.
- [x] Recreate the live local container with bridge networking and `/opt/hubarr:/config`, then confirm `/api/health` returns `200`.
- [x] Confirm live collection publish logs show Nathan's movie and show collections clean-skipping after order validation.

🤖 Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection reordering with bounded retries, progressive backoff, single-item moves, and robust handling/pruning of stale or missing items.
  * Post-reorder verification now detects drift; failed or non‑converging reorders leave the sync state dirty and record structured failure details.

* **New Features**
  * Added strict order-matching and richer mismatch metadata for clearer diagnostics.
  * Publish now validates custom (non-title) sort orders and returns per-user publish validation failures.

* **Tests**
  * Added reorder and publish validation tests plus a capturing-test logger helper.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Migz93/hubarr/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->