### PR TITLE
fix: skip unchanged isolation filters

### DIFF
--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -418,11 +418,13 @@ function groupSuccessfulSteps(run: SyncRun, items: SyncRunItem[]): HistoryStep[]
       (item) => item.status === "success" && item.action !== "collection.publish"
     );
     for (const item of genericSuccesses) {
+      const isSkipped = item.action.endsWith(".skipped");
       steps.push({
         id: `${item.id}-generic-success`,
         status: "success",
         label: formatStepLabel(item),
-        meta: formatStepMeta(item)
+        meta: formatStepMeta(item),
+        variant: isSkipped ? "skipped" : undefined
       });
     }
   } else if (run.kind === "rss") {

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -36,8 +36,10 @@ const ACTION_LABELS: Record<string, string> = {
   "watchlist.match.failed": "Match failed",
   "watchlist.date_unresolved": "Date unresolved",
   "collection.publish": "Collection publish",
+  "collection.publish.skipped": "Collection publish skipped",
   "collection.publish.followup": "Collection publish triggered",
   "isolation.filters": "Isolation filters",
+  "isolation.filters.skipped": "Isolation filters skipped",
   "sync.user": "User sync",
   "rss.feed.check.self": "Self RSS feed check",
   "rss.feed.check.friends": "Friends RSS feed check",
@@ -243,6 +245,7 @@ interface CollectionPublishDetails {
   collectionName?: string;
   collectionRatingKey?: string;
   matchedItems?: number;
+  reason?: string;
   message?: string;
 }
 
@@ -316,6 +319,17 @@ function formatStepLabel(item: SyncRunItem): string {
     return details?.message ?? "Triggered collection publish";
   }
 
+  if (item.action === "collection.publish.skipped") {
+    const details = item.details as CollectionPublishDetails | null;
+    const name = details?.displayName ?? "Unknown user";
+    const mediaType = formatMediaTypeLabel(details?.mediaType);
+    return `Skipped ${mediaType.toLowerCase()} collection publish for ${name}`;
+  }
+
+  if (item.action === "isolation.filters.skipped") {
+    return "Skipped isolation filters";
+  }
+
   return ACTION_LABELS[item.action] ?? item.action;
 }
 
@@ -328,6 +342,20 @@ function formatStepMeta(item: SyncRunItem): string | undefined {
   if (item.action === "collection.publish") {
     const details = item.details as CollectionPublishDetails | null;
     return details?.message;
+  }
+
+  if (item.action === "collection.publish.skipped") {
+    const details = item.details as CollectionPublishDetails | null;
+    return details?.reason === "state-unchanged"
+      ? "Collection state was unchanged."
+      : details?.reason;
+  }
+
+  if (item.action === "isolation.filters.skipped") {
+    const details = item.details as { reason?: string } | null;
+    return details?.reason === "inputs-unchanged"
+      ? "Isolation inputs were unchanged."
+      : details?.reason;
   }
 
   if (item.action === "rss.feed.check.self" || item.action === "rss.feed.check.friends") {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -255,6 +255,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       movieLibraryId: appSettings.defaultMovieLibraryId || "",
       showLibraryId: appSettings.defaultShowLibraryId || ""
     });
+    db.clearIsolationFilterState();
 
     services.upsertSelfUser().catch((err) => {
       logger.warn("Self user upsert failed after Plex settings save", {

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -357,6 +357,18 @@ export class HubarrDatabase {
     collectionsRepo.clearCollections(this.db);
   }
 
+  getIsolationFilterState(): settingsRepo.IsolationFilterState | null {
+    return settingsRepo.getIsolationFilterState(this.db);
+  }
+
+  saveIsolationFilterState(inputHash: string): settingsRepo.IsolationFilterState {
+    return settingsRepo.saveIsolationFilterState(this.db, inputHash);
+  }
+
+  clearIsolationFilterState(): void {
+    settingsRepo.clearIsolationFilterState(this.db);
+  }
+
   // -------------------------------------------------------------------------
   // Sync Runs
   // -------------------------------------------------------------------------

--- a/src/server/db/settings.ts
+++ b/src/server/db/settings.ts
@@ -10,7 +10,12 @@ import type {
   SessionUser
 } from "../../shared/types.js";
 
-export type SettingKey = "admin" | "plex" | "app" | "session_secret" | "seerr";
+export type IsolationFilterState = {
+  inputHash: string;
+  lastSyncedAt: string;
+};
+
+export type SettingKey = "admin" | "plex" | "app" | "session_secret" | "seerr" | "isolation_filters";
 
 export const defaultAppSettings: AppSettings = {
   reconciliationIntervalMinutes: 60,
@@ -57,6 +62,10 @@ export function setSetting(db: Database.Database, key: SettingKey, value: unknow
   `).run(key, JSON.stringify(value), updatedAt);
 }
 
+export function deleteSetting(db: Database.Database, key: SettingKey): void {
+  db.prepare("DELETE FROM settings WHERE key = ?").run(key);
+}
+
 export function seedDefaultSettings(db: Database.Database): void {
   if (!getSetting<AppSettings>(db, "app")) {
     setSetting(db, "app", defaultAppSettings);
@@ -69,6 +78,23 @@ export function resolveSessionSecret(db: Database.Database): string {
   const secret = crypto.randomBytes(48).toString("hex");
   setSetting(db, "session_secret", secret);
   return secret;
+}
+
+export function getIsolationFilterState(db: Database.Database): IsolationFilterState | null {
+  return getSetting<IsolationFilterState>(db, "isolation_filters");
+}
+
+export function saveIsolationFilterState(db: Database.Database, inputHash: string): IsolationFilterState {
+  const state: IsolationFilterState = {
+    inputHash,
+    lastSyncedAt: new Date().toISOString()
+  };
+  setSetting(db, "isolation_filters", state);
+  return state;
+}
+
+export function clearIsolationFilterState(db: Database.Database): void {
+  deleteSetting(db, "isolation_filters");
 }
 
 // -------------------------------------------------------------------------

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1807,7 +1807,10 @@ export class HubarrServices {
       })
     ));
 
-    await this.applyIsolationFilters(friends, runId, force, plex);
+    const isolationFailure = await this.applyIsolationFilters(friends, runId, force, plex);
+    if (isolationFailure) {
+      failures.push(`Isolation filters: ${isolationFailure}`);
+    }
 
     if (failures.length > 0) {
       const failedUsers = failedUserIds.size;
@@ -2802,15 +2805,15 @@ export class HubarrServices {
 
   /**
    * Apply per-user Plex content filter exclusions so each managed Plex user
-   * only sees their own watchlist hub row. Non-throwing — a failure here is
-   * logged as a warning so it doesn't abort a sync run.
+   * only sees their own watchlist hub row. Non-throwing so collection publishing
+   * can finish, but returns a failure message so the run can be marked errored.
    */
   async applyIsolationFilters(
     enabledUsers: UserRecord[],
     runId: number,
     force = false,
     plex = this.getPlexIntegration()
-  ): Promise<void> {
+  ): Promise<string | null> {
     const appSettings = this.db.getAppSettings();
     const inputHash = computeIsolationFilterInputHash(
       enabledUsers,
@@ -2833,7 +2836,7 @@ export class HubarrServices {
         inputHash,
         lastSyncedAt: previousState.lastSyncedAt
       });
-      return;
+      return null;
     }
 
     try {
@@ -2848,6 +2851,7 @@ export class HubarrServices {
         inputHash,
         lastSyncedAt: state.lastSyncedAt
       });
+      return null;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn("Isolation filter sync failed — collections are still published, but visibility isolation may be incomplete", { message });
@@ -2855,6 +2859,7 @@ export class HubarrServices {
       // because the previous successful hash still matches the current inputs.
       this.db.clearIsolationFilterState();
       this.db.addSyncRunItem(runId, "isolation.filters", "error", { message, inputHash });
+      return message;
     }
   }
 

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -48,6 +48,26 @@ function computePublishStateHash(params: {
   return crypto.createHash("sha256").update(payload).digest("hex");
 }
 
+function computeIsolationFilterInputHash(
+  enabledUsers: UserRecord[],
+  getEffectiveVisibility: (user: UserRecord) => VisibilityConfig
+): string {
+  // version: bump this when the payload schema changes to force a one-time global re-run.
+  const users = enabledUsers
+    .map((user) => ({
+      id: user.id,
+      plexUserId: user.plexUserId,
+      username: user.username,
+      visibility: getEffectiveVisibility(user)
+    }))
+    .sort((a, b) => a.id - b.id);
+  const payload = JSON.stringify({
+    version: 2,
+    users
+  });
+  return crypto.createHash("sha256").update(payload).digest("hex");
+}
+
 function isCustomCollectionSort(sortOrder: CollectionSortOrder): boolean {
   return sortOrder !== "title";
 }
@@ -1236,6 +1256,8 @@ export class HubarrServices {
           }
 
           if (exists === true) {
+            let skipPublish = false;
+
             if (isCustomCollectionSort(effectiveSortOrder)) {
               let liveKeys: string[] | null;
               try {
@@ -1258,10 +1280,8 @@ export class HubarrServices {
                   collectionRatingKey: stored.collectionRatingKey,
                   effectiveSortOrder
                 });
-                continue;
-              }
-
-              if (liveKeys) {
+                skipPublish = true;
+              } else if (liveKeys) {
                 this.logger.info("Collection item order differs from desired state, republishing", {
                   userId: friend.id,
                   mediaType,
@@ -1270,14 +1290,28 @@ export class HubarrServices {
                   ...buildOrderMismatchMeta(liveKeys, matchedRatingKeys)
                 });
               }
-              // Hash matches but Plex order drifted, so keep the stored
-              // collection identity and fall through to the reorder path.
+              // Hash matches but Plex order drifted — fall through to the reorder path.
             } else {
               this.logger.debug("Collection state unchanged and collection validated, skipping publish", {
                 userId: friend.id,
                 mediaType,
                 collectionRatingKey: stored.collectionRatingKey
               });
+              skipPublish = true;
+            }
+
+            if (skipPublish) {
+              if (runId !== null) {
+                this.db.addSyncRunItem(runId, "collection.publish.skipped", "success", {
+                  userId: friend.id,
+                  displayName: friend.displayName,
+                  mediaType,
+                  collectionName,
+                  collectionRatingKey: stored.collectionRatingKey,
+                  matchedItems: matchedRatingKeys.length,
+                  reason: "state-unchanged"
+                }, friend.id);
+              }
               continue;
             }
           } else if (exists === false) {
@@ -1773,7 +1807,7 @@ export class HubarrServices {
       })
     ));
 
-    await this.applyIsolationFilters(friends, runId);
+    await this.applyIsolationFilters(friends, runId, force, plex);
 
     if (failures.length > 0) {
       const failedUsers = failedUserIds.size;
@@ -2771,16 +2805,56 @@ export class HubarrServices {
    * only sees their own watchlist hub row. Non-throwing — a failure here is
    * logged as a warning so it doesn't abort a sync run.
    */
-  async applyIsolationFilters(enabledUsers: UserRecord[], runId: number): Promise<void> {
+  async applyIsolationFilters(
+    enabledUsers: UserRecord[],
+    runId: number,
+    force = false,
+    plex = this.getPlexIntegration()
+  ): Promise<void> {
+    const appSettings = this.db.getAppSettings();
+    const inputHash = computeIsolationFilterInputHash(
+      enabledUsers,
+      (user) => user.visibilityOverride ?? appSettings.visibilityDefaults
+    );
+    const previousState = this.db.getIsolationFilterState();
+
+    // Skip is based on local input hash only — out-of-band Plex filter changes are not
+    // detected here and will not be repaired until force=true (manual refresh / user sync).
+    if (!force && previousState?.inputHash === inputHash) {
+      this.logger.info("Isolation filters skipped because isolation inputs are unchanged", {
+        userCount: enabledUsers.length,
+        inputHash,
+        lastSyncedAt: previousState.lastSyncedAt
+      });
+      this.db.addSyncRunItem(runId, "isolation.filters.skipped", "success", {
+        reason: "inputs-unchanged",
+        forced: false,
+        userCount: enabledUsers.length,
+        inputHash,
+        lastSyncedAt: previousState.lastSyncedAt
+      });
+      return;
+    }
+
     try {
-      const plex = this.getPlexIntegration();
       const { updated, skipped } = await plex.syncIsolationFilters(enabledUsers);
-      this.logger.info("Isolation filters applied", { updated, skipped });
-      this.db.addSyncRunItem(runId, "isolation.filters", "success", { updated, skipped });
+      const state = this.db.saveIsolationFilterState(inputHash);
+      this.logger.info("Isolation filters applied", { updated, skipped, force, inputHash });
+      this.db.addSyncRunItem(runId, "isolation.filters", "success", {
+        updated,
+        skipped,
+        forced: force,
+        userCount: enabledUsers.length,
+        inputHash,
+        lastSyncedAt: state.lastSyncedAt
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn("Isolation filter sync failed — collections are still published, but visibility isolation may be incomplete", { message });
-      this.db.addSyncRunItem(runId, "isolation.filters", "error", { message });
+      // Clear stored state so the next scheduled run retries rather than skipping
+      // because the previous successful hash still matches the current inputs.
+      this.db.clearIsolationFilterState();
+      this.db.addSyncRunItem(runId, "isolation.filters", "error", { message, inputHash });
     }
   }
 
@@ -3324,6 +3398,7 @@ export class HubarrServices {
 
     const isolation = await plex.clearHubarrIsolationFilters();
     this.db.clearCollections();
+    this.db.clearIsolationFilterState();
 
     this.logger.info("Hubarr collections reset", {
       deleted,

--- a/tests/server/collection-order-validation.test.ts
+++ b/tests/server/collection-order-validation.test.ts
@@ -160,12 +160,26 @@ test("title collection sort still skips on hash match after existence validation
       createMovie("movie-old", "Old Movie", "2024-01-01", "rk-old")
     ];
     const plex = createPlexMock({ collectionOrder: ["rk-old", "rk-new"] });
+    const runId = db.createSyncRun("publish", "Collection sync started.");
 
     await service.publishUserCollections(user, items, null, false, plex);
-    await service.publishUserCollections(user, items, null, false, plex);
+    await service.publishUserCollections(user, items, runId, false, plex);
 
     assert.equal(plex.calls.collectionExists, 1);
     assert.equal(plex.calls.ensureCollection, 1);
+    const run = db.getSyncRunWithItems(runId);
+    assert.ok(run);
+    const skippedItem = run.items.find((item) => item.action === "collection.publish.skipped");
+    assert.ok(skippedItem);
+    assert.deepEqual(skippedItem.details, {
+      userId: user.id,
+      displayName: "alex",
+      mediaType: "movie",
+      collectionName: "alexs Watchlist",
+      collectionRatingKey: "collection-1",
+      matchedItems: 2,
+      reason: "state-unchanged"
+    });
   } finally {
     cleanup();
   }

--- a/tests/server/isolation-filter-skip.test.ts
+++ b/tests/server/isolation-filter-skip.test.ts
@@ -34,7 +34,7 @@ function createService() {
   const { logger } = createCapturingLogger();
   const { db, cleanup } = createTestDatabase();
   const service = new HubarrServices(db, logger, {} as ImageCacheService) as unknown as {
-    applyIsolationFilters: (enabledUsers: UserRecord[], runId: number, force?: boolean, plex?: unknown) => Promise<void>;
+    applyIsolationFilters: (enabledUsers: UserRecord[], runId: number, force?: boolean, plex?: unknown) => Promise<string | null>;
   };
 
   return { db, service, cleanup };
@@ -144,12 +144,49 @@ test("isolation filters rerun after a failed sync clears stored state", async ()
     };
     const runId = db.createSyncRun("publish", "Collection sync started.");
 
-    await service.applyIsolationFilters([user], runId, false, plex);
+    const failure = await service.applyIsolationFilters([user], runId, false, plex);
+    assert.equal(failure, "Plex API error");
     assert.equal(calls.syncIsolationFilters, 1);
 
     // State should be cleared on error so the next run retries
     await service.applyIsolationFilters([user], runId, false, plex);
     assert.equal(calls.syncIsolationFilters, 2);
+  } finally {
+    cleanup();
+  }
+});
+
+test("collection sync run is marked error when isolation filters fail", async () => {
+  const { logger } = createCapturingLogger();
+  const { db, cleanup } = createTestDatabase();
+  const service = new HubarrServices(db, logger, {} as ImageCacheService) as unknown as {
+    runPublishPass: (force?: boolean) => Promise<{ id: number; status: string; error: string | null }>;
+    publishUserCollections: () => Promise<string[]>;
+    getPlexIntegration: () => unknown;
+  };
+
+  try {
+    const user = createUser(db);
+    db.updateAppSettings({
+      defaultMovieLibraryId: "movies",
+      defaultShowLibraryId: "shows"
+    });
+    service.publishUserCollections = async () => [];
+    service.getPlexIntegration = () => ({
+      createCollectionLabel(username: string) { return `hubarr:${username}`; },
+      async syncIsolationFilters() {
+        throw new Error("Plex API error");
+      }
+    });
+
+    const run = await service.runPublishPass(false);
+
+    assert.equal(run.status, "error");
+    assert.equal(run.error, "Isolation filters: Plex API error");
+    const detail = db.getSyncRunWithItems(run.id);
+    assert.ok(detail);
+    assert.ok(detail.items.some((item) => item.action === "isolation.filters" && item.status === "error"));
+    assert.equal(db.getUser(user.id)?.lastSyncError, null);
   } finally {
     cleanup();
   }

--- a/tests/server/isolation-filter-skip.test.ts
+++ b/tests/server/isolation-filter-skip.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { UserRecord } from "../../src/shared/types.js";
+import { HubarrServices } from "../../src/server/services.js";
+import type { ImageCacheService } from "../../src/server/image-cache.js";
+import { createTestDatabase } from "./test-db.js";
+import { createCapturingLogger } from "./test-helpers.js";
+
+function createUser(db: ReturnType<typeof createTestDatabase>["db"]): UserRecord {
+  db.upsertUsers([{ plexUserId: "plex-1", username: "alex", displayName: "Alex", avatarUrl: null }]);
+  const user = db.listUsers()[0];
+  assert.ok(user);
+  return db.updateUser(user.id, { enabled: true });
+}
+
+function createPlexMock() {
+  const calls = {
+    syncIsolationFilters: 0
+  };
+
+  return {
+    calls,
+    createCollectionLabel(username: string) {
+      return `hubarr:${username}`;
+    },
+    async syncIsolationFilters() {
+      calls.syncIsolationFilters += 1;
+      return { updated: 1, skipped: 0 };
+    }
+  };
+}
+
+function createService() {
+  const { logger } = createCapturingLogger();
+  const { db, cleanup } = createTestDatabase();
+  const service = new HubarrServices(db, logger, {} as ImageCacheService) as unknown as {
+    applyIsolationFilters: (enabledUsers: UserRecord[], runId: number, force?: boolean, plex?: unknown) => Promise<void>;
+  };
+
+  return { db, service, cleanup };
+}
+
+test("scheduled isolation filters skip when isolation inputs are unchanged", async () => {
+  const { db, service, cleanup } = createService();
+
+  try {
+    const user = createUser(db);
+    const plex = createPlexMock();
+    const runId = db.createSyncRun("publish", "Collection sync started.");
+
+    await service.applyIsolationFilters([user], runId, false, plex);
+    await service.applyIsolationFilters([user], runId, false, plex);
+
+    assert.equal(plex.calls.syncIsolationFilters, 1);
+
+    const run = db.getSyncRunWithItems(runId);
+    assert.ok(run);
+    const applied = run.items.find((item) => item.action === "isolation.filters");
+    const skipped = run.items.find((item) => item.action === "isolation.filters.skipped");
+    assert.ok(applied);
+    assert.ok(skipped);
+    assert.equal((skipped.details as { reason: string }).reason, "inputs-unchanged");
+  } finally {
+    cleanup();
+  }
+});
+
+test("forced isolation filters run even when isolation inputs are unchanged", async () => {
+  const { db, service, cleanup } = createService();
+
+  try {
+    const user = createUser(db);
+    const plex = createPlexMock();
+    const runId = db.createSyncRun("publish", "Collection sync started.");
+
+    await service.applyIsolationFilters([user], runId, false, plex);
+    await service.applyIsolationFilters([user], runId, true, plex);
+
+    assert.equal(plex.calls.syncIsolationFilters, 2);
+
+    const run = db.getSyncRunWithItems(runId);
+    assert.ok(run);
+    const appliedItems = run.items.filter((item) => item.action === "isolation.filters");
+    assert.equal(appliedItems.length, 2);
+    assert.equal((appliedItems[1]?.details as { forced: boolean }).forced, true);
+  } finally {
+    cleanup();
+  }
+});
+
+test("scheduled isolation filters rerun when label inputs change", async () => {
+  const { db, service, cleanup } = createService();
+
+  try {
+    const user = createUser(db);
+    const renamedUser = { ...user, username: "alex-renamed" };
+    const plex = createPlexMock();
+    const runId = db.createSyncRun("publish", "Collection sync started.");
+
+    await service.applyIsolationFilters([user], runId, false, plex);
+    await service.applyIsolationFilters([renamedUser], runId, false, plex);
+
+    assert.equal(plex.calls.syncIsolationFilters, 2);
+  } finally {
+    cleanup();
+  }
+});
+
+test("isolation filters rerun after reset clears stored state", async () => {
+  const { db, service, cleanup } = createService();
+
+  try {
+    const user = createUser(db);
+    const plex = createPlexMock();
+    const runId = db.createSyncRun("publish", "Collection sync started.");
+
+    await service.applyIsolationFilters([user], runId, false, plex);
+    db.clearIsolationFilterState();
+    await service.applyIsolationFilters([user], runId, false, plex);
+
+    assert.equal(plex.calls.syncIsolationFilters, 2);
+  } finally {
+    cleanup();
+  }
+});
+
+test("isolation filters rerun after a failed sync clears stored state", async () => {
+  const { db, service, cleanup } = createService();
+
+  try {
+    const user = createUser(db);
+    const failOnce = { shouldFail: true };
+    const calls = { syncIsolationFilters: 0 };
+    const plex = {
+      createCollectionLabel(username: string) { return `hubarr:${username}`; },
+      async syncIsolationFilters() {
+        calls.syncIsolationFilters += 1;
+        if (failOnce.shouldFail) {
+          failOnce.shouldFail = false;
+          throw new Error("Plex API error");
+        }
+        return { updated: 1, skipped: 0 };
+      }
+    };
+    const runId = db.createSyncRun("publish", "Collection sync started.");
+
+    await service.applyIsolationFilters([user], runId, false, plex);
+    assert.equal(calls.syncIsolationFilters, 1);
+
+    // State should be cleared on error so the next run retries
+    await service.applyIsolationFilters([user], runId, false, plex);
+    assert.equal(calls.syncIsolationFilters, 2);
+  } finally {
+    cleanup();
+  }
+});
+
+test("scheduled isolation filters rerun when effective visibility inputs change", async () => {
+  const { db, service, cleanup } = createService();
+
+  try {
+    const user = createUser(db);
+    const sharedHomeUser = {
+      ...user,
+      visibilityOverride: {
+        recommended: false,
+        home: true,
+        shared: true
+      }
+    };
+    const plex = createPlexMock();
+    const runId = db.createSyncRun("publish", "Collection sync started.");
+
+    await service.applyIsolationFilters([user], runId, false, plex);
+    await service.applyIsolationFilters([sharedHomeUser], runId, false, plex);
+
+    assert.equal(plex.calls.syncIsolationFilters, 2);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Adds skip-aware change detection for Plex isolation filters during collection sync. Scheduled collection syncs now avoid recomputing and applying isolation filters when the isolation-relevant inputs have not changed, while forced/manual paths still run the repair path. The History detail view also gets explicit skipped work entries so future activity filtering can classify no-change runs without parsing summary text.

Closes #155

## Changes

- `src/server/services.ts`: computes and stores an isolation input hash from enabled publishing users and their effective visibility settings, skips scheduled isolation work when the hash is unchanged, preserves forced/manual behavior, records structured isolation apply/skip metadata, and clears stored isolation state after failures or collection resets.
- `src/server/db/settings.ts` and `src/server/db/index.ts`: add persistence helpers for the isolation filter state stored in settings.
- `src/server/app.ts`: clears stored isolation state after Plex settings are saved so changed Plex context cannot reuse stale isolation state.
- `src/client/pages/History.tsx`: adds labels and metadata text for skipped collection publishes and skipped isolation filter runs.
- `tests/server/collection-order-validation.test.ts`: verifies collection publish skip history details are recorded when existing collection state is unchanged.
- `tests/server/isolation-filter-skip.test.ts`: covers unchanged-input skips, forced reruns, label/visibility input changes, reset behavior, and failure retry behavior.

## Test plan

- [x] Run `npm run lint` and confirm ESLint passes.
- [x] Run `npm run check` and confirm TypeScript checks pass for client and server projects.
- [x] Run `npx tsx --test tests/server/isolation-filter-skip.test.ts tests/server/collection-order-validation.test.ts` and confirm all focused server tests pass.
- [x] Rebuild and restart the local `hubarr` Docker container, then confirm `/api/health` returns `200` from inside the container.
- [x] Trigger/observe collection sync logs and confirm isolation applies once for changed inputs, then skips when inputs are unchanged.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now shows skipped sync steps with clear, user-facing labels and reasons.
  * Isolation filter runs can be forced to reapply even when inputs match cached state.

* **Refactor**
  * Sync logic skips redundant publishing and isolation work when state is unchanged, improving efficiency.

* **Chores**
  * Persisted isolation-filter state is cleared at appropriate lifecycle points to ensure correct retry behavior.

* **Tests**
  * Added tests covering isolation-filter skip/force/ retry scenarios and skipped-publish recording.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Migz93/hubarr/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->