### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hubarr",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hubarr",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hubarr",
   "private": true,
   "license": "GPL-3.0-only",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server/index.ts",


### PR DESCRIPTION
## Summary

Bump Hubarr from `2.1.0` to `2.2.0` in preparation for the next release. This aligns the package metadata with the minor release expected from the feature PRs included since `v2.1.0`.

## Changes

- `package.json`: updates the application version to `2.2.0`.
- `package-lock.json`: updates the root package version and lockfile package metadata to `2.2.0`.

## Test plan

- [x] Run `npm pkg get version` and confirm it returns `2.2.0`.
- [x] Run a Node version consistency check confirming `package.json`, `package-lock.json`, and the root lockfile package all use `2.2.0`.
- [x] Run `git diff --check` and confirm the patch has no whitespace errors.

🤖 Generated with Codex