### PR TITLE
fix: backfill watchlist dates when enabling users

### DIFF
--- a/docs/watchlist.md
+++ b/docs/watchlist.md
@@ -307,9 +307,11 @@ The backfill first runs the user's normal GraphQL watchlist sync so the current
 watchlist rows and identifier aliases are available. After each activity-feed
 page is upserted, Hubarr checks the user's sentinel-date watchlist rows through
 the same identifier matching tables used by normal sync. The scan stops once no
-unresolved sentinel rows remain, or when the feed is exhausted. A second user
-sync then reapplies date resolution so `watchlist_cache.added_at` is updated
-from the newly cached activity rows.
+unresolved sentinel rows remain, or when the feed is exhausted. The latest
+processed activity-feed cursor is stored in `job_run_state` under a per-user
+backfill key so a later retry can resume a long scan instead of starting again
+from the newest page. A second user sync then reapplies date resolution so
+`watchlist_cache.added_at` is updated from the newly cached activity rows.
 
 ### How it is used
 

--- a/docs/watchlist.md
+++ b/docs/watchlist.md
@@ -294,6 +294,23 @@ Since Plex returns events newest-first, the fetch stops as soon as an entry
 older than the last run timestamp is encountered — keeping the incremental cost
 low regardless of total feed size.
 
+### Per-user backfill on enable
+
+When an existing friend is enabled after the global activity cache has already
+entered incremental mode, Hubarr starts a non-blocking activity-date backfill for
+that user. This flow is intentionally independent of
+`activity-cache-fetch.last_run_at`: it scans the historical activity feed with no
+global cursor, filters events to the enabled user's Plex ID, and upserts matching
+rows into `watchlist_activity_cache`.
+
+The backfill first runs the user's normal GraphQL watchlist sync so the current
+watchlist rows and identifier aliases are available. After each activity-feed
+page is upserted, Hubarr checks the user's sentinel-date watchlist rows through
+the same identifier matching tables used by normal sync. The scan stops once no
+unresolved sentinel rows remain, or when the feed is exhausted. A second user
+sync then reapplies date resolution so `watchlist_cache.added_at` is updated
+from the newly cached activity rows.
+
 ### How it is used
 
 During `syncUser()`, after the GraphQL fetch and merge, any item whose `addedAt`

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -588,7 +588,9 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       res.status(400).json({ error: "ids (array) and enabled (boolean) are required." });
       return;
     }
-    const ids = [...new Set((body.ids as unknown[]).filter((id): id is number => typeof id === "number"))];
+    const ids = [...new Set(
+      (body.ids as unknown[]).filter((id): id is number => typeof id === "number" && Number.isSafeInteger(id) && id > 0)
+    )];
     const usersToBackfill = body.enabled
       ? ids
           .map((id) => db.getUser(id))

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -588,7 +588,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       res.status(400).json({ error: "ids (array) and enabled (boolean) are required." });
       return;
     }
-    const ids = (body.ids as unknown[]).filter((id): id is number => typeof id === "number");
+    const ids = [...new Set((body.ids as unknown[]).filter((id): id is number => typeof id === "number"))];
     const usersToBackfill = body.enabled
       ? ids
           .map((id) => db.getUser(id))
@@ -600,9 +600,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       enabled: body.enabled,
       updated
     });
-    const updatedIds = new Set(updated);
     for (const previousUser of usersToBackfill) {
-      if (!updatedIds.has(previousUser.id)) continue;
       const user = db.getUser(previousUser.id);
       if (user?.enabled) {
         startUserActivityDateBackfill(user);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -15,6 +15,7 @@ import type {
   SettingsResponse,
   SessionUser,
   SetupStatusResponse,
+  UserRecord,
   VisibilityConfig
 } from "../shared/types.js";
 import { createSessionId } from "./auth.js";
@@ -173,6 +174,20 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       return;
     }
     next();
+  }
+
+  function startUserActivityDateBackfill(user: UserRecord) {
+    logger.info("User enabled — starting activity-date backfill", {
+      userId: user.id,
+      displayName: user.displayName
+    });
+    services.backfillUserActivityDates(user.id).catch((err) => {
+      logger.warn("User activity-date backfill failed after enable", {
+        userId: user.id,
+        displayName: user.displayName,
+        message: err instanceof Error ? err.message : String(err)
+      });
+    });
   }
 
   function setSessionCookie(res: Response, sessionId: string) {
@@ -574,12 +589,25 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       return;
     }
     const ids = (body.ids as unknown[]).filter((id): id is number => typeof id === "number");
+    const usersToBackfill = body.enabled
+      ? ids
+          .map((id) => db.getUser(id))
+          .filter((user): user is UserRecord => user !== null && !user.enabled)
+      : [];
     const updated = db.bulkUpdateUsers(ids, body.enabled);
     logger.info("Bulk user update applied", {
       requestedIds: ids.length,
       enabled: body.enabled,
       updated
     });
+    const updatedIds = new Set(updated);
+    for (const previousUser of usersToBackfill) {
+      if (!updatedIds.has(previousUser.id)) continue;
+      const user = db.getUser(previousUser.id);
+      if (user?.enabled) {
+        startUserActivityDateBackfill(user);
+      }
+    }
     res.json({ updated });
   });
 
@@ -673,6 +701,7 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       }
 
       const updatedFields = Object.keys(body).filter((key) => allowedUserPatchFields.has(key));
+      const previousUser = db.getUser(Number(req.params.id));
       const user = db.updateUser(Number(req.params.id), updatePayload);
       logger.info("User settings updated", {
         userId: user.id,
@@ -680,6 +709,9 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
         updatedFields,
         fieldCount: updatedFields.length
       });
+      if (updatePayload.enabled === true && previousUser && !previousUser.enabled) {
+        startUserActivityDateBackfill(user);
+      }
       res.json(user);
     } catch (error) {
       res.status(404).json({ error: error instanceof Error ? error.message : String(error) });

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -278,6 +278,10 @@ export class HubarrDatabase {
     return watchlistRepo.getActivityCacheDate(this.db, plexItemId, plexUserId);
   }
 
+  countUnresolvedWatchlistDatesAfterActivityCache(userId: number): number {
+    return watchlistRepo.countUnresolvedWatchlistDatesAfterActivityCache(this.db, userId);
+  }
+
   getActivityCacheDateForUserItem(userId: number, plexItemId: string): string | null {
     return identifiersRepo.getActivityCacheDateForUserItem(this.db, userId, plexItemId);
   }

--- a/src/server/db/watchlist.ts
+++ b/src/server/db/watchlist.ts
@@ -642,6 +642,63 @@ export function getActivityCacheDate(
   return row?.watchlisted_at ?? null;
 }
 
+export function countUnresolvedWatchlistDatesAfterActivityCache(db: Database.Database, userId: number): number {
+  const row = db.prepare(`
+    WITH unresolved AS (
+      SELECT w.plex_item_id
+      FROM watchlist_cache w
+      WHERE w.user_id = ?
+        AND w.added_at = '2001-01-01T00:00:00.000Z'
+    ),
+    user_aliases AS (
+      SELECT lower(identifier_value) AS plex_user_id
+      FROM user_identifier_aliases
+      WHERE user_id = ?
+    ),
+    user_cache AS (
+      SELECT lower(plex_item_id) AS plex_item_id
+      FROM watchlist_activity_cache
+      WHERE lower(plex_user_id) IN (SELECT plex_user_id FROM user_aliases)
+    ),
+    unresolved_media AS (
+      SELECT u.plex_item_id, mi.id AS media_item_id
+      FROM unresolved u
+      LEFT JOIN media_items mi ON mi.canonical_plex_item_id = lower(u.plex_item_id)
+    ),
+    direct_matches AS (
+      SELECT u.plex_item_id
+      FROM unresolved u
+      JOIN user_cache uc ON uc.plex_item_id = lower(u.plex_item_id)
+    ),
+    identifier_matches AS (
+      SELECT um.plex_item_id
+      FROM unresolved_media um
+      JOIN media_item_identifiers mii ON mii.media_item_id = um.media_item_id
+      JOIN user_cache uc ON uc.plex_item_id = mii.identifier_value
+    ),
+    canonical_matches AS (
+      SELECT um.plex_item_id
+      FROM unresolved_media um
+      JOIN media_items mi ON mi.id = um.media_item_id
+      JOIN user_cache uc ON uc.plex_item_id = mi.canonical_plex_item_id
+    ),
+    resolved AS (
+      SELECT plex_item_id FROM direct_matches
+      UNION
+      SELECT plex_item_id FROM identifier_matches
+      UNION
+      SELECT plex_item_id FROM canonical_matches
+    )
+    SELECT COUNT(*) AS count
+    FROM unresolved u
+    WHERE NOT EXISTS (
+      SELECT 1 FROM resolved r WHERE r.plex_item_id = u.plex_item_id
+    )
+  `).get(userId, userId) as { count: number } | undefined;
+
+  return row?.count ?? 0;
+}
+
 /**
  * Delete all rows from watchlist_activity_cache and reset the job run state
  * so the next scheduled fetch performs a full re-population.

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1074,6 +1074,7 @@ export class PlexIntegration {
     since: string | null,
     options: {
       plexUserId?: string;
+      after?: string | null;
       onPage?: (
         entries: Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }>,
         page: { endCursor: string | null; hasNextPage: boolean; pageNumber: number }
@@ -1081,7 +1082,7 @@ export class PlexIntegration {
     } = {}
   ): Promise<Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }>> {
     const results: Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }> = [];
-    let after: string | null = null;
+    let after: string | null = options.after ?? null;
     let hasNextPage = true;
     let pageNumber = 0;
     const targetPlexUserId = options.plexUserId?.trim().toLowerCase();
@@ -1121,7 +1122,9 @@ export class PlexIntegration {
         });
       }
 
-      results.push(...pageEntries);
+      if (!options.onPage) {
+        results.push(...pageEntries);
+      }
 
       const shouldContinue = options.onPage
         ? await options.onPage(pageEntries, {

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1071,13 +1071,23 @@ export class PlexIntegration {
    * watchlist_activity_cache, keeping only the most recent date per user+item.
    */
   async fetchWatchlistActivityFeed(
-    since: string | null
+    since: string | null,
+    options: {
+      plexUserId?: string;
+      onPage?: (
+        entries: Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }>,
+        page: { endCursor: string | null; hasNextPage: boolean; pageNumber: number }
+      ) => boolean | Promise<boolean>;
+    } = {}
   ): Promise<Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }>> {
     const results: Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }> = [];
     let after: string | null = null;
     let hasNextPage = true;
+    let pageNumber = 0;
+    const targetPlexUserId = options.plexUserId?.trim().toLowerCase();
 
     while (hasNextPage) {
+      pageNumber++;
       const data: PlexActivityFeedResponse = await this.requestCommunity<PlexActivityFeedResponse>(
         `query GetWatchlistActivity($first: PaginationInt!, $after: String) {
            activityFeed(first: $first, after: $after, types: [WATCHLIST]) {
@@ -1093,6 +1103,7 @@ export class PlexIntegration {
       );
 
       let reachedSince = false;
+      const pageEntries: Array<{ plexItemId: string; plexUserId: string; watchlistedAt: string }> = [];
       for (const node of data.activityFeed.nodes) {
         // Incremental mode: stop once we pass entries older than last fetch
         if (since && node.date <= since) {
@@ -1100,16 +1111,27 @@ export class PlexIntegration {
           break;
         }
         if (!node.metadataItem) continue;
+        if (targetPlexUserId && node.userV2.id.toLowerCase() !== targetPlexUserId) continue;
         const guids = node.metadataItem.guid ? [node.metadataItem.guid] : undefined;
         const plexItemId = this.buildPlexItemId(node.metadataItem.key ?? node.metadataItem.id, guids);
-        results.push({
+        pageEntries.push({
           plexItemId,
           plexUserId: node.userV2.id,
           watchlistedAt: node.date
         });
       }
 
-      hasNextPage = !reachedSince && data.activityFeed.pageInfo.hasNextPage;
+      results.push(...pageEntries);
+
+      const shouldContinue = options.onPage
+        ? await options.onPage(pageEntries, {
+            endCursor: data.activityFeed.pageInfo.endCursor,
+            hasNextPage: data.activityFeed.pageInfo.hasNextPage,
+            pageNumber
+          })
+        : true;
+
+      hasNextPage = shouldContinue && !reachedSince && data.activityFeed.pageInfo.hasNextPage;
       after = data.activityFeed.pageInfo.endCursor;
     }
 

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1165,7 +1165,7 @@ export class HubarrServices {
       durationMs: Date.now() - syncStart
     });
 
-    return mergedWithDates;
+    return { items: mergedWithDates, selfPlexUuid };
   }
 
   private diffWatchlistItems(
@@ -1810,7 +1810,7 @@ export class HubarrServices {
         });
       }
 
-      const items = await this.syncUser(friend, runId, rssDateMap);
+      const { items } = await this.syncUser(friend, runId, rssDateMap);
       this.db.completeSyncRun(runId, "success", `Manual sync finished for ${label}.`, null, this.classifySyncRunActivity(runId));
 
       // Publish pass runs first so stale matchedRatingKey values are cleared before
@@ -2373,9 +2373,13 @@ export class HubarrServices {
     });
 
     try {
-      await this.syncUser(friend, runId);
-      const activityFeedPlexUserId = friend.isSelf ? await plex.fetchSelfPlexUuid() : friend.plexUserId;
+      const initialSync = await this.syncUser(friend, runId);
+      let activityFeedPlexUserId = friend.plexUserId;
       if (friend.isSelf) {
+        if (!initialSync.selfPlexUuid) {
+          throw new Error("Self user activity-date backfill could not resolve the Plex UUID.");
+        }
+        activityFeedPlexUserId = initialSync.selfPlexUuid;
         this.db.upsertUserIdentifierAlias(friend.id, activityFeedPlexUserId);
       }
       let remaining = this.db.countUnresolvedWatchlistDatesAfterActivityCache(friend.id);

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -2332,6 +2332,137 @@ export class HubarrServices {
     }
   }
 
+  async backfillUserActivityDates(userId: number): Promise<void> {
+    const friend = this.db.getUser(userId);
+    if (!friend) {
+      this.logger.warn("User activity-date backfill skipped — user not found", { userId });
+      return;
+    }
+    if (!friend.enabled) {
+      this.logger.warn("User activity-date backfill skipped — user is disabled", {
+        userId: friend.id,
+        displayName: friend.displayName
+      });
+      return;
+    }
+
+    const plexSettings = this.db.getPlexSettings();
+    if (!plexSettings) {
+      this.logger.warn("User activity-date backfill skipped — Plex is not configured yet", {
+        userId: friend.id,
+        displayName: friend.displayName
+      });
+      return;
+    }
+
+    const label = friend.isSelf ? "self" : friend.displayName;
+    const runId = this.db.createSyncRun("user", `Activity-date backfill for ${label}.`);
+    const plex = new PlexIntegration(plexSettings, this.logger);
+    let scannedPages = 0;
+    let fetched = 0;
+    let upserted = 0;
+
+    this.logger.info("User activity-date backfill started", {
+      userId: friend.id,
+      displayName: friend.displayName,
+      plexUserId: friend.plexUserId
+    });
+
+    try {
+      await this.syncUser(friend, runId);
+      let remaining = this.db.countUnresolvedWatchlistDatesAfterActivityCache(friend.id);
+      const initialRemaining = remaining;
+
+      if (remaining === 0) {
+        this.db.addSyncRunItem(runId, "watchlist.date_backfill", "success", {
+          userId: friend.id,
+          displayName: friend.displayName,
+          scannedPages,
+          fetched,
+          upserted,
+          initialRemaining,
+          remaining
+        }, friend.id);
+        this.db.completeSyncRun(runId, "success", `Activity-date backfill found no unresolved dates for ${label}.`, null, "no_changes");
+        this.logger.info("User activity-date backfill skipped scan — no unresolved dates", {
+          userId: friend.id,
+          displayName: friend.displayName
+        });
+        return;
+      }
+
+      await plex.fetchWatchlistActivityFeed(null, {
+        plexUserId: friend.plexUserId,
+        onPage: (entries, page) => {
+          scannedPages = page.pageNumber;
+          fetched += entries.length;
+          if (entries.length > 0) {
+            this.db.upsertActivityCacheEntries(entries);
+            upserted += entries.length;
+          }
+          remaining = this.db.countUnresolvedWatchlistDatesAfterActivityCache(friend.id);
+          this.logger.debug("User activity-date backfill page processed", {
+            userId: friend.id,
+            displayName: friend.displayName,
+            page: page.pageNumber,
+            entries: entries.length,
+            remaining
+          });
+          return remaining > 0;
+        }
+      });
+
+      await this.syncUser(friend, runId);
+      const finalRemaining = this.db.countUnresolvedWatchlistDatesAfterActivityCache(friend.id);
+      const resolved = Math.max(0, initialRemaining - finalRemaining);
+
+      this.db.addSyncRunItem(runId, "watchlist.date_backfill", "success", {
+        userId: friend.id,
+        displayName: friend.displayName,
+        scannedPages,
+        fetched,
+        upserted,
+        resolved,
+        initialRemaining,
+        remaining: finalRemaining
+      }, friend.id);
+      this.db.completeSyncRun(
+        runId,
+        "success",
+        `Activity-date backfill finished for ${label}: resolved ${resolved}, ${finalRemaining} unresolved.`,
+        null,
+        this.classifySyncRunActivity(runId)
+      );
+
+      this.logger.info("User activity-date backfill complete", {
+        userId: friend.id,
+        displayName: friend.displayName,
+        scannedPages,
+        fetched,
+        upserted,
+        resolved,
+        remaining: finalRemaining
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error("User activity-date backfill failed", {
+        userId: friend.id,
+        displayName: friend.displayName,
+        message
+      });
+      this.db.addSyncRunItem(runId, "watchlist.date_backfill", "error", {
+        userId: friend.id,
+        displayName: friend.displayName,
+        scannedPages,
+        fetched,
+        upserted,
+        message
+      }, friend.id);
+      this.db.completeSyncRun(runId, "error", `Activity-date backfill failed for ${label}.`, message);
+      throw err;
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // RSS — initialization
   // ---------------------------------------------------------------------------

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -2358,6 +2358,9 @@ export class HubarrServices {
     const label = friend.isSelf ? "self" : friend.displayName;
     const runId = this.db.createSyncRun("user", `Activity-date backfill for ${label}.`);
     const plex = new PlexIntegration(plexSettings, this.logger);
+    const stateId = `activity-date-backfill:${friend.id}`;
+    const savedState = this.db.getJobRunState(stateId);
+    let after = savedState?.lastRunAt ?? null;
     let scannedPages = 0;
     let fetched = 0;
     let upserted = 0;
@@ -2365,11 +2368,16 @@ export class HubarrServices {
     this.logger.info("User activity-date backfill started", {
       userId: friend.id,
       displayName: friend.displayName,
-      plexUserId: friend.plexUserId
+      plexUserId: friend.plexUserId,
+      resumeCursorPresent: Boolean(after)
     });
 
     try {
       await this.syncUser(friend, runId);
+      const activityFeedPlexUserId = friend.isSelf ? await plex.fetchSelfPlexUuid() : friend.plexUserId;
+      if (friend.isSelf) {
+        this.db.upsertUserIdentifierAlias(friend.id, activityFeedPlexUserId);
+      }
       let remaining = this.db.countUnresolvedWatchlistDatesAfterActivityCache(friend.id);
       const initialRemaining = remaining;
 
@@ -2384,6 +2392,10 @@ export class HubarrServices {
           remaining
         }, friend.id);
         this.db.completeSyncRun(runId, "success", `Activity-date backfill found no unresolved dates for ${label}.`, null, "no_changes");
+        this.db.saveJobRunState(stateId, {
+          lastRunAt: null,
+          lastRunStatus: "success"
+        });
         this.logger.info("User activity-date backfill skipped scan — no unresolved dates", {
           userId: friend.id,
           displayName: friend.displayName
@@ -2392,7 +2404,8 @@ export class HubarrServices {
       }
 
       await plex.fetchWatchlistActivityFeed(null, {
-        plexUserId: friend.plexUserId,
+        plexUserId: activityFeedPlexUserId,
+        after,
         onPage: (entries, page) => {
           scannedPages = page.pageNumber;
           fetched += entries.length;
@@ -2407,6 +2420,11 @@ export class HubarrServices {
             page: page.pageNumber,
             entries: entries.length,
             remaining
+          });
+          after = page.endCursor;
+          this.db.saveJobRunState(stateId, {
+            lastRunAt: after,
+            lastRunStatus: "error"
           });
           return remaining > 0;
         }
@@ -2433,6 +2451,10 @@ export class HubarrServices {
         null,
         this.classifySyncRunActivity(runId)
       );
+      this.db.saveJobRunState(stateId, {
+        lastRunAt: null,
+        lastRunStatus: "success"
+      });
 
       this.logger.info("User activity-date backfill complete", {
         userId: friend.id,
@@ -2459,6 +2481,10 @@ export class HubarrServices {
         message
       }, friend.id);
       this.db.completeSyncRun(runId, "error", `Activity-date backfill failed for ${label}.`, message);
+      this.db.saveJobRunState(stateId, {
+        lastRunAt: after,
+        lastRunStatus: "error"
+      });
       throw err;
     }
   }

--- a/tests/server/identifiers.test.ts
+++ b/tests/server/identifiers.test.ts
@@ -56,3 +56,60 @@ test("batchUpsertMediaItemIdentifiers seeds canonical, discover, and guid lookup
     cleanup();
   }
 });
+
+test("countUnresolvedWatchlistDatesAfterActivityCache uses identifier aliases", () => {
+  const { db, cleanup } = createTestDatabase();
+
+  try {
+    db.upsertUsers([
+      { plexUserId: "plex-user-1", username: "alice", displayName: "Alice", avatarUrl: null }
+    ]);
+
+    const [alice] = db.listUsers();
+    db.upsertUserIdentifierAlias(alice.id, "plex-user-1");
+
+    db.replaceWatchlistItems(alice.id, [
+      {
+        plexItemId: "movie-a",
+        title: "Movie A",
+        type: "movie",
+        year: 2026,
+        releaseDate: "2026-01-01",
+        thumb: null,
+        guids: ["imdb://tt1234567"],
+        discoverKey: "/library/metadata/101",
+        source: "graphql",
+        addedAt: "2001-01-01T00:00:00.000Z",
+        matchedRatingKey: null
+      },
+      {
+        plexItemId: "movie-b",
+        title: "Movie B",
+        type: "movie",
+        year: 2026,
+        releaseDate: "2026-02-01",
+        thumb: null,
+        guids: ["imdb://tt7654321"],
+        discoverKey: "/library/metadata/102",
+        source: "graphql",
+        addedAt: "2001-01-01T00:00:00.000Z",
+        matchedRatingKey: null
+      }
+    ]);
+    db.batchUpsertMediaItemIdentifiers(db.getWatchlistItems(alice.id));
+
+    assert.equal(db.countUnresolvedWatchlistDatesAfterActivityCache(alice.id), 2);
+
+    db.upsertActivityCacheEntries([
+      {
+        plexItemId: "imdb://tt1234567",
+        plexUserId: "plex-user-1",
+        watchlistedAt: "2026-04-10T12:00:00.000Z"
+      }
+    ]);
+
+    assert.equal(db.countUnresolvedWatchlistDatesAfterActivityCache(alice.id), 1);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Closes #172

This PR starts a targeted historical watchlist-date backfill whenever an existing Plex friend is enabled. The backfill is independent of the global `activity-cache-fetch.last_run_at` cursor, so users enabled after the initial activity cache population can recover older watchlisted dates without clearing the global cache.

## Changes

- `src/server/app.ts`
  - Detects disabled-to-enabled transitions in both single-user updates and bulk user updates.
  - Starts the backfill asynchronously so the API response returns immediately.
  - Logs backfill start and failure details with user context.

- `src/server/services.ts`
  - Adds `backfillUserActivityDates()` to run the user's current GraphQL watchlist sync, scan historical activity feed pages for that Plex user, upsert matching activity rows, stop once unresolved sentinel-date items are resolved, and run the user sync again to apply recovered dates.
  - Records backfill progress and outcome in sync history with scanned page, fetched entry, resolved, and remaining counts.

- `src/server/integrations/plex.ts`
  - Extends `fetchWatchlistActivityFeed()` with optional user filtering and per-page callbacks while preserving the existing global incremental activity-cache behavior.

- `src/server/db/watchlist.ts` and `src/server/db/index.ts`
  - Adds an identifier-aware unresolved-date counter that uses the existing media and user alias tables to decide whether sentinel watchlist rows now have activity-cache matches.

- `tests/server/identifiers.test.ts`
  - Adds coverage proving the unresolved-date counter recognizes activity-cache matches through identifier aliases.

- `docs/watchlist.md`
  - Documents the enable-time per-user backfill flow and its separation from the global activity-cache cursor.

## Test plan

- [x] Run `npm run check` and confirm TypeScript passes.
- [x] Run `npm run lint` and confirm ESLint passes.
- [x] Run `node --import tsx --test tests/server/identifiers.test.ts` and confirm the identifier-aware unresolved-date tests pass.
- [x] Build the local Docker image with `docker build -t hubarr .`.
- [x] Recreate the local `hubarr` container with bridge networking, `/opt/hubarr:/config`, and port `9301:9301`.
- [x] Confirm the running container responds successfully from inside the container at `/api/health`.

🤖 Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic per-user backfill of watchlist activity dates when users are enabled (via single or bulk updates), with resumable progress, progress persistence, and post-backfill date resolution.
  * Plex activity feed fetching now supports pagination, per-user filtering, custom cursors, and per-page hooks for incremental processing.

* **Documentation**
  * Added docs describing per-user backfill behavior for the activity feed cache.

* **Tests**
  * Added test validating unresolved watchlist date resolution using identifier aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->