### PR TITLE
fix: install native build tools for Docker dependency builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 ﻿FROM node:22-trixie-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
 RUN npm install
 
 FROM node:22-trixie-slim AS build


### PR DESCRIPTION
## Summary

Fixes the `Develop Docker Publish` workflow after the `better-sqlite3` upgrade. When no compatible prebuilt module is available, npm now has the tools required to compile the native addon during the Docker dependency stage.

## Changes

- `Dockerfile`: installs Python 3, make, and g++ in the disposable `deps` stage before `npm install`. The tools are not copied into the final runtime image.

## Test plan

- [x] Build the Docker `build` target locally with `docker build --target build -t hubarr .`.
- [x] Confirm `npm install` compiles and installs `better-sqlite3` successfully under Node 22.
- [x] Confirm `npm run build` completes inside the Docker build.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added system build tools to the application’s container build environment.
  * Improved package cleanup during image creation to help reduce unnecessary image contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->