### PR TITLE
chore: bump version to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hubarr",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hubarr",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hubarr",
   "private": true,
   "license": "GPL-3.0-only",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server/index.ts",


### PR DESCRIPTION
## Summary

Prepares the dependency-maintenance release as version 2.2.1. This patch release carries the dependency, GitHub Actions, Docker build, and workflow-hardening changes already integrated on `develop`.

## Changes

- `package.json`: updates the application version from 2.2.0 to 2.2.1.
- `package-lock.json`: aligns the root package metadata with version 2.2.1.

## Test plan

- [x] Run `npm run lint`.
- [x] Run `npm run check`.
- [x] Run `npm run build`.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->