### PR TITLE
fix: clean up disabled user collections

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -596,6 +596,11 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
           .map((id) => db.getUser(id))
           .filter((user): user is UserRecord => user !== null && !user.enabled)
       : [];
+    const usersToCleanup = !body.enabled
+      ? ids
+          .map((id) => db.getUser(id))
+          .filter((user): user is UserRecord => user !== null && user.enabled)
+      : [];
     const updated = db.bulkUpdateUsers(ids, body.enabled);
     logger.info("Bulk user update applied", {
       requestedIds: ids.length,
@@ -607,6 +612,18 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       if (user?.enabled) {
         startUserActivityDateBackfill(user);
       }
+    }
+    const disabledUsers = usersToCleanup.filter((previousUser) => {
+      const user = db.getUser(previousUser.id);
+      return user && !user.enabled;
+    });
+    if (disabledUsers.length > 0) {
+      void services.cleanupDisabledUserCollections(disabledUsers).catch((error) => {
+        logger.error("Disabled-user collection cleanup failed after bulk user update", {
+          userCount: disabledUsers.length,
+          message: error instanceof Error ? error.message : String(error)
+        });
+      });
     }
     res.json({ updated });
   });
@@ -711,6 +728,15 @@ export function createApp(config: RuntimeConfig, scheduler?: JobScheduler) {
       });
       if (updatePayload.enabled === true && previousUser && !previousUser.enabled) {
         startUserActivityDateBackfill(user);
+      }
+      if (updatePayload.enabled === false && previousUser?.enabled && !user.enabled) {
+        void services.cleanupDisabledUserCollections([previousUser]).catch((error) => {
+          logger.error("Disabled-user collection cleanup failed after user update", {
+            userId: previousUser.id,
+            displayName: previousUser.displayName,
+            message: error instanceof Error ? error.message : String(error)
+          });
+        });
       }
       res.json(user);
     } catch (error) {

--- a/src/server/db/collections.ts
+++ b/src/server/db/collections.ts
@@ -70,6 +70,11 @@ export function listCollections(db: Database.Database): PlexCollectionRecord[] {
     .all() as PlexCollectionRecord[];
 }
 
+export function deleteCollectionsForUser(db: Database.Database, userId: number): number {
+  const result = db.prepare("DELETE FROM plex_collections WHERE user_id = ?").run(userId);
+  return Number(result.changes);
+}
+
 export function clearCollections(db: Database.Database): void {
   db.prepare("DELETE FROM plex_collections").run();
 }

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -358,6 +358,10 @@ export class HubarrDatabase {
     return collectionsRepo.listCollections(this.db);
   }
 
+  deleteCollectionsForUser(userId: number): number {
+    return collectionsRepo.deleteCollectionsForUser(this.db, userId);
+  }
+
   clearCollections(): void {
     collectionsRepo.clearCollections(this.db);
   }

--- a/src/server/integrations/plex.ts
+++ b/src/server/integrations/plex.ts
@@ -1584,7 +1584,13 @@ export class PlexIntegration {
 
   async deleteCollection(collectionRatingKey: string): Promise<void> {
     this.logger.info("Deleting Plex collection", { collectionRatingKey });
-    await this.requestServer(`/library/metadata/${collectionRatingKey}`, { method: "DELETE" });
+    try {
+      await this.requestServer(`/library/metadata/${collectionRatingKey}`, { method: "DELETE" });
+    } catch (err) {
+      // 400/404 means the collection is already gone — treat as success.
+      if (this.isItemMissingError(err)) return;
+      throw err;
+    }
   }
 
   async updateCollectionVisibility(

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1977,6 +1977,49 @@ export class HubarrServices {
     });
 
     const allCollections = this.db.listCollections();
+    const collectionsByLabel = new Map<string, Array<{ ratingKey: string; source: "label-scan"; title?: string; libraryId?: string }>>();
+
+    for (const library of libraries) {
+      let plexCollections: Array<{ ratingKey: string; title: string }>;
+      try {
+        plexCollections = await plex.getCollections(library.key);
+      } catch (error) {
+        this.logger.warn("Could not scan Plex library during disabled-user collection cleanup", {
+          libraryId: library.key,
+          libraryTitle: library.title,
+          message: error instanceof Error ? error.message : String(error)
+        });
+        continue;
+      }
+
+      for (const collection of plexCollections) {
+        try {
+          const labels = await plex.getCollectionLabels(collection.ratingKey);
+          for (const label of labels) {
+            const normalizedLabel = label.toLowerCase();
+            if (!normalizedLabel.startsWith("hubarr:")) {
+              continue;
+            }
+
+            const entries = collectionsByLabel.get(normalizedLabel) ?? [];
+            entries.push({
+              ratingKey: collection.ratingKey,
+              source: "label-scan",
+              title: collection.title,
+              libraryId: library.key
+            });
+            collectionsByLabel.set(normalizedLabel, entries);
+          }
+        } catch (error) {
+          this.logger.warn("Could not read Plex collection labels during disabled-user collection cleanup", {
+            collectionRatingKey: collection.ratingKey,
+            title: collection.title,
+            libraryId: library.key,
+            message: error instanceof Error ? error.message : String(error)
+          });
+        }
+      }
+    }
 
     for (const user of users) {
       const expectedLabel = plex.createCollectionLabel(user.username).toLowerCase();
@@ -1991,43 +2034,8 @@ export class HubarrServices {
         }
       }
 
-      for (const library of libraries) {
-        let plexCollections: Array<{ ratingKey: string; title: string }>;
-        try {
-          plexCollections = await plex.getCollections(library.key);
-        } catch (error) {
-          this.logger.warn("Could not scan Plex library during disabled-user collection cleanup", {
-            userId: user.id,
-            displayName: user.displayName,
-            libraryId: library.key,
-            libraryTitle: library.title,
-            message: error instanceof Error ? error.message : String(error)
-          });
-          continue;
-        }
-
-        for (const collection of plexCollections) {
-          try {
-            const labels = await plex.getCollectionLabels(collection.ratingKey);
-            if (labels.some((label) => label.toLowerCase() === expectedLabel)) {
-              candidates.set(collection.ratingKey, {
-                ratingKey: collection.ratingKey,
-                source: "label-scan",
-                title: collection.title,
-                libraryId: library.key
-              });
-            }
-          } catch (error) {
-            this.logger.warn("Could not read Plex collection labels during disabled-user collection cleanup", {
-              userId: user.id,
-              displayName: user.displayName,
-              collectionRatingKey: collection.ratingKey,
-              title: collection.title,
-              libraryId: library.key,
-              message: error instanceof Error ? error.message : String(error)
-            });
-          }
-        }
+      for (const collection of collectionsByLabel.get(expectedLabel) ?? []) {
+        candidates.set(collection.ratingKey, collection);
       }
 
       for (const candidate of candidates.values()) {

--- a/src/server/services.ts
+++ b/src/server/services.ts
@@ -1925,6 +1925,155 @@ export class HubarrServices {
     return this.db.listSyncRuns(1)[0];
   }
 
+  async cleanupDisabledUserCollections(users: UserRecord[]) {
+    if (users.length === 0) {
+      return {
+        users: 0,
+        deleted: 0,
+        failed: 0,
+        localRecordsDeleted: 0
+      };
+    }
+
+    let plex: ReturnType<HubarrServices["getPlexIntegration"]>;
+    try {
+      plex = this.getPlexIntegration();
+    } catch (error) {
+      let localRecordsDeleted = 0;
+      for (const user of users) {
+        localRecordsDeleted += this.db.deleteCollectionsForUser(user.id);
+      }
+      this.db.clearIsolationFilterState();
+      this.logger.error("Disabled-user collection cleanup could not contact Plex", {
+        userCount: users.length,
+        localRecordsDeleted,
+        message: error instanceof Error ? error.message : String(error)
+      });
+      return {
+        users: users.length,
+        deleted: 0,
+        failed: users.length,
+        localRecordsDeleted
+      };
+    }
+
+    let libraries: Array<{ key: string; title: string; type: "movie" | "show" }>;
+    try {
+      libraries = await plex.getLibraries();
+    } catch (error) {
+      libraries = [];
+      this.logger.warn("Could not list Plex libraries during disabled-user collection cleanup; only DB-tracked collections will be deleted", {
+        userCount: users.length,
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+    let deleted = 0;
+    let failed = 0;
+    let localRecordsDeleted = 0;
+
+    this.logger.info("Disabled-user collection cleanup started", {
+      userCount: users.length,
+      libraryCount: libraries.length
+    });
+
+    const allCollections = this.db.listCollections();
+
+    for (const user of users) {
+      const expectedLabel = plex.createCollectionLabel(user.username).toLowerCase();
+      const candidates = new Map<string, { ratingKey: string; source: "db" | "label-scan"; title?: string; libraryId?: string }>();
+
+      for (const record of allCollections.filter((collection) => collection.userId === user.id)) {
+        if (record.collectionRatingKey) {
+          candidates.set(record.collectionRatingKey, {
+            ratingKey: record.collectionRatingKey,
+            source: "db"
+          });
+        }
+      }
+
+      for (const library of libraries) {
+        let plexCollections: Array<{ ratingKey: string; title: string }>;
+        try {
+          plexCollections = await plex.getCollections(library.key);
+        } catch (error) {
+          this.logger.warn("Could not scan Plex library during disabled-user collection cleanup", {
+            userId: user.id,
+            displayName: user.displayName,
+            libraryId: library.key,
+            libraryTitle: library.title,
+            message: error instanceof Error ? error.message : String(error)
+          });
+          continue;
+        }
+
+        for (const collection of plexCollections) {
+          try {
+            const labels = await plex.getCollectionLabels(collection.ratingKey);
+            if (labels.some((label) => label.toLowerCase() === expectedLabel)) {
+              candidates.set(collection.ratingKey, {
+                ratingKey: collection.ratingKey,
+                source: "label-scan",
+                title: collection.title,
+                libraryId: library.key
+              });
+            }
+          } catch (error) {
+            this.logger.warn("Could not read Plex collection labels during disabled-user collection cleanup", {
+              userId: user.id,
+              displayName: user.displayName,
+              collectionRatingKey: collection.ratingKey,
+              title: collection.title,
+              libraryId: library.key,
+              message: error instanceof Error ? error.message : String(error)
+            });
+          }
+        }
+      }
+
+      for (const candidate of candidates.values()) {
+        try {
+          await plex.deleteCollection(candidate.ratingKey);
+          deleted++;
+        } catch (error) {
+          failed++;
+          this.logger.error("Could not delete Plex collection during disabled-user cleanup", {
+            userId: user.id,
+            displayName: user.displayName,
+            collectionRatingKey: candidate.ratingKey,
+            title: candidate.title,
+            libraryId: candidate.libraryId,
+            source: candidate.source,
+            message: error instanceof Error ? error.message : String(error)
+          });
+        }
+      }
+
+      const deletedRecords = this.db.deleteCollectionsForUser(user.id);
+      localRecordsDeleted += deletedRecords;
+      this.logger.info("Disabled-user collection cleanup finished for user", {
+        userId: user.id,
+        displayName: user.displayName,
+        candidates: candidates.size,
+        localRecordsDeleted: deletedRecords
+      });
+    }
+
+    this.db.clearIsolationFilterState();
+    this.logger.info("Disabled-user collection cleanup complete", {
+      users: users.length,
+      deleted,
+      failed,
+      localRecordsDeleted
+    });
+
+    return {
+      users: users.length,
+      deleted,
+      failed,
+      localRecordsDeleted
+    };
+  }
+
   async runWatchlistCleanup() {
     const startedAt = Date.now();
     const settings = this.db.getAppSettings();

--- a/tests/server/disabled-user-cleanup.test.ts
+++ b/tests/server/disabled-user-cleanup.test.ts
@@ -166,6 +166,53 @@ test("disabled-user cleanup falls back to DB-only when getLibraries throws", asy
   }
 });
 
+test("disabled-user cleanup scans Plex collections once for a bulk user cleanup", async () => {
+  const calls = {
+    getCollections: 0,
+    getCollectionLabels: 0
+  };
+  const deleted: string[] = [];
+  const plex = {
+    createCollectionLabel(username: string) {
+      return `hubarr:${username}-watchlist`;
+    },
+    async getLibraries() {
+      return [{ key: "movies", title: "Movies", type: "movie" as const }];
+    },
+    async getCollections() {
+      calls.getCollections += 1;
+      return [
+        { ratingKey: "orphan-alex", title: "Alex Watchlist" },
+        { ratingKey: "orphan-bob", title: "Bob Watchlist" }
+      ];
+    },
+    async getCollectionLabels(ratingKey: string) {
+      calls.getCollectionLabels += 1;
+      return {
+        "orphan-alex": ["hubarr:alex-watchlist"],
+        "orphan-bob": ["hubarr:bob-watchlist"]
+      }[ratingKey] ?? [];
+    },
+    async deleteCollection(ratingKey: string) {
+      deleted.push(ratingKey);
+    }
+  };
+  const { db, service, cleanup } = createService(plex);
+
+  try {
+    const alex = createUser(db, "plex-alex", "alex", "Alex");
+    const bob = createUser(db, "plex-bob", "bob", "Bob");
+
+    await service.cleanupDisabledUserCollections([alex, bob]);
+
+    assert.equal(calls.getCollections, 1);
+    assert.equal(calls.getCollectionLabels, 2);
+    assert.deepEqual(deleted.sort(), ["orphan-alex", "orphan-bob"]);
+  } finally {
+    cleanup();
+  }
+});
+
 test("disabled-user cleanup logs deletion failures and continues with other users", async () => {
   const deleted: string[] = [];
   const plex = {

--- a/tests/server/disabled-user-cleanup.test.ts
+++ b/tests/server/disabled-user-cleanup.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { UserRecord } from "../../src/shared/types.js";
+import { HubarrServices } from "../../src/server/services.js";
+import type { ImageCacheService } from "../../src/server/image-cache.js";
+import { createTestDatabase } from "./test-db.js";
+import { createCapturingLogger } from "./test-helpers.js";
+
+type CleanupResult = {
+  users: number;
+  deleted: number;
+  failed: number;
+  localRecordsDeleted: number;
+};
+
+type CleanupCapableService = {
+  cleanupDisabledUserCollections(users: UserRecord[]): Promise<CleanupResult>;
+  getPlexIntegration: () => unknown;
+};
+
+function createUser(
+  db: ReturnType<typeof createTestDatabase>["db"],
+  plexUserId: string,
+  username: string,
+  displayName: string
+): UserRecord {
+  db.upsertUsers([{ plexUserId, username, displayName, avatarUrl: null }]);
+  const user = db.listUsers().find((candidate) => candidate.plexUserId === plexUserId);
+  assert.ok(user);
+  return db.updateUser(user.id, { enabled: true });
+}
+
+function addCollectionRecord(
+  db: ReturnType<typeof createTestDatabase>["db"],
+  userId: number,
+  mediaType: "movie" | "show",
+  collectionRatingKey: string
+): void {
+  db.upsertCollectionRecord(userId, mediaType, {
+    collectionRatingKey,
+    visibleName: `${mediaType} collection`,
+    labelName: `hubarr:${userId}`,
+    hubIdentifier: null,
+    lastSyncedHash: "hash",
+    lastSyncedAt: "2026-06-01T00:00:00.000Z",
+    lastSyncError: null
+  });
+}
+
+function createService(plex: unknown) {
+  const { logger, entries } = createCapturingLogger();
+  const { db, cleanup } = createTestDatabase();
+  const service = new HubarrServices(db, logger, {} as ImageCacheService) as unknown as CleanupCapableService;
+  service.getPlexIntegration = () => plex;
+  return { db, service, cleanup, entries };
+}
+
+test("disabled-user cleanup deletes DB-tracked and exact-label orphaned Plex collections", async () => {
+  const deleted: string[] = [];
+  const plex = {
+    createCollectionLabel(username: string) {
+      return `hubarr:${username}-watchlist`;
+    },
+    async getLibraries() {
+      return [{ key: "movies", title: "Movies", type: "movie" as const }];
+    },
+    async getCollections() {
+      return [
+        { ratingKey: "orphan-alex", title: "Renamed Alex Watchlist" },
+        { ratingKey: "other-user", title: "Other Watchlist" },
+        { ratingKey: "near-match", title: "Near Match" }
+      ];
+    },
+    async getCollectionLabels(ratingKey: string) {
+      return {
+        "orphan-alex": ["hubarr:alex-watchlist"],
+        "other-user": ["hubarr:bob-watchlist"],
+        "near-match": ["hubarr:alex-watchlist-extra"]
+      }[ratingKey] ?? [];
+    },
+    async deleteCollection(ratingKey: string) {
+      deleted.push(ratingKey);
+    }
+  };
+  const { db, service, cleanup } = createService(plex);
+
+  try {
+    const alex = createUser(db, "plex-alex", "alex", "Alex");
+    const bob = createUser(db, "plex-bob", "bob", "Bob");
+    addCollectionRecord(db, alex.id, "movie", "tracked-alex");
+    addCollectionRecord(db, bob.id, "movie", "tracked-bob");
+    db.saveIsolationFilterState("unchanged-inputs");
+
+    const result = await service.cleanupDisabledUserCollections([alex]);
+
+    assert.deepEqual(deleted.sort(), ["orphan-alex", "tracked-alex"]);
+    assert.equal(result.deleted, 2);
+    assert.equal(result.failed, 0);
+    assert.equal(result.localRecordsDeleted, 1);
+    assert.deepEqual(db.listCollections().map((collection) => collection.collectionRatingKey), ["tracked-bob"]);
+    assert.equal(db.getIsolationFilterState(), null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("disabled-user cleanup only clears local DB records and isolation state when Plex is not configured", async () => {
+  const { db, service, cleanup } = createService(null);
+  service.getPlexIntegration = () => {
+    throw new Error("Plex is not configured yet.");
+  };
+
+  try {
+    const alex = createUser(db, "plex-alex", "alex", "Alex");
+    addCollectionRecord(db, alex.id, "movie", "tracked-alex");
+    db.saveIsolationFilterState("some-inputs");
+
+    const result = await service.cleanupDisabledUserCollections([alex]);
+
+    assert.equal(result.deleted, 0);
+    assert.equal(result.failed, 1);
+    assert.equal(result.localRecordsDeleted, 1);
+    assert.equal(db.listCollections().length, 0);
+    assert.equal(db.getIsolationFilterState(), null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("disabled-user cleanup falls back to DB-only when getLibraries throws", async () => {
+  const deleted: string[] = [];
+  const plex = {
+    createCollectionLabel(username: string) {
+      return `hubarr:${username}-watchlist`;
+    },
+    async getLibraries(): Promise<never> {
+      throw new Error("Plex unreachable");
+    },
+    async getCollections() {
+      return [];
+    },
+    async getCollectionLabels() {
+      return [];
+    },
+    async deleteCollection(ratingKey: string) {
+      deleted.push(ratingKey);
+    }
+  };
+  const { db, service, cleanup, entries } = createService(plex);
+
+  try {
+    const alex = createUser(db, "plex-alex", "alex", "Alex");
+    addCollectionRecord(db, alex.id, "movie", "tracked-alex");
+
+    const result = await service.cleanupDisabledUserCollections([alex]);
+
+    // DB-tracked collection deleted even though library scan was skipped.
+    assert.deepEqual(deleted, ["tracked-alex"]);
+    assert.equal(result.deleted, 1);
+    assert.equal(result.failed, 0);
+    assert.equal(result.localRecordsDeleted, 1);
+    assert.equal(db.listCollections().length, 0);
+    assert.ok(entries.some((entry) => entry.level === "warn" && entry.message.includes("Could not list Plex libraries")));
+  } finally {
+    cleanup();
+  }
+});
+
+test("disabled-user cleanup logs deletion failures and continues with other users", async () => {
+  const deleted: string[] = [];
+  const plex = {
+    createCollectionLabel(username: string) {
+      return `hubarr:${username}-watchlist`;
+    },
+    async getLibraries() {
+      return [];
+    },
+    async getCollections() {
+      return [];
+    },
+    async getCollectionLabels() {
+      return [];
+    },
+    async deleteCollection(ratingKey: string) {
+      if (ratingKey === "tracked-alex") {
+        throw new Error("delete failed");
+      }
+      deleted.push(ratingKey);
+    }
+  };
+  const { db, service, cleanup, entries } = createService(plex);
+
+  try {
+    const alex = createUser(db, "plex-alex", "alex", "Alex");
+    const bob = createUser(db, "plex-bob", "bob", "Bob");
+    addCollectionRecord(db, alex.id, "movie", "tracked-alex");
+    addCollectionRecord(db, bob.id, "movie", "tracked-bob");
+
+    const result = await service.cleanupDisabledUserCollections([alex, bob]);
+
+    assert.deepEqual(deleted, ["tracked-bob"]);
+    assert.equal(result.deleted, 1);
+    assert.equal(result.failed, 1);
+    assert.equal(result.localRecordsDeleted, 2);
+    assert.equal(db.listCollections().length, 0);
+    assert.ok(entries.some((entry) => entry.level === "error" && entry.message === "Could not delete Plex collection during disabled-user cleanup"));
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Closes #174

This PR cleans up Hubarr-owned Plex collections when a user is disabled, preventing stale user-labelled collections and stale isolation-filter state from lingering after the user leaves the publishing scope. It handles both single-user and bulk disable flows, and keeps Plex cleanup in the service layer where API calls, logging, and failure handling already live.

## Changes

- `src/server/app.ts`: detects enabled-to-disabled transitions before and after user updates. Bulk updates pre-fetch currently enabled users before `bulkUpdateUsers`, then schedule cleanup only for users that actually became disabled. Single-user updates use the existing previous-user lookup for the same transition check.
- `src/server/services.ts`: adds `cleanupDisabledUserCollections`, which deletes DB-tracked collection rating keys, scans all Plex libraries for exact matching Hubarr user labels, logs per-library/collection failures, clears local collection records for disabled users, and clears isolation filter state so later publish passes cannot skip on stale inputs.
- `src/server/db/collections.ts` and `src/server/db/index.ts`: add a focused helper to delete local Plex collection records for one user.
- `src/server/integrations/plex.ts`: treats 400/404 responses during collection deletion as already-gone success cases, while still surfacing transient/auth/server failures.
- `tests/server/disabled-user-cleanup.test.ts`: covers DB-tracked cleanup, exact-label orphan cleanup, no near-label or other-user deletion, Plex-not-configured fallback, library-list fallback, failure logging, continued processing, local row deletion, and isolation-state clearing.

## Test plan

- [x] Run `npx tsx --test tests/server/disabled-user-cleanup.test.ts` to verify disabled-user cleanup behavior and edge cases.
- [x] Run `npm run check` to verify TypeScript across client and server configs.
- [x] Run `npm run lint` to verify ESLint across the repo.
- [x] Run `npx tsx --test tests/server/*.test.ts` to verify existing server coverage still passes.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collections are now cleaned up when users are disabled (single and bulk operations), with async processing and aggregated reporting.
  * Added a DB-only fallback when external integration is unavailable so local collection records are still removed.

* **Bug Fixes**
  * Treats missing/invalid remote collection items as no-op instead of failing; improves error handling and logging for deletion failures.

* **Tests**
  * Added comprehensive tests covering cleanup, fallbacks, bulk behavior, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->