### PR TITLE
fix: normalize GHCR image names

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository }}
+  IMAGE_NAME: ghcr.io/migz93/hubarr
 
 jobs:
   docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository }}
+  IMAGE_NAME: ghcr.io/migz93/hubarr
 
 jobs:
   docker:


### PR DESCRIPTION
## Summary

Normalize the GHCR image name used by the Docker publish workflows.

## Changes

- Use lowercase repository image references so Trivy can scan the pushed manifest digest.

## Test plan

- Workflow YAML validation passed.
- `npm run check` passed.
- Hubarr: `npm run lint` passed.

— Codex