### PR TITLE
fix: limit Seerr history to enabled users

### DIFF
--- a/src/client/pages/History.tsx
+++ b/src/client/pages/History.tsx
@@ -291,6 +291,18 @@ interface SyncUserErrorDetails {
   message?: string;
 }
 
+interface SeerrRequestDetails {
+  userId?: number;
+  displayName?: string;
+  plexItemId?: string;
+  title?: string;
+  type?: string;
+  tmdbId?: number;
+  outcome?: string;
+  reason?: string;
+  error?: string;
+}
+
 function titleCaseStatus(status: SyncRun["status"]): string {
   return capitalizeSentence(status);
 }
@@ -323,7 +335,34 @@ function formatMediaTypeLabel(mediaType?: string): string {
   return "Items";
 }
 
+function formatSeerrOutcomeLabel(item: SyncRunItem, details: SeerrRequestDetails | null): string {
+  if (item.action === "seerr.request.created") return "requested in Seerr";
+  if (item.action === "seerr.request.failed") return "Seerr request failed";
+  if (item.action === "seerr.request.skipped") {
+    if (details?.reason === "missing_tmdb_id") return "skipped: missing TMDB ID";
+    if (details?.reason === "unlinked_user") return "skipped: no linked Seerr user";
+    return "Seerr request skipped";
+  }
+
+  if (details?.outcome === "already_requested") return "already requested in Seerr";
+  if (details?.outcome === "already_available") return "already in Seerr";
+  if (details?.outcome === "added_directly") return "already added in Seerr";
+  return "already in Seerr";
+}
+
+function formatSeerrStepLabel(item: SyncRunItem): string {
+  const details = item.details as SeerrRequestDetails | null;
+  const title = details?.title ?? "Unknown item";
+  const type = details?.type ? ` (${details.type})` : "";
+  const name = details?.displayName ?? "Unknown user";
+  return `${title}${type} for ${name}: ${formatSeerrOutcomeLabel(item, details)}`;
+}
+
 function formatStepLabel(item: SyncRunItem): string {
+  if (item.action.startsWith("seerr.request.")) {
+    return formatSeerrStepLabel(item);
+  }
+
   if (item.action === "sync.user" && item.status === "error") {
     const details = item.details as SyncUserErrorDetails | null;
     return details?.displayName
@@ -390,6 +429,12 @@ function formatStepMeta(item: SyncRunItem): string | undefined {
     if (item.status === "error") return details?.message;
     if (details?.checked === false) return "Feed was not initialized for this run.";
     return `${details?.found ?? 0} new item${details?.found === 1 ? "" : "s"} found`;
+  }
+
+  if (item.action.startsWith("seerr.request.")) {
+    const details = item.details as SeerrRequestDetails | null;
+    if (item.status === "error") return details?.error;
+    return undefined;
   }
 
   if (item.details && typeof item.details === "object") {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -2979,7 +2979,7 @@ export class HubarrServices {
 
   private isSeerrRequestWorkEnabled(userId: number): boolean {
     const link = this.db.getSeerrUserLink(userId);
-    return Boolean(link?.autoRequestEnabled);
+    return Boolean(link?.autoRequestEnabled && link.effectiveSeerrUserId);
   }
 
   private buildSeerrRequestWork(scope: SeerrRequestSyncScope): SeerrRequestWorkItem[] {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -2977,18 +2977,30 @@ export class HubarrServices {
     return this.db.getWatchlistItems(userId).filter((item) => !item.matchedRatingKey);
   }
 
+  private isSeerrRequestWorkEnabled(userId: number): boolean {
+    const link = this.db.getSeerrUserLink(userId);
+    return Boolean(link?.autoRequestEnabled);
+  }
+
   private buildSeerrRequestWork(scope: SeerrRequestSyncScope): SeerrRequestWorkItem[] {
     if (scope.mode === "all") {
       const { trackedUsers } = this.getUserScopes();
-      return trackedUsers.map((user) => ({
-        user,
-        items: this.getMissingWatchlistItemsForUser(user.id)
-      })).filter((entry) => entry.items.length > 0);
+      return trackedUsers
+        .filter((user) => this.isSeerrRequestWorkEnabled(user.id))
+        .map((user) => ({
+          user,
+          items: this.getMissingWatchlistItemsForUser(user.id)
+        }))
+        .filter((entry) => entry.items.length > 0);
     }
 
     const user = this.db.getUser(scope.userId);
     if (!user) {
       throw new Error("User not found.");
+    }
+
+    if (!this.isSeerrRequestWorkEnabled(user.id)) {
+      return [];
     }
 
     if (scope.mode === "items") {
@@ -3052,6 +3064,7 @@ export class HubarrServices {
       const work = this.dedupeSeerrRequestWork(rawWork);
       const requireAutoRequest = scope.mode !== "all";
       const itemCount = work.reduce((sum, entry) => sum + entry.items.length, 0);
+      const rawItemCount = rawWork.reduce((sum, entry) => sum + entry.items.length, 0);
       let processedUsers = 0;
 
       this.logger.info("Seerr request sync work prepared", {
@@ -3059,6 +3072,8 @@ export class HubarrServices {
         triggeredBy: scope.triggeredBy,
         userCount: work.length,
         itemCount,
+        rawUserCount: rawWork.length,
+        rawItemCount,
         requireAutoRequest
       });
 

--- a/tests/server/seerr-work.test.ts
+++ b/tests/server/seerr-work.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WatchlistItem } from "../../src/shared/types.js";
+import { HubarrServices } from "../../src/server/services.js";
+import type { ImageCacheService } from "../../src/server/image-cache.js";
+import { createTestDatabase } from "./test-db.js";
+import { createCapturingLogger } from "./test-helpers.js";
+
+function missingItem(id: string, title: string): WatchlistItem {
+  return {
+    plexItemId: id,
+    title,
+    type: "movie",
+    year: 2026,
+    releaseDate: "2026-01-01",
+    thumb: null,
+    guids: [`tmdb://${id.replace(/\D/g, "") || "1"}`],
+    discoverKey: id,
+    source: "graphql",
+    addedAt: "2026-05-01T00:00:00.000Z",
+    matchedRatingKey: null
+  };
+}
+
+test("Seerr request work only counts linked users with automatic requests enabled", () => {
+  const { db, cleanup } = createTestDatabase();
+  const { logger } = createCapturingLogger();
+  const service = new HubarrServices(db, logger, {} as ImageCacheService) as unknown as {
+    buildSeerrRequestWork: (scope: { mode: "all"; triggeredBy: "manual" }) => Array<{
+      user: { id: number; displayName: string };
+      items: WatchlistItem[];
+    }>;
+  };
+
+  try {
+    db.saveSeerrSettings({
+      enabled: true,
+      baseUrl: "http://seerr:5055",
+      apiKey: "test-key",
+      autoRequestEnabled: false,
+      useServiceAccount: false,
+      serviceAccountSeerrUserId: null
+    });
+    db.upsertUsers([
+      { plexUserId: "plex-1", username: "alice", displayName: "Alice", avatarUrl: null },
+      { plexUserId: "plex-2", username: "bob", displayName: "Bob", avatarUrl: null },
+      { plexUserId: "plex-3", username: "cara", displayName: "Cara", avatarUrl: null }
+    ]);
+
+    const [alice, bob, cara] = db.listUsers();
+    assert.ok(alice);
+    assert.ok(bob);
+    assert.ok(cara);
+    db.updateUser(alice.id, { enabled: true });
+    db.updateUser(bob.id, { enabled: true });
+    db.updateUser(cara.id, { enabled: true });
+
+    db.upsertWatchlistItem(alice.id, missingItem("movie-101", "Alice Missing"));
+    db.upsertWatchlistItem(bob.id, missingItem("movie-202", "Bob Missing"));
+    db.upsertWatchlistItem(cara.id, missingItem("movie-303", "Cara Missing"));
+
+    db.upsertSeerrUserLink({
+      userId: alice.id,
+      manualSeerrUserId: 1001,
+      autoRequestEnabledOverride: true
+    });
+    db.upsertSeerrUserLink({
+      userId: bob.id,
+      manualSeerrUserId: 1002,
+      autoRequestEnabledOverride: false
+    });
+
+    const work = service.buildSeerrRequestWork({ mode: "all", triggeredBy: "manual" });
+
+    assert.equal(work.length, 1);
+    assert.equal(work[0]?.user.id, alice.id);
+    assert.equal(work[0]?.items.length, 1);
+    assert.equal(work[0]?.items[0]?.title, "Alice Missing");
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/server/seerr-work.test.ts
+++ b/tests/server/seerr-work.test.ts
@@ -47,7 +47,10 @@ test("Seerr request work only counts linked users with automatic requests enable
       { plexUserId: "plex-3", username: "cara", displayName: "Cara", avatarUrl: null }
     ]);
 
-    const [alice, bob, cara] = db.listUsers();
+    const users = db.listUsers();
+    const alice = users.find((user) => user.username === "alice");
+    const bob = users.find((user) => user.username === "bob");
+    const cara = users.find((user) => user.username === "cara");
     assert.ok(alice);
     assert.ok(bob);
     assert.ok(cara);


### PR DESCRIPTION
## Summary

Fixes Seerr request sync history so the run summary only counts users who are actually eligible for automatic Seerr requests. The History page now also shows useful Seerr step labels with the item title, user, and final Seerr outcome instead of repeating a generic status for every row.

## Changes

- `src/server/services.ts`: filters Seerr sync work to users with a linked effective Seerr account and automatic requests enabled before calculating progress and final summary totals. Adds structured log fields for the prepared work totals.
- `src/client/pages/History.tsx`: formats Seerr request history rows with item title, media type, display name, and a specific outcome such as already requested, already in Seerr, requested, skipped, or failed.
- `tests/server/seerr-work.test.ts`: adds coverage proving unlinked or auto-request-disabled users are excluded from Seerr request work counts.

## Test plan

- [x] Run `npm run lint`.
- [x] Run `npm run check`.
- [x] Run `node --import tsx --test tests/server/seerr-work.test.ts`.
- [x] Rebuild and restart the local `hubarr` Docker container, then verify the in-container health endpoint returns 200.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seerr request history now shows human-readable step labels, outcomes, and detailed error info for clearer troubleshooting
  * Auto-request synchronization now respects each user's auto-request enablement, so syncs only process eligible accounts

* **Tests**
  * Added test coverage ensuring per-user auto-request filtering behaves correctly

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Migz93/hubarr/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->