### PR TITLE
docs: add mandatory cross-AI review process before opening a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,9 @@ type/branch-name branch → PR into develop → develop → chore/bump-version �
 1. **Start a new branch** from `develop` for every piece of work — features, bug fixes, chores, CI changes, everything. Never commit new work directly to `develop` or `main`.
    - Branch naming: `feat/short-description`, `fix/short-description`, `chore/short-description`, `ci/short-description`, `docs/short-description`
 
-2. **Do the work** on that branch. Commit as many times as needed. Push the branch to GitHub.
+2. **Do the work** on that branch. Commit as many times as needed.
+
+2a. **Get a cross-AI review before opening the PR.** See "Cross-AI Review Before Opening The PR" below — this is mandatory, not optional polish. Push the branch to GitHub once this review pass is clean.
 
 3. **Open a PR** from that branch into `develop` using `gh pr create`. This is what feeds the release notes — the PR title becomes the changelog entry. Use a semantic title (`feat:`, `fix:`, `chore:`, etc.).
 
@@ -121,6 +123,31 @@ type/branch-name branch → PR into develop → develop → chore/bump-version �
 9. **Tag `main`** with `vX.Y.Z` and push the tag. This triggers the Docker build workflow.
 
 10. **Publish the GitHub release** — review the auto-generated draft and publish it.
+
+---
+
+### Cross-AI Review Before Opening The PR (Mandatory)
+
+Hubarr is worked on by two AI agents — Claude and Codex — usually in separate chat sessions, with the user relaying messages between them. Before step 3 above (opening the PR), every branch — feature, fix, chore, CI, or docs, matching "the required workflow for all changes" at the top of this flow — must go through a review pass by the *other* agent. This is required, not optional polish: it catches real issues before human review, which substantially cuts down the back-and-forth.
+
+**Roles are relative, not fixed to a specific AI.** Whichever agent wrote the code is "the implementer"; the other agent is "the reviewer." If Codex implemented, Claude reviews, and vice versa — this section applies symmetrically regardless of which agent is reading it right now.
+
+**When this starts:** once the implementer believes the work is complete *and* the user has confirmed they're happy with it. Not before — the user is still the gate on scope and direction.
+
+**The review loop** (the implementer drives this state machine — never wait for the user to ask "what's next" or "can you do a full review"):
+
+| Last review was... | Result | Next step |
+|---|---|---|
+| Full | Clean | Branch is cleared to open the PR (step 3) |
+| Full | Findings | Resolve each finding (see below), then request a **delta review** scoped to just the fix/disposition |
+| Delta | Clean | Automatically request a new **full review** from scratch — a clean delta is never the finish line |
+| Delta | Findings | Resolve each finding (see below), then request another **delta review** |
+
+In words: the first review of a branch is always a full review of the whole diff. From there, keep alternating — a delta review after every round of fixes, and once a delta review comes back clean, immediately trigger one more full review from scratch, offered without being asked, before considering the branch done. Only a **full** review pass coming back clean clears the branch to open a PR; a clean delta review alone is never sufficient on its own. Keep alternating full ⇄ delta-until-clean until a full pass finds nothing new. This catches things a narrow delta view misses (e.g. the same unsafe pattern repeated elsewhere in the codebase) while keeping most rounds cheap.
+
+**Resolving a finding:** "findings" doesn't mean every suggestion must be applied as-is. If the implementer agrees, fix it. If the implementer disagrees, it should respond to the reviewer with its reasoning and evidence instead of silently applying (or silently ignoring) the suggestion. The reviewer re-evaluates against that reasoning. If they still disagree after that exchange, surface it to the user for a decision — neither agent unilaterally overrides the other. Whatever the outcome — a code change or a deliberate no-change — send it through the next delta review like any other resolved finding, so the reviewer confirms the final state before the next full pass.
+
+**Minimal effort for the user:** their job is only to paste the prompt into the other agent's chat and paste the response back here. The implementer tracks review state (was the last request a delta or a full pass? did it come back clean?) and always produces the next prompt proactively.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ type/branch-name branch → PR into develop → develop → chore/bump-version �
 
 2. **Do the work** on that branch. Commit as many times as needed.
 
-2a. **Get a cross-AI review before opening the PR.** See "Cross-AI Review Before Opening The PR" below — this is mandatory, not optional polish. Push the branch to GitHub once this review pass is clean.
+2a. **Get a cross-AI review before opening the PR.** See "Cross-AI Review Before Opening The PR" below — this is mandatory, not optional polish. Push the branch to GitHub whenever the reviewer needs to see it (the diff can also be pasted directly into the prompt) — pushing early is fine. What matters is that the **PR itself** is not opened until a full review comes back clean.
 
 3. **Open a PR** from that branch into `develop` using `gh pr create`. This is what feeds the release notes — the PR title becomes the changelog entry. Use a semantic title (`feat:`, `fix:`, `chore:`, etc.).
 


### PR DESCRIPTION
## Summary

Documents a new required step in the development flow: before any feature/fix/chore/docs branch gets a PR opened, the AI that didn't implement it (Claude ↔ Codex) reviews it first. Mirrors the same change already adopted in shelfbridge (Migz93/shelfbridge#51), ported and adapted for hubarr's own workflow and conventions.

## Changes

- `AGENTS.md`:
  - Step 2 of the main development flow split into 2 (do the work) and a new step 2a (get a cross-AI review before opening the PR), clarifying that the branch may be pushed early for the reviewer's benefit but the PR itself is gated on a clean full review.
  - Added a new "Cross-AI Review Before Opening The PR (Mandatory)" section describing the review loop: the first pass on a branch is always a full review; after any findings, fixes go through a delta review; once a delta review comes back clean, a fresh full review is automatically triggered before the branch is considered clear for a PR.

## Test plan

- [ ] N/A — documentation only, no code changes.

This PR itself went through the process it documents: one full review (found a push-timing ambiguity in step 2a), one delta review confirming the fix, and one final full review confirming everything is consistent — all performed by Codex.

🤖 Generated with Claude Code