### PR TITLE
chore: autolabel semantic release PR titles

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,6 +10,20 @@ template: |
   - `ghcr.io/$OWNER/$REPOSITORY:latest`
   - `ghcr.io/$OWNER/$REPOSITORY:v$RESOLVED_VERSION`
 
+autolabeler:
+  - label: enhancement
+    title:
+      - "/^feat(\\(.+\\))?:/i"
+  - label: bug
+    title:
+      - "/^fix(\\(.+\\))?:/i"
+  - label: documentation
+    title:
+      - "/^docs(\\(.+\\))?:/i"
+  - label: github_actions
+    title:
+      - "/^ci(\\(.+\\))?:/i"
+
 categories:
   - title: Features
     labels:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,15 +13,24 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  auto-label:
+    name: Auto Label Pull Request
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply release labels
+        uses: release-drafter/release-drafter/autolabeler@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
+
   update-release-draft:
     name: Update Release Draft
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Update draft release


### PR DESCRIPTION
## Summary

Teach Release Drafter to map semantic PR titles to the existing labels that already drive the changelog categories and version resolver. This lets `feat:` pull requests automatically receive the `enhancement` label, so releases with feature PRs resolve to a minor version instead of only a patch.

## Changes

- `.github/release-drafter.yml`: adds autolabeler rules for `feat:`, `fix:`, `docs:`, and `ci:` PR titles, mapping them to existing repo labels (`enhancement`, `bug`, `documentation`, and `github_actions`).
- `.github/workflows/release-drafter.yml`: splits PR autolabeling from draft updating, running the autolabeler on pull request events and keeping draft release updates on `main` pushes.
- `.github/workflows/release-drafter.yml`: grants pull request write permission so the autolabeler can apply labels.

## Test plan

- [x] Run `npx --yes yaml-lint .github/release-drafter.yml .github/workflows/release-drafter.yml` and confirm both YAML files parse successfully.
- [x] Run `git diff --check` and confirm the patch has no whitespace errors.
- [ ] After this PR is merged, open or update a PR with a semantic title such as `feat:` and confirm Release Drafter applies the matching release label.

🤖 Generated with Codex