### PR TITLE
feat: add History activity filtering

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -146,6 +146,24 @@ Tests that cached images are served correctly from `/images/`, that the route is
 
 ---
 
+### `tests/playwright/history.spec.ts` — History filters
+
+Read-only. Safe to run against a live instance.
+
+| Test | What it checks |
+|---|---|
+| Type filter buttons are all visible | Verifies the history type filter includes All, GraphQL, RSS, Manual, and Collection |
+| Status filter buttons are all visible | Verifies the status filter includes All, Success, Error, and Running |
+| Activity filter buttons are all visible | Verifies the activity filter includes All, Changes, and No Changes |
+| Activity filter starts with All | Verifies the activity filter order is All, Changes, then No Changes |
+| Page size select is visible | Verifies the history page-size selector is rendered |
+| RSS type filter updates URL | Clicks the RSS type filter and verifies `?type=rss` appears in the URL |
+| Success status filter updates URL | Clicks the Success status filter and verifies `?status=success` appears in the URL |
+| No Changes activity filter updates URL | Clicks the No Changes activity filter and verifies `?activity=no_changes` appears in the URL |
+| All activity filter updates URL | Clicks the All activity filter and verifies `?activity=all` appears in the URL |
+
+---
+
 ### `tests/playwright/live-refresh.spec.ts` — Live refresh behavior
 
 These tests trigger real background work and verify that the open page updates

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -229,12 +229,28 @@ History stores higher-level sync runs such as:
 - `full`
 - `user`
 - `publish`
+- `seerr`
+- `watchlist-cleanup`
 
 It also stores per-run detail rows for actions such as watchlist fetches, match
 failures, unresolved `addedAt` dates, collection updates, and RSS feed checks.
 The History page groups those raw rows into more readable operational steps so
 the UI reflects what a job actually did rather than dumping every low-level
 event verbatim.
+
+Each sync run also records an activity outcome:
+
+- `changes` means the run made a meaningful Hubarr, Plex, Seerr, or watchlist
+  state change.
+- `no_changes` means the run completed successfully after checking work but did
+  not need to update state.
+- `unknown` is reserved for historical rows and unsuccessful runs where activity
+  is not meaningful.
+
+The History page defaults to the `All` activity filter. Users can switch to
+`Changes` to hide routine successful no-op polling, while running and failed runs
+remain included in the `Changes` view so active or broken work stays
+discoverable.
 
 ### Jobs
 

--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -8,6 +8,7 @@ import type { HistoryPageResponse, SearchCandidate, SyncRun, SyncRunDetail, Sync
 
 type KindFilter = "all" | "full" | "rss" | "user" | "publish" | "seerr" | "watchlist-cleanup";
 type StatusFilter = "all" | "success" | "error" | "running";
+type ActivityFilter = "changes" | "no_changes" | "all";
 
 const KIND_LABELS: Record<string, string> = {
   full: "GraphQL",
@@ -56,6 +57,7 @@ const ACTION_LABELS: Record<string, string> = {
 
 const VALID_KINDS: KindFilter[] = ["all", "full", "rss", "user", "publish", "seerr", "watchlist-cleanup"];
 const VALID_STATUSES: StatusFilter[] = ["all", "success", "error", "running"];
+const VALID_ACTIVITIES: ActivityFilter[] = ["all", "changes", "no_changes"];
 const VALID_PAGE_SIZES = [10, 25, 50, 100];
 const HISTORY_FAST_REFRESH_MS = 2_500;
 const HISTORY_IDLE_REFRESH_MS = 15_000;
@@ -65,6 +67,7 @@ export default function History() {
 
   const kind = (VALID_KINDS.includes(searchParams.get("type") as KindFilter) ? searchParams.get("type") : "all") as KindFilter;
   const status = (VALID_STATUSES.includes(searchParams.get("status") as StatusFilter) ? searchParams.get("status") : "all") as StatusFilter;
+  const activity = (VALID_ACTIVITIES.includes(searchParams.get("activity") as ActivityFilter) ? searchParams.get("activity") : "all") as ActivityFilter;
   const page = Math.max(1, Number(searchParams.get("page") ?? 1));
   const pageSize = VALID_PAGE_SIZES.includes(Number(searchParams.get("pageSize"))) ? Number(searchParams.get("pageSize")) : 10;
 
@@ -84,7 +87,7 @@ export default function History() {
   const load = useCallback(async (background = false) => {
     setLoading((current) => current || !background);
     try {
-      const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize), kind, status });
+      const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize), kind, status, activity });
       const result = await apiGet<HistoryPageResponse>(`/api/history?${params.toString()}`);
       setData(result);
       setError(null);
@@ -93,7 +96,7 @@ export default function History() {
     } finally {
       setLoading(false);
     }
-  }, [page, pageSize, kind, status]);
+  }, [page, pageSize, kind, status, activity]);
 
   const runs = data?.results ?? [];
   const pageInfo = data?.pageInfo;
@@ -123,7 +126,7 @@ export default function History() {
       {/* Filters */}
       <div className="flex flex-wrap gap-2 mb-4 items-center">
         {/* Kind filter */}
-        <div className="flex rounded-lg overflow-hidden border border-outline-variant/30">
+        <div role="group" aria-label="Type filter" className="flex rounded-lg overflow-hidden border border-outline-variant/30">
           {VALID_KINDS.map((k) => (
             <button
               key={k}
@@ -134,13 +137,13 @@ export default function History() {
                   : "bg-background-container text-on-surface-variant hover:text-on-surface"
               }`}
             >
-              {k === "all" ? "All types" : KIND_LABELS[k] ?? k}
+              {k === "all" ? "All" : KIND_LABELS[k] ?? k}
             </button>
           ))}
         </div>
 
         {/* Status filter */}
-        <div className="flex rounded-lg overflow-hidden border border-outline-variant/30">
+        <div role="group" aria-label="Status filter" className="flex rounded-lg overflow-hidden border border-outline-variant/30">
           {(["all", "success", "error", "running"] as StatusFilter[]).map((s) => (
             <button
               key={s}
@@ -151,7 +154,24 @@ export default function History() {
                   : "bg-background-container text-on-surface-variant hover:text-on-surface"
               }`}
             >
-              {s === "all" ? "All status" : titleCaseStatus(s)}
+              {s === "all" ? "All" : titleCaseStatus(s)}
+            </button>
+          ))}
+        </div>
+
+        {/* Activity filter */}
+        <div role="group" aria-label="Activity filter" className="flex rounded-lg overflow-hidden border border-outline-variant/30">
+          {VALID_ACTIVITIES.map((a) => (
+            <button
+              key={a}
+              onClick={() => setParam("activity", a, true)}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                activity === a
+                  ? "bg-primary-dim text-on-surface"
+                  : "bg-background-container text-on-surface-variant hover:text-on-surface"
+              }`}
+            >
+              {activityLabel(a)}
             </button>
           ))}
         </div>
@@ -273,6 +293,13 @@ interface SyncUserErrorDetails {
 
 function titleCaseStatus(status: SyncRun["status"]): string {
   return capitalizeSentence(status);
+}
+
+function activityLabel(activity: ActivityFilter | SyncRun["activity"]): string {
+  if (activity === "changes") return "Changes";
+  if (activity === "no_changes") return "No Changes";
+  if (activity === "unknown") return "Unknown";
+  return "All";
 }
 
 function formatRunDuration(run: SyncRun, now = Date.now()): string | null {
@@ -682,6 +709,8 @@ function RunRow({ run }: { run: SyncRun }) {
 
   const config = statusConfig[liveRun.status];
   const durationText = formatRunDuration(liveRun, now);
+  const showActivityBadge = liveRun.status === "success" &&
+    (liveRun.activity === "changes" || liveRun.activity === "no_changes");
 
   return (
     <div className="bg-background-container rounded-xl border border-outline-variant/20 overflow-hidden">
@@ -698,6 +727,11 @@ function RunRow({ run }: { run: SyncRun }) {
             <span className={`text-xs px-1.5 py-0.5 rounded-full border font-medium ${config.badge}`}>
               {titleCaseStatus(liveRun.status)}
             </span>
+            {showActivityBadge && (
+              <span className="text-xs px-1.5 py-0.5 rounded-full border border-outline-variant/20 bg-background-container-high text-on-surface-variant font-medium">
+                {activityLabel(liveRun.activity)}
+              </span>
+            )}
           </div>
           <div className="text-on-surface-variant text-xs mt-0.5 truncate">
             {capitalizeSentence(stripKindPrefix(liveRun.summary))}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -798,8 +798,11 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
     const pageSize = Math.min(100, Math.max(1, Number(req.query["pageSize"] ?? 10)));
     const kind = (req.query["kind"] as string) || "all";
     const status = (req.query["status"] as string) || "all";
+    const VALID_ACTIVITIES = ["all", "changes", "no_changes", "unknown"];
+    const rawActivity = (req.query["activity"] as string) || "all";
+    const activity = VALID_ACTIVITIES.includes(rawActivity) ? rawActivity : "all";
 
-    const { results, total } = db.listSyncRunsPaginated({ page, pageSize, kind, status });
+    const { results, total } = db.listSyncRunsPaginated({ page, pageSize, kind, status, activity });
     const pages = Math.max(1, Math.ceil(total / pageSize));
     res.json({ results, pageInfo: { page, pageSize, pages, total } });
   });

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -12,6 +12,7 @@ import type {
   PlexSettingsView,
   SessionUser,
   SyncRun,
+  SyncRunActivity,
   SeerrRequestState,
   SeerrUserLink,
   UserRecord,
@@ -385,8 +386,8 @@ export class HubarrDatabase {
     return syncRepo.createSyncRun(this.db, kind, summary);
   }
 
-  completeSyncRun(id: number, status: SyncRun["status"], summary: string, error: string | null): void {
-    syncRepo.completeSyncRun(this.db, id, status, summary, error);
+  completeSyncRun(id: number, status: SyncRun["status"], summary: string, error: string | null, activity?: SyncRunActivity): void {
+    syncRepo.completeSyncRun(this.db, id, status, summary, error, activity);
   }
 
   updateSyncRunSummary(id: number, summary: string): void {
@@ -406,6 +407,7 @@ export class HubarrDatabase {
     pageSize: number;
     kind?: string;
     status?: string;
+    activity?: string;
   }): { results: SyncRun[]; total: number } {
     return syncRepo.listSyncRunsPaginated(this.db, options);
   }

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -212,6 +212,16 @@ const migrations: Migration[] = [
           ON seerr_request_state(plex_item_id);
       `);
     }
+  },
+  {
+    version: 2,
+    up(db) {
+      db.exec(`
+        ALTER TABLE sync_runs
+          ADD COLUMN activity TEXT NOT NULL DEFAULT 'unknown'
+            CHECK(activity IN ('changes', 'no_changes', 'unknown'));
+      `);
+    }
   }
 ];
 

--- a/src/server/db/sync.ts
+++ b/src/server/db/sync.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import type { DashboardResponse, RecentlyAddedItem, SyncRun } from "../../shared/types.js";
+import type { DashboardResponse, RecentlyAddedItem, SyncRun, SyncRunActivity } from "../../shared/types.js";
 import type { Logger } from "../logger.js";
 import { buildGuidMergePlan, mergeRawPayloadGuids } from "./guid-dedupe.js";
 import { listSeerrRequestedPlexItemIds } from "./seerr.js";
@@ -82,10 +82,15 @@ export function completeSyncRun(
   id: number,
   status: SyncRun["status"],
   summary: string,
-  error: string | null
+  error: string | null,
+  activity: SyncRunActivity = "unknown"
 ): void {
-  db.prepare("UPDATE sync_runs SET status = ?, completed_at = ?, summary = ?, error = ? WHERE id = ?")
-    .run(status, new Date().toISOString(), summary, error, id);
+  // Non-success runs always store "unknown": a partial-failure run may have done real
+  // work, but classifying its activity reliably is ambiguous, so we leave it to the
+  // "changes" filter's broad OR fallback (status IN ('running', 'error')) instead.
+  const runActivity = status === "success" ? activity : "unknown";
+  db.prepare("UPDATE sync_runs SET status = ?, completed_at = ?, summary = ?, error = ?, activity = ? WHERE id = ?")
+    .run(status, new Date().toISOString(), summary, error, runActivity, id);
 }
 
 export function updateSyncRunSummary(db: Database.Database, id: number, summary: string): void {
@@ -109,7 +114,7 @@ export function addSyncRunItem(
 export function listSyncRuns(db: Database.Database, limit = 10): SyncRun[] {
   return db
     .prepare(
-      "SELECT id, kind, status, started_at AS startedAt, completed_at AS completedAt, summary, error FROM sync_runs ORDER BY started_at DESC LIMIT ?"
+      "SELECT id, kind, status, activity, started_at AS startedAt, completed_at AS completedAt, summary, error FROM sync_runs ORDER BY started_at DESC LIMIT ?"
     )
     .all(limit) as SyncRun[];
 }
@@ -121,9 +126,10 @@ export function listSyncRunsPaginated(
     pageSize: number;
     kind?: string;
     status?: string;
+    activity?: string;
   }
 ): { results: SyncRun[]; total: number } {
-  const { page, pageSize, kind, status } = options;
+  const { page, pageSize, kind, status, activity } = options;
   const conditions: string[] = [];
   const params: unknown[] = [];
 
@@ -135,13 +141,20 @@ export function listSyncRunsPaginated(
     conditions.push("status = ?");
     params.push(status);
   }
+  if (activity === "changes") {
+    conditions.push("(activity = 'changes' OR status IN ('running', 'error'))");
+  } else if (activity === "no_changes") {
+    conditions.push("(status = 'success' AND activity = 'no_changes')");
+  } else if (activity === "unknown") {
+    conditions.push("activity = 'unknown'");
+  }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
   const offset = (page - 1) * pageSize;
 
   const total = (db.prepare(`SELECT COUNT(*) AS count FROM sync_runs ${where}`).get(...params) as { count: number }).count;
   const results = db
-    .prepare(`SELECT id, kind, status, started_at AS startedAt, completed_at AS completedAt, summary, error FROM sync_runs ${where} ORDER BY started_at DESC LIMIT ? OFFSET ?`)
+    .prepare(`SELECT id, kind, status, activity, started_at AS startedAt, completed_at AS completedAt, summary, error FROM sync_runs ${where} ORDER BY started_at DESC LIMIT ? OFFSET ?`)
     .all(...params, pageSize, offset) as SyncRun[];
 
   return { results, total };
@@ -152,7 +165,7 @@ export function getSyncRunWithItems(
   runId: number
 ): (SyncRun & { items: Array<{ id: number; runId: number; userId: number | null; action: string; status: string; details: unknown; createdAt: string }> }) | null {
   const run = db
-    .prepare("SELECT id, kind, status, started_at AS startedAt, completed_at AS completedAt, summary, error FROM sync_runs WHERE id = ?")
+    .prepare("SELECT id, kind, status, activity, started_at AS startedAt, completed_at AS completedAt, summary, error FROM sync_runs WHERE id = ?")
     .get(runId) as SyncRun | undefined;
 
   if (!run) return null;

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -4,6 +4,7 @@ import type {
   CollectionSortOrder,
   PreloadPhase,
   PreloadProgressEvent,
+  SeerrRequestState,
   SeerrUser,
   UserRecord,
   PlexSettingsInput,
@@ -465,7 +466,8 @@ export class HubarrServices {
           runId,
           runStatus,
           `Onboarding preload: ${succeeded}/${total} users synced.`,
-          failures.length > 0 ? failures.join(" | ") : null
+          failures.length > 0 ? failures.join(" | ") : null,
+          runStatus === "success" ? this.classifySyncRunActivity(runId) : undefined
         );
         emit("graphql-sync", "done", `Synced watchlists for ${succeeded} of ${total} user${total !== 1 ? "s" : ""}`, { progress: total, total });
         this.logger.info("Onboarding preload: watchlist sync complete", { succeeded, failed: total - succeeded });
@@ -1057,6 +1059,8 @@ export class HubarrServices {
       return item;
     });
 
+    const watchlistChanges = this.diffWatchlistItems(existingItems, mergedWithDates);
+
     this.db.replaceWatchlistItems(friend.id, mergedWithDates);
 
     const plexSettings = this.db.getPlexSettings();
@@ -1102,7 +1106,11 @@ export class HubarrServices {
         isSelf: friend.isSelf,
         itemCount: mergedWithDates.length,
         matched: matchedCount,
-        unmatched: unmatchedItems.length
+        unmatched: unmatchedItems.length,
+        changed: watchlistChanges.changed,
+        added: watchlistChanges.added,
+        removed: watchlistChanges.removed,
+        updated: watchlistChanges.updated
       },
       friend.id
     );
@@ -1158,6 +1166,90 @@ export class HubarrServices {
     });
 
     return mergedWithDates;
+  }
+
+  private diffWatchlistItems(
+    before: WatchlistItem[],
+    after: WatchlistItem[]
+  ): { changed: boolean; added: number; removed: number; updated: number } {
+    const beforeById = new Map(before.map((item) => [item.plexItemId, item]));
+    const afterById = new Map(after.map((item) => [item.plexItemId, item]));
+    let added = 0;
+    let removed = 0;
+    let updated = 0;
+
+    for (const [plexItemId, item] of afterById) {
+      const existing = beforeById.get(plexItemId);
+      if (!existing) {
+        added++;
+        continue;
+      }
+      if (this.watchlistItemChanged(existing, item)) {
+        updated++;
+      }
+    }
+
+    for (const plexItemId of beforeById.keys()) {
+      if (!afterById.has(plexItemId)) {
+        removed++;
+      }
+    }
+
+    return {
+      changed: added > 0 || removed > 0 || updated > 0,
+      added,
+      removed,
+      updated
+    };
+  }
+
+  private watchlistItemChanged(before: WatchlistItem, after: WatchlistItem): boolean {
+    const beforeGuids = [...(before.guids ?? [])].sort();
+    const afterGuids = [...(after.guids ?? [])].sort();
+    return before.title !== after.title ||
+      before.type !== after.type ||
+      before.year !== after.year ||
+      before.releaseDate !== after.releaseDate ||
+      before.thumb !== after.thumb ||
+      before.discoverKey !== after.discoverKey ||
+      before.source !== after.source ||
+      before.addedAt !== after.addedAt ||
+      before.matchedRatingKey !== after.matchedRatingKey ||
+      beforeGuids.length !== afterGuids.length ||
+      beforeGuids.some((guid, index) => guid !== afterGuids[index]);
+  }
+
+  private classifySyncRunActivity(runId: number): "changes" | "no_changes" {
+    const run = this.db.getSyncRunWithItems(runId);
+    const hasChanges = run?.items.some((item) => {
+      if (item.status !== "success") return false;
+      if (item.action === "watchlist.fetch") {
+        const details = item.details as { changed?: unknown };
+        return details.changed === true;
+      }
+      if (item.action === "isolation.filters") {
+        const details = item.details as { updated?: unknown };
+        return typeof details.updated === "number" && details.updated > 0;
+      }
+      return item.action === "collection.publish" ||
+        item.action === "watchlist.cleanup.removed" ||
+        item.action === "seerr.request.created" ||
+        (item.action === "seerr.request.existing" && (item.details as { stateChanged?: unknown }).stateChanged === true);
+    }) ?? false;
+
+    return hasChanges ? "changes" : "no_changes";
+  }
+
+  private seerrRequestStateChanged(before: SeerrRequestState | null, after: SeerrRequestState): boolean {
+    if (!before) return true;
+    return before.plexItemId !== after.plexItemId ||
+      before.seerrRequestId !== after.seerrRequestId ||
+      before.seerrMediaId !== after.seerrMediaId ||
+      before.tmdbId !== after.tmdbId ||
+      before.outcome !== after.outcome ||
+      before.lastError !== after.lastError ||
+      before.effectiveSeerrUserId !== after.effectiveSeerrUserId ||
+      before.executionSeerrUserId !== after.executionSeerrUserId;
   }
 
   private async publishUserCollections(
@@ -1636,7 +1728,7 @@ export class HubarrServices {
         durationMs: Date.now() - syncStart
       });
     } else {
-      this.db.completeSyncRun(runId, "success", `Full sync finished for ${friends.length} users.`, null);
+      this.db.completeSyncRun(runId, "success", `Full sync finished for ${friends.length} users.`, null, this.classifySyncRunActivity(runId));
       this.logger.info("Full sync complete", {
         succeeded: friends.length,
         failed: 0,
@@ -1719,7 +1811,7 @@ export class HubarrServices {
       }
 
       const items = await this.syncUser(friend, runId, rssDateMap);
-      this.db.completeSyncRun(runId, "success", `Manual sync finished for ${label}.`, null);
+      this.db.completeSyncRun(runId, "success", `Manual sync finished for ${label}.`, null, this.classifySyncRunActivity(runId));
 
       // Publish pass runs first so stale matchedRatingKey values are cleared before
       // Seerr sync evaluates which items are genuinely missing from Plex.
@@ -1822,7 +1914,7 @@ export class HubarrServices {
         durationMs: Date.now() - syncStart
       });
     } else {
-      this.db.completeSyncRun(runId, "success", `Collection sync finished for ${friends.length} users.`, null);
+      this.db.completeSyncRun(runId, "success", `Collection sync finished for ${friends.length} users.`, null, this.classifySyncRunActivity(runId));
       this.logger.info("Collection sync complete", {
         succeeded: friends.length,
         failed: 0,
@@ -1847,7 +1939,7 @@ export class HubarrServices {
         reason: "cleanup-disabled",
         message: "Watchlist cleanup is disabled."
       });
-      this.db.completeSyncRun(runId, "success", "Watchlist Cleanup skipped: cleanup is disabled.", null);
+      this.db.completeSyncRun(runId, "success", "Watchlist Cleanup skipped: cleanup is disabled.", null, "no_changes");
       this.logger.info("Watchlist Cleanup skipped because cleanup is disabled");
       return { removed: 0, skipped: 1 };
     }
@@ -1859,7 +1951,7 @@ export class HubarrServices {
         reason: "missing-admin-user",
         message: "Admin/self user is not configured."
       });
-      this.db.completeSyncRun(runId, "success", "Watchlist Cleanup skipped: admin user is not configured.", null);
+      this.db.completeSyncRun(runId, "success", "Watchlist Cleanup skipped: admin user is not configured.", null, "no_changes");
       return { removed: 0, skipped: 1 };
     }
 
@@ -1976,7 +2068,7 @@ export class HubarrServices {
       const summary = removed > 0
         ? `Watchlist Cleanup removed ${removed} item${removed !== 1 ? "s" : ""}; skipped ${skipped}; failed ${failed}.`
         : `Watchlist Cleanup skipped: no watched items to remove (${skipped} skipped; ${failed} failed).`;
-      this.db.completeSyncRun(runId, "success", summary, null);
+      this.db.completeSyncRun(runId, "success", summary, null, removed > 0 ? "changes" : "no_changes");
       this.logger.info("Watchlist Cleanup complete", { removed, skipped, failed, durationMs: Date.now() - startedAt });
 
       if (removed > 0) {
@@ -2340,7 +2432,7 @@ export class HubarrServices {
       }
 
       if (!this.selfRssPrimed && !this.usersRssPrimed) {
-        this.db.completeSyncRun(runId, "success", "RSS sync skipped: neither feed is initialized.", null);
+        this.db.completeSyncRun(runId, "success", "RSS sync skipped: neither feed is initialized.", null, "no_changes");
         return this.db.listSyncRuns(1)[0];
       }
 
@@ -2449,7 +2541,8 @@ export class HubarrServices {
         total > 0
           ? `RSS sync: ${total} new item(s) processed (self: ${selfProcessed}, friends: ${friendsProcessed}).`
           : "RSS sync: 0 new items.",
-        null
+        null,
+        total > 0 ? "changes" : "no_changes"
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -2943,7 +3036,7 @@ export class HubarrServices {
     try {
       const seerrSettings = this.db.getSeerrSettings();
       if (!seerrSettings.enabled || !seerrSettings.baseUrl || !seerrSettings.apiKey) {
-        this.db.completeSyncRun(runId, "success", "Seerr request sync skipped: Seerr is not configured.", null);
+        this.db.completeSyncRun(runId, "success", "Seerr request sync skipped: Seerr is not configured.", null, "no_changes");
         this.db.saveJobRunState("seerr-request-sync", {
           lastRunAt: new Date().toISOString(),
           lastRunStatus: "success"
@@ -2978,7 +3071,7 @@ export class HubarrServices {
       const summary = itemCount > 0
         ? `Seerr request sync finished for ${work.length} user(s) and ${itemCount} missing item(s).`
         : "Seerr request sync: 0 missing items.";
-      this.db.completeSyncRun(runId, "success", summary, null);
+      this.db.completeSyncRun(runId, "success", summary, null, this.classifySyncRunActivity(runId));
       this.db.saveJobRunState("seerr-request-sync", {
         lastRunAt: new Date().toISOString(),
         lastRunStatus: "success"
@@ -3190,7 +3283,8 @@ export class HubarrServices {
 
       if (evaluation) {
         // Item is already known to Seerr — update cached state and move on
-        this.db.upsertSeerrRequestState({
+        const previousState = this.db.getSeerrRequestState(friend.id, item.plexItemId);
+        const savedState = this.db.upsertSeerrRequestState({
           userId: friend.id,
           plexItemId: item.plexItemId,
           seerrRequestId: evaluation.seerrRequestId,
@@ -3200,6 +3294,7 @@ export class HubarrServices {
           effectiveSeerrUserId: requesterSeerrUserId,
           executionSeerrUserId
         });
+        const stateChanged = this.seerrRequestStateChanged(previousState, savedState);
         this.db.addSyncRunItem(runId, "seerr.request.existing", "success", {
           userId: friend.id,
           displayName: friend.displayName,
@@ -3209,7 +3304,8 @@ export class HubarrServices {
           tmdbId,
           outcome: evaluation.outcome,
           seerrRequestId: evaluation.seerrRequestId,
-          seerrMediaId: evaluation.seerrMediaId
+          seerrMediaId: evaluation.seerrMediaId,
+          stateChanged
         }, friend.id);
         continue;
       }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,5 @@
 export type SyncStatus = "idle" | "running" | "success" | "error";
+export type SyncRunActivity = "changes" | "no_changes" | "unknown";
 export type MediaType = "movie" | "show";
 
 export interface BootstrapStatus {
@@ -231,6 +232,7 @@ export interface SyncRun {
   id: number;
   kind: "full" | "user" | "rss" | "publish" | "seerr" | "watchlist-cleanup";
   status: SyncStatus;
+  activity: SyncRunActivity;
   startedAt: string;
   completedAt: string | null;
   summary: string;

--- a/tests/playwright/history.spec.ts
+++ b/tests/playwright/history.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * History filter tests — verify that type/status filter buttons and the page-size
- * selector render correctly, and that clicking filters updates the URL.
+ * History filter tests — verify that type/status/activity filter buttons and
+ * the page-size selector render correctly, and that clicking filters updates the URL.
  * Read-only. Safe to run against a live instance.
  */
 
@@ -15,19 +15,35 @@ test.describe("History filters", () => {
 
   test("Type filter buttons are all visible", async ({ page }) => {
     // exact: true prevents matching history run-row buttons that contain these words
-    await expect(page.getByRole("button", { name: "All types", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "GraphQL", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "RSS", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Manual", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Collection", exact: true })).toBeVisible();
+    const filter = page.getByRole("group", { name: "Type filter" });
+    await expect(filter.getByRole("button", { name: "All", exact: true })).toBeVisible();
+    await expect(filter.getByRole("button", { name: "GraphQL", exact: true })).toBeVisible();
+    await expect(filter.getByRole("button", { name: "RSS", exact: true })).toBeVisible();
+    await expect(filter.getByRole("button", { name: "Manual", exact: true })).toBeVisible();
+    await expect(filter.getByRole("button", { name: "Collection", exact: true })).toBeVisible();
   });
 
   test("Status filter buttons are all visible", async ({ page }) => {
     // exact: true prevents matching history run-row buttons whose names include these words
-    await expect(page.getByRole("button", { name: "All status", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^success$/i })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^error$/i })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^running$/i })).toBeVisible();
+    const filter = page.getByRole("group", { name: "Status filter" });
+    await expect(filter.getByRole("button", { name: "All", exact: true })).toBeVisible();
+    await expect(filter.getByRole("button", { name: /^success$/i })).toBeVisible();
+    await expect(filter.getByRole("button", { name: /^error$/i })).toBeVisible();
+    await expect(filter.getByRole("button", { name: /^running$/i })).toBeVisible();
+  });
+
+  test("Activity filter buttons are all visible", async ({ page }) => {
+    const filter = page.getByRole("group", { name: "Activity filter" });
+    await expect(filter.getByRole("button", { name: "All", exact: true })).toBeVisible();
+    await expect(filter.getByRole("button", { name: "Changes", exact: true })).toBeVisible();
+    await expect(filter.getByRole("button", { name: "No Changes", exact: true })).toBeVisible();
+  });
+
+  test("Activity filter starts with All", async ({ page }) => {
+    const activityButtons = page.getByRole("group", { name: "Activity filter" }).getByRole("button");
+    await expect(activityButtons.nth(0)).toHaveText("All");
+    await expect(activityButtons.nth(1)).toHaveText("Changes");
+    await expect(activityButtons.nth(2)).toHaveText("No Changes");
   });
 
   test("Page size select is visible", async ({ page }) => {
@@ -35,12 +51,22 @@ test.describe("History filters", () => {
   });
 
   test("RSS type filter updates URL", async ({ page }) => {
-    await page.getByRole("button", { name: "RSS", exact: true }).click();
+    await page.getByRole("group", { name: "Type filter" }).getByRole("button", { name: "RSS", exact: true }).click();
     await expect(page).toHaveURL(/[?&]type=rss/);
   });
 
   test("Success status filter updates URL", async ({ page }) => {
-    await page.getByRole("button", { name: /^success$/i }).click();
+    await page.getByRole("group", { name: "Status filter" }).getByRole("button", { name: /^success$/i }).click();
     await expect(page).toHaveURL(/[?&]status=success/);
+  });
+
+  test("No Changes activity filter updates URL", async ({ page }) => {
+    await page.getByRole("group", { name: "Activity filter" }).getByRole("button", { name: "No Changes", exact: true }).click();
+    await expect(page).toHaveURL(/[?&]activity=no_changes/);
+  });
+
+  test("All activity filter updates URL", async ({ page }) => {
+    await page.getByRole("group", { name: "Activity filter" }).getByRole("button", { name: "All", exact: true }).click();
+    await expect(page).toHaveURL(/[?&]activity=all/);
   });
 });

--- a/tests/playwright/live-refresh.spec.ts
+++ b/tests/playwright/live-refresh.spec.ts
@@ -95,7 +95,7 @@ test.describe("Live refresh", () => {
 });
 
 async function getLatestRun(request: APIRequestContext, kind: SyncRun["kind"]): Promise<SyncRun | null> {
-  const response = await request.get(`/api/history?page=1&pageSize=10&kind=${kind}&status=all`);
+  const response = await request.get(`/api/history?page=1&pageSize=10&kind=${kind}&status=all&activity=all`);
   expect(response.ok()).toBe(true);
   const body = await response.json() as { results: SyncRun[] };
   return body.results[0] ?? null;

--- a/tests/server/history-progress.test.ts
+++ b/tests/server/history-progress.test.ts
@@ -24,3 +24,33 @@ test("updateSyncRunSummary refreshes the live history summary for running syncs"
     cleanup();
   }
 });
+
+test("history activity filtering separates changes from no-change success runs", () => {
+  const { db, cleanup } = createTestDatabase();
+
+  try {
+    const changesRunId = db.createSyncRun("rss", "RSS sync started.");
+    db.completeSyncRun(changesRunId, "success", "RSS sync: 1 new item processed.", null, "changes");
+
+    const noChangesRunId = db.createSyncRun("rss", "RSS sync started.");
+    db.completeSyncRun(noChangesRunId, "success", "RSS sync: 0 new items.", null, "no_changes");
+
+    const runningRunId = db.createSyncRun("publish", "Collection sync started.");
+    const errorRunId = db.createSyncRun("full", "Full sync started.");
+    db.completeSyncRun(errorRunId, "error", "Full sync failed.", "Boom");
+
+    const changes = db.listSyncRunsPaginated({ page: 1, pageSize: 10, activity: "changes" }).results;
+    assert.deepEqual(
+      changes.map((run) => run.id).sort((a, b) => a - b),
+      [changesRunId, runningRunId, errorRunId].sort((a, b) => a - b)
+    );
+
+    const noChanges = db.listSyncRunsPaginated({ page: 1, pageSize: 10, activity: "no_changes" }).results;
+    assert.deepEqual(noChanges.map((run) => run.id), [noChangesRunId]);
+
+    const all = db.listSyncRunsPaginated({ page: 1, pageSize: 10, activity: "all" }).results;
+    assert.equal(all.length, 4);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Adds a History activity filter so sync runs can be viewed by whether they made meaningful changes, completed successfully with no changes, or should be shown together. This stores an explicit activity outcome on new sync runs and keeps status filtering separate, so status continues to describe whether a run succeeded, failed, or is still running.

Closes #158

## Changes

- `src/server/db/migrations.ts`, `src/server/db/sync.ts`, `src/server/db/index.ts`, and `src/shared/types.ts`: add the persisted `sync_runs.activity` field with `changes`, `no_changes`, and `unknown` outcomes; expose activity in run list/detail queries; and add activity filtering to paginated History results.
- `src/server/app.ts`: accepts an independent `activity` query parameter for `/api/history`, defaulting to `all` after the requested UX adjustment.
- `src/server/services.ts`: classifies RSS, Watchlist Cleanup, Collection sync, Seerr sync, full GraphQL sync, manual sync, and onboarding preload runs. Full/manual syncs now record explicit watchlist before/after diff metadata, while collection, isolation, cleanup, and Seerr outcomes classify from recorded run items.
- `src/client/pages/History.tsx`: adds the Activity filter group, aligns all filter groups to use `All` as the first option, adds accessible group labels, and shows activity badges for classified successful runs.
- `tests/server/history-progress.test.ts`, `tests/playwright/history.spec.ts`, and `tests/playwright/live-refresh.spec.ts`: cover activity filtering behavior, History filter UI/URL behavior, and ensure live-refresh helpers continue to query all activity when needed.
- `docs/sync.md` and `TESTING.md`: document activity outcomes, the History filter behavior, and the new Playwright coverage.

## Test plan

- [x] Run `npm run check` to verify client and server TypeScript.
- [x] Run `npm run lint` to verify ESLint.
- [x] Run `npx tsx --test tests/server/history-progress.test.ts` to verify activity filtering semantics.
- [x] Run `npm run build` to verify production client/server build output.
- [x] Run `npx playwright test tests/playwright/history.spec.ts` against the rebuilt live Hubarr container to verify the History filter UI and URL behavior.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added activity filter to History page to filter sync runs by change detection status (All, Changes, or No Changes options)
  * Activity badges now display on successful sync runs indicating whether changes were detected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Migz93/hubarr/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->