### PR TITLE
chore: disable CodeRabbit docstring coverage warning

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -42,6 +42,8 @@ reviews:
       requirements: "PR title must start with a conventional commit type: feat:, fix:, chore:, docs:, refactor:, ci:"
     description:
       mode: "warning"
+    docstring_coverage:
+      mode: "disabled"
 
   finishing_touches:
     docstrings:


### PR DESCRIPTION
## Summary

The `finishing_touches.docstrings.enabled: false` setting in `.coderabbit.yaml` only controls whether CodeRabbit proactively *adds* docstrings to PRs. The docstring coverage warning that appeared on PR #162 comes from a separate `pre_merge_checks.docstring_coverage` check. This PR adds an explicit `mode: "disabled"` entry for that check so CodeRabbit no longer reports it.

## Changes

- `.coderabbit.yaml`: Added `docstring_coverage: mode: "disabled"` under `pre_merge_checks` to suppress the coverage warning entirely.

## Test plan

- [ ] Merge this PR into `develop`.
- [ ] Open a subsequent PR and confirm CodeRabbit no longer surfaces a docstring coverage pre-merge warning.

Closes #163

🤖 Generated with Claude Code