### PR TITLE
feat: slim runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,21 @@ COPY package.json package-lock.json* ./
 RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
-RUN npm install
+RUN npm ci
 
 FROM node:22-trixie-slim AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
+
+FROM node:22-trixie-slim AS production-deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+RUN npm ci --omit=dev
 
 FROM node:22-trixie-slim AS runtime
 WORKDIR /app
@@ -25,10 +33,10 @@ ENV COMMIT_SHA=$COMMIT_SHA
 RUN apt-get update \
   && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core \
   && rm -rf /var/lib/apt/lists/*
-COPY --from=build /app/package.json ./package.json
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/dist ./dist
-RUN mkdir -p /config && chown -R node:node /config /app
+COPY --chown=node:node --from=build /app/package.json ./package.json
+COPY --chown=node:node --from=production-deps /app/node_modules ./node_modules
+COPY --chown=node:node --from=build /app/dist ./dist
+RUN mkdir -p /config && chown node:node /config
 USER node
 EXPOSE 9301
 CMD ["node", "dist/server/server/index.js"]


### PR DESCRIPTION
## Summary

This PR reduces Hubarr's runtime Docker image without removing its required Debian base, font support, or normal runtime diagnostics. The current production image copies development tooling and then creates a complete duplicate ownership layer; this change replaces that layout with production-only dependencies and ownership applied during file copies.

The locally built amd64 image falls from 240.3 MB to 145.2 MB, a reduction of 95.1 MB (39.6%). The application continues to run as the unprivileged `node` user.

## Changes

- `Dockerfile`
  - Use `npm ci` for the build dependency stage, making dependency installation reproducible from the lockfile.
  - Add a dedicated `production-deps` stage that runs `npm ci --omit=dev` so the runtime image excludes TypeScript, Playwright, ESLint, Vite, and other build-only packages.
  - Copy runtime files with `COPY --chown=node:node` and limit the remaining ownership operation to the empty `/config` directory, avoiding a duplicate layer for the entire application.

## Test plan

- [x] Build the candidate image locally with `docker build -t hubarr:slim-test .`.
- [x] Confirm the candidate image is 145.2 MB versus 240.3 MB for the current amd64 `develop` image.
- [x] Run the container as `node`, confirm `/app/node_modules`, `/app/dist`, and `/config` are owned by that user, and load Sharp and better-sqlite3 successfully.
- [x] Replace the live Hubarr container with the candidate while preserving its bind mount, port, bridge network, and restart policy; confirm HTTP 200 and completed sync jobs.

Closes #234

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container build reliability through deterministic dependency installation.
  * Reduced the production container footprint by excluding development dependencies.
  * Streamlined build stages and runtime file ownership handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->