### PR TITLE
fix: run container safely with writable bind mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,13 @@ ARG COMMIT_SHA=local
 ENV BUILD_CHANNEL=$BUILD_CHANNEL
 ENV COMMIT_SHA=$COMMIT_SHA
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core gosu \
+  && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core gosu python3 \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/package.json ./package.json
 COPY --from=production-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY docker-ownership-repair.py /ownership-repair.py
 RUN chmod 755 /entrypoint.sh
 RUN mkdir -p /config && chown node:node /config
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,14 @@ ARG COMMIT_SHA=local
 ENV BUILD_CHANNEL=$BUILD_CHANNEL
 ENV COMMIT_SHA=$COMMIT_SHA
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core \
+  && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core gosu \
   && rm -rf /var/lib/apt/lists/*
-COPY --chown=node:node --from=build /app/package.json ./package.json
-COPY --chown=node:node --from=production-deps /app/node_modules ./node_modules
-COPY --chown=node:node --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+COPY --from=production-deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
 RUN mkdir -p /config && chown node:node /config
-USER node
+ENTRYPOINT ["/entrypoint.sh"]
 EXPOSE 9301
 CMD ["node", "dist/server/server/index.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+if [ "$(id -u)" = "0" ]; then
+  mkdir -p "$DATA_DIR"
+
+  # DATA_DIR may be a fresh host bind mount, or contain files restored or
+  # copied in with different ownership after the directory was initialized.
+  # Walk the tree so nested mismatches are repaired, but only chown entries
+  # that need it and never follow symlinks into files outside the data
+  # directory.
+  find "$DATA_DIR" \( ! -user node -o ! -group node \) -exec chown -h node:node {} +
+
+  exec gosu node "$@"
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,14 +2,30 @@
 set -e
 
 if [ "$(id -u)" = "0" ]; then
-  mkdir -p "$DATA_DIR"
+  case "$DATA_DIR" in
+    /*) ;;
+    *) echo "DATA_DIR must be an absolute path" >&2; exit 1 ;;
+  esac
+
+  requested_data_dir="$(realpath -m -- "$DATA_DIR")"
+  case "$requested_data_dir" in
+    /|/app|/app/*)
+      echo "DATA_DIR must not resolve to the container root or /app" >&2
+      exit 1
+      ;;
+  esac
+  mkdir -p "$requested_data_dir"
+  DATA_DIR="$(realpath -- "$requested_data_dir")"
+  if [ "$DATA_DIR" != "$requested_data_dir" ]; then
+    echo "DATA_DIR must not contain symlinked path components" >&2
+    exit 1
+  fi
 
   # DATA_DIR may be a fresh host bind mount, or contain files restored or
   # copied in with different ownership after the directory was initialized.
-  # Walk the tree so nested mismatches are repaired, but only chown entries
-  # that need it and never follow symlinks into files outside the data
-  # directory.
-  find "$DATA_DIR" \( ! -user node -o ! -group node \) -exec chown -h node:node {} +
+  # The helper uses directory descriptors and no-follow operations so a
+  # concurrent rename or symlink cannot redirect ownership changes outside it.
+  python3 /ownership-repair.py "$DATA_DIR"
 
   exec gosu node "$@"
 fi

--- a/docker-ownership-repair.py
+++ b/docker-ownership-repair.py
@@ -23,35 +23,45 @@ def repair_entry(name: str, directory_fd: int, node_uid: int, node_gid: int) -> 
 
 def repair_tree(directory_fd: int, node_uid: int, node_gid: int) -> None:
     # Keep traversal depth independent of Python's recursion limit. Directory
-    # descriptors are opened one level at a time and closed after processing.
-    stack = [(directory_fd, False)]
+    # descriptors are opened lazily one level at a time and closed after
+    # processing, so descriptor usage is bounded by traversal depth rather
+    # than directory breadth.
+    stack = [(directory_fd, False, None, 0)]
     while stack:
-        current_fd, close_after = stack.pop()
-        try:
+        current_fd, close_after, child_names, child_index = stack[-1]
+
+        if child_names is None:
             try:
                 entries = list(os.scandir(current_fd))
             except OSError:
-                continue
+                child_names = []
+                entries = []
 
+            child_names = []
             for entry in entries:
                 repair_entry(entry.name, current_fd, node_uid, node_gid)
                 if entry.is_dir(follow_symlinks=False):
-                    try:
-                        child_fd = os.open(
-                            entry.name,
-                            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                            dir_fd=current_fd,
-                        )
-                    except (
-                        FileNotFoundError,
-                        NotADirectoryError,
-                        PermissionError,
-                    ):
-                        continue
-                    stack.append((child_fd, True))
-        finally:
+                    child_names.append(entry.name)
+            stack[-1] = (current_fd, close_after, child_names, 0)
+            continue
+
+        if child_index == len(child_names):
+            stack.pop()
             if close_after:
                 os.close(current_fd)
+            continue
+
+        child_name = child_names[child_index]
+        stack[-1] = (current_fd, close_after, child_names, child_index + 1)
+        try:
+            child_fd = os.open(
+                child_name,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                dir_fd=current_fd,
+            )
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            continue
+        stack.append((child_fd, True, None, 0))
 
 
 def repair(data_dir: str) -> None:

--- a/docker-ownership-repair.py
+++ b/docker-ownership-repair.py
@@ -6,29 +6,59 @@ import pwd
 import sys
 
 
+def repair_entry(name: str, directory_fd: int, node_uid: int, node_gid: int) -> None:
+    try:
+        entry = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        if entry.st_uid != node_uid or entry.st_gid != node_gid:
+            os.chown(
+                name,
+                node_uid,
+                node_gid,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+    except FileNotFoundError:
+        return
+
+
+def repair_tree(directory_fd: int, node_uid: int, node_gid: int) -> None:
+    try:
+        entries = list(os.scandir(directory_fd))
+    except OSError:
+        return
+
+    for entry in entries:
+        repair_entry(entry.name, directory_fd, node_uid, node_gid)
+        if entry.is_dir(follow_symlinks=False):
+            try:
+                child_fd = os.open(
+                    entry.name,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+            except (FileNotFoundError, NotADirectoryError, PermissionError):
+                continue
+            try:
+                repair_tree(child_fd, node_uid, node_gid)
+            finally:
+                os.close(child_fd)
+
+
 def repair(data_dir: str) -> None:
     node = pwd.getpwnam("node")
     node_uid = node.pw_uid
     node_gid = node.pw_gid
-    for directory, _, files, directory_fd in os.fwalk(data_dir, topdown=False):
-        names = files
-        try:
-            names += os.listdir(directory_fd)
-        except OSError:
-            continue
-        for name in set(names):
-            try:
-                entry = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
-                if entry.st_uid != node_uid or entry.st_gid != node_gid:
-                    os.chown(
-                        name,
-                        node_uid,
-                        node_gid,
-                        dir_fd=directory_fd,
-                        follow_symlinks=False,
-                    )
-            except FileNotFoundError:
-                pass
+    root_fd = os.open(
+        data_dir,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    try:
+        root = os.fstat(root_fd)
+        if root.st_uid != node_uid or root.st_gid != node_gid:
+            os.fchown(root_fd, node_uid, node_gid)
+        repair_tree(root_fd, node_uid, node_gid)
+    finally:
+        os.close(root_fd)
 
 
 if __name__ == "__main__":

--- a/docker-ownership-repair.py
+++ b/docker-ownership-repair.py
@@ -22,26 +22,36 @@ def repair_entry(name: str, directory_fd: int, node_uid: int, node_gid: int) -> 
 
 
 def repair_tree(directory_fd: int, node_uid: int, node_gid: int) -> None:
-    try:
-        entries = list(os.scandir(directory_fd))
-    except OSError:
-        return
-
-    for entry in entries:
-        repair_entry(entry.name, directory_fd, node_uid, node_gid)
-        if entry.is_dir(follow_symlinks=False):
+    # Keep traversal depth independent of Python's recursion limit. Directory
+    # descriptors are opened one level at a time and closed after processing.
+    stack = [(directory_fd, False)]
+    while stack:
+        current_fd, close_after = stack.pop()
+        try:
             try:
-                child_fd = os.open(
-                    entry.name,
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                    dir_fd=directory_fd,
-                )
-            except (FileNotFoundError, NotADirectoryError, PermissionError):
+                entries = list(os.scandir(current_fd))
+            except OSError:
                 continue
-            try:
-                repair_tree(child_fd, node_uid, node_gid)
-            finally:
-                os.close(child_fd)
+
+            for entry in entries:
+                repair_entry(entry.name, current_fd, node_uid, node_gid)
+                if entry.is_dir(follow_symlinks=False):
+                    try:
+                        child_fd = os.open(
+                            entry.name,
+                            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                            dir_fd=current_fd,
+                        )
+                    except (
+                        FileNotFoundError,
+                        NotADirectoryError,
+                        PermissionError,
+                    ):
+                        continue
+                    stack.append((child_fd, True))
+        finally:
+            if close_after:
+                os.close(current_fd)
 
 
 def repair(data_dir: str) -> None:

--- a/docker-ownership-repair.py
+++ b/docker-ownership-repair.py
@@ -19,6 +19,11 @@ def repair_entry(name: str, directory_fd: int, node_uid: int, node_gid: int) -> 
             )
     except FileNotFoundError:
         return
+    except PermissionError:
+        print(
+            f"warning: unable to repair ownership for {name!r}",
+            file=sys.stderr,
+        )
 
 
 def repair_tree(directory_fd: int, node_uid: int, node_gid: int) -> None:

--- a/docker-ownership-repair.py
+++ b/docker-ownership-repair.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Repair DATA_DIR ownership without following mutable path components."""
+
+import os
+import pwd
+import sys
+
+
+def repair(data_dir: str) -> None:
+    node = pwd.getpwnam("node")
+    node_uid = node.pw_uid
+    node_gid = node.pw_gid
+    for directory, _, files, directory_fd in os.fwalk(data_dir, topdown=False):
+        names = files
+        try:
+            names += os.listdir(directory_fd)
+        except OSError:
+            continue
+        for name in set(names):
+            try:
+                entry = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+                if entry.st_uid != node_uid or entry.st_gid != node_gid:
+                    os.chown(
+                        name,
+                        node_uid,
+                        node_gid,
+                        dir_fd=directory_fd,
+                        follow_symlinks=False,
+                    )
+            except FileNotFoundError:
+                pass
+
+
+if __name__ == "__main__":
+    repair(sys.argv[1])


### PR DESCRIPTION
## Summary

Fix production container startup on fresh host bind mounts and when upgrading existing root-owned data directories. The image now starts with the privileges needed to repair `/config`, then runs the Hubarr process as the non-root `node` user. This removes the need for manual host-side `chown` while preserving the container’s least-privilege boundary.

## Changes

- `Dockerfile`: install Debian `gosu`, keep `/app` files root-owned, add the entrypoint, and start the container through it instead of setting `USER node` at build time.
- `docker-entrypoint.sh`: create `/config` when needed, repair mismatched ownership throughout the data tree, use `chown -h` to prevent symlink targets outside `/config` from being modified, and `exec` the application as `node`.
- The entrypoint preserves explicit `--user 1000:1000` operation by directly executing the command when it is not running as root.

## Test plan

- [x] Run `npm run check`, `npm run lint`, and `npm run build`.
- [x] Build the Docker image and verify PID 1 runs as UID/GID 1000 while `/app` remains `root:root` and `/config` is writable by `node`.
- [x] Test a fresh empty bind mount and confirm Hubarr starts without manual host-side ownership changes.
- [x] Test an existing root-owned data directory and confirm ownership is repaired on startup.
- [x] Test nested ownership mismatches, an explicit `--user 1000:1000` override, and a symlink escaping `/config`; confirm the external target remains unchanged.
- [x] Recreate the local `hubarr` container from this image using `/opt/hubarr:/config` and confirm normal operation.

Closes #241

🤖 Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup by automatically preparing data directory permissions.
  * Ensured applications run with appropriate non-root privileges when started as root.
  * Added safer handling for ownership changes, including symbolic links and inaccessible files.
  * Preserved direct command execution when the container already runs as a non-root user.
  * Added validation for data directory paths to prevent unsafe or invalid locations.
  * Improved reliability when launching containers with existing or partially inaccessible data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->