### PR TITLE
fix: pin setup-node action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        # v7.0.0 — pinned to an immutable commit for workflow supply-chain security.
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Set up Node.js
         if: matrix.language == 'javascript-typescript'
-        uses: actions/setup-node@v6
+        # v7.0.0 — pinned to an immutable commit for workflow supply-chain security.
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

Pins the Node.js setup action to the immutable commit behind its v7 release in the CI and CodeQL workflows. This resolves the outstanding workflow supply-chain security finding while adopting the setup-node v7 update.

## Changes

- `.github/workflows/ci.yml`: updates the CI setup-node action to the v7 immutable commit SHA.
- `.github/workflows/codeql.yml`: updates the CodeQL JavaScript/TypeScript setup-node action to the same immutable commit SHA.

## Test plan

- [x] Confirmed the SHA resolves to the official `actions/setup-node` v7 release commit.
- [x] Ran `git diff --check`.

🤖 Generated with Codex